### PR TITLE
chore: add sponsorship funding links

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,2 @@
+github: i-am-logger
+buy_me_a_coffee: i_am_logger


### PR DESCRIPTION
Adds `.github/FUNDING.yml`, matching pr4xis. GitHub renders the Sponsor button on the repository from this file; no README change is needed.

Platforms: GitHub Sponsors (`i-am-logger`) and Buy Me a Coffee (`i_am_logger`).

The commented-out placeholders from GitHub's default template are left out — the file lists only the platforms actually in use.