### PR TITLE
docs: add crates.io, downloads and docs.rs badges

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,8 +5,18 @@ name: CI
 on:
   push:
     branches: [ master ]
+  # A change that touches only prose cannot break a build, so it runs nothing.
+  # This filter is on pull_request alone. On master the release job needs the
+  # workflow to run whatever changed, and a release PR carries CHANGELOG.md -
+  # ignoring markdown there would leave the release unpublished.
   pull_request:
     branches: [ master ]
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+      - 'assets/**'
+      - 'LICENSE'
+      - '.github/FUNDING.yml'
 
 concurrency:
   group: ci-${{ github.head_ref || github.ref }}

--- a/README.md
+++ b/README.md
@@ -9,13 +9,16 @@ Terminal today, GUI next.
 
 ![rav](assets/demo.gif)
 
-[![CI](https://img.shields.io/github/actions/workflow/status/i-am-logger/rav/ci.yml?branch=master&label=CI&logo=githubactions&logoColor=white)](https://github.com/i-am-logger/rav/actions/workflows/ci.yml)
 [![Rust](https://img.shields.io/badge/Rust-2b2b2b?logo=rust&logoColor=white)](https://www.rust-lang.org)
 [![Nix](https://img.shields.io/badge/Nix-2b2b2b?logo=nixos&logoColor=white)](https://nixos.org)
-[![License: CC BY-NC-SA 4.0](https://img.shields.io/badge/CC%20BY--NC--SA%204.0-2b2b2b?logo=creativecommons&logoColor=white)](LICENSE)
-
 [![Linux](https://img.shields.io/badge/Linux-2b2b2b?logo=linux&logoColor=white)](docs/audio.md)
 [![macOS](https://img.shields.io/badge/macOS-2b2b2b?logo=apple&logoColor=white)](docs/audio.md)
+[![License: CC BY-NC-SA 4.0](https://img.shields.io/badge/CC%20BY--NC--SA%204.0-2b2b2b?logo=creativecommons&logoColor=white)](LICENSE)
+
+[![CI](https://img.shields.io/github/actions/workflow/status/i-am-logger/rav/ci.yml?branch=master&label=CI&logo=githubactions&logoColor=white)](https://github.com/i-am-logger/rav/actions/workflows/ci.yml)
+[![crates.io](https://img.shields.io/crates/v/rav?logo=rust&logoColor=white&color=2b2b2b)](https://crates.io/crates/rav)
+[![Downloads](https://img.shields.io/crates/d/rav?logo=rust&logoColor=white&color=2b2b2b)](https://crates.io/crates/rav)
+[![docs.rs](https://img.shields.io/docsrs/rav?logo=docsdotrs&logoColor=white&color=2b2b2b)](https://docs.rs/rav)
 
 </div>
 

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -20,6 +20,17 @@ semver_check = true
 # merge is the point.
 release_always = false
 
+# A release PR opens only when something a user of the crate would notice has
+# landed. Releasability is otherwise decided by changed files, so a README or
+# CI-config edit is enough to propose a version on its own.
+#
+# The changelog's commit_parsers below cannot do this: they filter after the
+# version is calculated, so a skipped commit still bumps.
+#
+# Matches feat, fix and perf in all four conventional forms - bare, scoped,
+# breaking, and scoped breaking.
+release_commits = '^(feat|fix|perf)(\([^)]*\))?!?:'
+
 pr_labels = ["release", "automated"]
 
 [changelog]


### PR DESCRIPTION
Line one is the four things that change - CI, published version, downloads, docs build. Line two is what does not - Rust, Nix, Linux, macOS, licence.

`crates/d` rather than `crates/dv`: the latter counts only the newest version, so it would reset to near-zero on every release and read worse the more often rav ships.

Every URL verified to resolve: `CI: passing`, `crates.io: v1.0.0-beta.2`, `downloads: 27`, `docs: passing`.