### PR TITLE
ci: do not build or release for prose-only changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,8 +5,18 @@ name: CI
 on:
   push:
     branches: [ master ]
+  # A change that touches only prose cannot break a build, so it runs nothing.
+  # This filter is on pull_request alone. On master the release job needs the
+  # workflow to run whatever changed, and a release PR carries CHANGELOG.md -
+  # ignoring markdown there would leave the release unpublished.
   pull_request:
     branches: [ master ]
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+      - 'assets/**'
+      - 'LICENSE'
+      - '.github/FUNDING.yml'
 
 concurrency:
   group: ci-${{ github.head_ref || github.ref }}

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -20,6 +20,17 @@ semver_check = true
 # merge is the point.
 release_always = false
 
+# A release PR opens only when something a user of the crate would notice has
+# landed. Releasability is otherwise decided by changed files, so a README or
+# CI-config edit is enough to propose a version on its own.
+#
+# The changelog's commit_parsers below cannot do this: they filter after the
+# version is calculated, so a skipped commit still bumps.
+#
+# Matches feat, fix and perf in all four conventional forms - bare, scoped,
+# breaking, and scoped breaking.
+release_commits = '^(feat|fix|perf)(\([^)]*\))?!?:'
+
 pr_labels = ["release", "automated"]
 
 [changelog]


### PR DESCRIPTION
Two independent changes, both using the documented mechanism rather than a workaround.

## `paths-ignore` on pull requests

A PR touching only markdown, `docs/`, `assets/`, `LICENSE` or `FUNDING.yml` now runs no jobs. Compiling and testing a README edit proves nothing.

The filter is on `pull_request` only, deliberately. On master the workflow must still run whatever changed: a release PR carries `CHANGELOG.md`, and ignoring markdown there would mean no `Release` job and nothing published.

The usual objection to path filters is that a required status check which never runs blocks the PR forever. This repository's ruleset contains only `deletion` and `non_fast_forward` — no required checks — so the native filter is safe here and a `dorny/paths-filter` job with `if:` on every job would be unnecessary machinery.

## `release_commits`

```toml
release_commits = '^(feat|fix|perf)(\([^)]*\))?!?:'
```

A release PR now opens only when something a user of the crate would notice has landed. Releasability is otherwise decided by *changed files*, so a README or CI edit was enough to propose a version by itself.

`commit_parsers` could not do this. Its filtering runs after the version is calculated, so a skipped commit still bumps — the changelog came out clean while the release still happened.

Verified against every commit on master and all four conventional forms: `feat:`, `feat(x):`, `feat!:`, `feat(x)!:` release; `docs:`, `chore:`, `ci:`, `refactor:` do not.