### PR TITLE
docs: add crates.io, downloads and docs.rs badges

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,8 @@ name: CI
 on:
   push:
     branches: [ master ]
+  # No paths-ignore: README.md, docs/ and LICENSE ship inside the crate, so a
+  # change to any of them is released and earns the same checks as code.
   pull_request:
     branches: [ master ]
 

--- a/README.md
+++ b/README.md
@@ -9,13 +9,16 @@ Terminal today, GUI next.
 
 ![rav](assets/demo.gif)
 
-[![CI](https://img.shields.io/github/actions/workflow/status/i-am-logger/rav/ci.yml?branch=master&label=CI&logo=githubactions&logoColor=white)](https://github.com/i-am-logger/rav/actions/workflows/ci.yml)
 [![Rust](https://img.shields.io/badge/Rust-2b2b2b?logo=rust&logoColor=white)](https://www.rust-lang.org)
 [![Nix](https://img.shields.io/badge/Nix-2b2b2b?logo=nixos&logoColor=white)](https://nixos.org)
-[![License: CC BY-NC-SA 4.0](https://img.shields.io/badge/CC%20BY--NC--SA%204.0-2b2b2b?logo=creativecommons&logoColor=white)](LICENSE)
-
 [![Linux](https://img.shields.io/badge/Linux-2b2b2b?logo=linux&logoColor=white)](docs/audio.md)
 [![macOS](https://img.shields.io/badge/macOS-2b2b2b?logo=apple&logoColor=white)](docs/audio.md)
+[![License: CC BY-NC-SA 4.0](https://img.shields.io/badge/CC%20BY--NC--SA%204.0-2b2b2b?logo=creativecommons&logoColor=white)](LICENSE)
+
+[![CI](https://img.shields.io/github/actions/workflow/status/i-am-logger/rav/ci.yml?branch=master&label=CI&logo=githubactions&logoColor=white)](https://github.com/i-am-logger/rav/actions/workflows/ci.yml)
+[![crates.io](https://img.shields.io/crates/v/rav?logo=rust&logoColor=white&color=2b2b2b)](https://crates.io/crates/rav)
+[![Downloads](https://img.shields.io/crates/d/rav?logo=rust&logoColor=white&color=2b2b2b)](https://crates.io/crates/rav)
+[![docs.rs](https://img.shields.io/docsrs/rav?logo=docsdotrs&logoColor=white&color=2b2b2b)](https://docs.rs/rav)
 
 </div>
 

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -20,6 +20,15 @@ semver_check = true
 # merge is the point.
 release_always = false
 
+# There is deliberately no release_commits filter. What is releasable is decided
+# by which packaged files changed, which is already the rule this crate wants:
+# README.md, docs/*.md, LICENSE, skins/ and src/ all ship inside the crate, so
+# editing any of them requires a new version before crates.io shows it. Files
+# under .github/ are not packaged, so CI changes release nothing.
+#
+# A commit-message filter would break that, since it cannot see which files a
+# commit touched.
+
 pr_labels = ["release", "automated"]
 
 [changelog]


### PR DESCRIPTION
## Badges

Line one is what rav *is* — Rust, Nix, Linux, macOS, licence. Line two is what changes — CI, published version, downloads, docs build.

New: `crates.io` (reads `v1.0.0-beta.2`), `downloads` and `docs.rs` (reads `docs: passing`). Every URL verified to render real text rather than a 404 or a silently blank badge — `docs-rs` is an invalid logo slug that renders empty; the correct one is `docsdotrs`.

`crates/d` rather than `crates/dv`: the latter counts only the newest version, so it would reset to near-zero on every release and read worse the more often rav ships.

## Two comments, no behaviour change

Earlier revisions of this branch added a `paths-ignore` filter and a `release_commits` regex. Both are removed. `cargo package --list` shows why:

```
README.md   docs/audio.md   docs/developing.md   docs/skins.md
LICENSE     skins/*.toml    src/**              release-plz.toml
```

Those ship *inside* the crate, so crates.io only shows an edit to them once a new version is published — a docs change is a release. `.github/**` is not packaged, so CI changes release nothing.

release-plz decides releasability from changed packaged files, which is already exactly that rule. A `release_commits` regex would have broken it, because it matches commit *messages* and cannot see which files a commit touched. The two comments record why neither filter is there, so nothing re-adds them.

Being typed `docs:`, this PR does cut a release — correctly, since it edits the README that crates.io renders.