### PR TITLE
fix(ci): take the release tag from release-plz output, not git describe

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,12 +139,17 @@ jobs:
         with:
           name: rav-linux-x86_64
           path: dist
+      # The tag comes from release-plz's own output. It creates the tag through
+      # the GitHub API, so the tag exists on the remote while this checkout has
+      # none of it - git describe finds nothing here.
       - name: Attach it to the release
         if: steps.release-plz.outputs.releases_created == 'true'
         env:
           GITHUB_TOKEN: ${{ github.token }}
+          RELEASES: ${{ steps.release-plz.outputs.releases }}
         run: |
-          TAG=$(git describe --tags --abbrev=0)
+          TAG=$(echo "$RELEASES" | jq -r '.[0].tag')
+          test -n "$TAG" && test "$TAG" != "null"
           chmod +x dist/rav
           mv dist/rav dist/rav-linux-x86_64
           gh release upload "$TAG" dist/rav-linux-x86_64 --clobber

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,27 +2,15 @@
 
 ## [1.0.0-beta.1](https://github.com/i-am-logger/rav/releases/tag/rav-v1.0.0-beta.1) - 2026-08-09
 
-### Chore
+First release on crates.io.
 
-- *(actions)* accept token as input for publish_crate composite action ([#31](https://github.com/i-am-logger/rav/pull/31))
-- flake update and cleanup
-- rav is now published to icrates.io ([#9](https://github.com/i-am-logger/rav/pull/9))
-- Create dependabot.yml
+### Added
 
-### Ci
-
-- remove cargo-based lint; only run Nix build in PR workflow ([#27](https://github.com/i-am-logger/rav/pull/27))
-
-### Feat
-
-- [**breaking**] rebuild the analyser, with skins as data files ([#40](https://github.com/i-am-logger/rav/pull/40))
-- add sensitivity control for visualization
-- [**breaking**] add initial visualization implementation
-
-### Fix
-
-- automate PR management in github actions ([#7](https://github.com/i-am-logger/rav/pull/7))
-- release-please to point to ./.
+- Real-time spectrum analyser with bars and peak caps, plus an oscilloscope view.
+- Four built-in skins - rav, winamp, terminal and mono - cycled at runtime. A
+  skin is a TOML file, so one can be added without touching the code.
+- System audio capture with no virtual device: a CoreAudio process tap on macOS,
+  a PipeWire or PulseAudio monitor source on Linux.
 
 ## [0.2.4](https://github.com/i-am-logger/rav/compare/rav-v0.2.3...rav-v0.2.4) (2025-08-09)
 

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -7,6 +7,10 @@ git_tag_name = "rav-v{{ version }}"
 
 git_release_enable = true
 
+# "auto" marks a version carrying a pre-release suffix as a GitHub pre-release,
+# so a beta does not present itself as the latest stable download.
+git_release_type = "auto"
+
 # cargo-semver-checks before each release: a breaking change proposed as a patch
 # bump is rejected and the version escalated.
 semver_check = true
@@ -27,8 +31,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 """
 
-# Release commits are not changes. Parsed in, each one back-fills a changelog
-# entry and opens another release PR, which produces another release commit.
+# The changelog carries what a user of the crate would notice. Everything else -
+# chore, ci, build, test, refactor, and release-plz's own release commits - is
+# skipped by the trailing catch-all.
+#
+# Group names match the Keep a Changelog headings the header above promises.
+# These replace git-cliff's defaults rather than adding to them, so feat and fix
+# have to be listed for them to appear at all.
 commit_parsers = [
-    { message = "^chore(\\(.+\\))?: release", skip = true },
+    { message = "^feat", group = "Added" },
+    { message = "^fix", group = "Fixed" },
+    { message = "^perf", group = "Performance" },
+    { message = "^doc", group = "Documentation" },
+    { message = ".*", skip = true },
 ]


### PR DESCRIPTION
`Release` failed on the 1.0.0-beta.1 run at the asset-upload step:

```
fatal: No names found, cannot describe anything.
```

release-plz creates the tag through the GitHub API, so it exists on the remote while the job's checkout — taken before release-plz ran — has no tags at all. `git describe` therefore finds nothing on the run that creates a release, and only succeeds on a re-run, once the tag is old enough to have been fetched. Re-running is what unblocked 1.0.0-beta.1; without this fix every release needs that manual step.

The tag is available directly in the action's `releases` output, which is what this uses. The publish itself was never affected.

Also here:

- `git_release_type = "auto"` — flags a version with a pre-release suffix as a GitHub pre-release. 1.0.0-beta.1 was published as a normal release and presented itself as the latest download.
- `commit_parsers` — the changelog now carries only what a user of the crate would notice. The generated 1.0.0-beta.1 entry listed the entire repository history, including `release-please to point to ./.` and `remove cargo-based lint; only run Nix build in PR workflow`, the latter no longer true.
- `CHANGELOG.md` — that entry rewritten to describe the release.

The published release has already been repaired by hand: binary attached, notes rewritten, pre-release flag set. crates.io is immutable so the 1.0.0-beta.1 entry there stands as published.