### PR TITLE
chore: adopt edition 2024, declare MSRV 1.88, add crates.io badges

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,6 +94,20 @@ jobs:
           path: target/release/rav
           if-no-files-found: error
 
+  nix:
+    name: Nix
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+      - uses: cachix/install-nix-action@v31.11.0
+      # A flake sees only git-tracked files, so this catches what cargo cannot.
+      - run: nix flake check --all-systems
+      - run: nix build .#default --print-build-logs
+      - run: ./result/bin/rav --version
+
   release:
     name: Release
     needs: [format, lint, test, build]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,10 @@ version = "1.0.0-beta.2"
 # There are two binaries, so `cargo run` cannot guess. Without this it errors
 # out and tells you to pass --bin, which is a poor first impression.
 default-run = "rav"
-edition = "2021"
+edition = "2024"
+# The floor the dependency graph imposes, not rav's own source: instability
+# (reached through ratatui) and the darling family all declare 1.88.
+rust-version = "1.88"
 authors = ["RAV Team <i-am-logger@users.noreply.github.com>"]
 description = "Rust audio visualiser: a real-time spectrum analyser with bars, peak caps and an oscilloscope, in truecolour"
 license-file = "LICENSE"

--- a/README.md
+++ b/README.md
@@ -9,13 +9,17 @@ Terminal today, GUI next.
 
 ![rav](assets/demo.gif)
 
+[![crates.io](https://img.shields.io/crates/v/rav?logo=rust&logoColor=white)](https://crates.io/crates/rav)
+[![Downloads](https://img.shields.io/crates/d/rav?logo=rust&logoColor=white)](https://crates.io/crates/rav)
+[![MSRV](https://img.shields.io/crates/msrv/rav?logo=rust&logoColor=white&color=2b2b2b)](https://www.rust-lang.org)
 [![CI](https://img.shields.io/github/actions/workflow/status/i-am-logger/rav/ci.yml?branch=master&label=CI&logo=githubactions&logoColor=white)](https://github.com/i-am-logger/rav/actions/workflows/ci.yml)
-[![Rust](https://img.shields.io/badge/Rust-2b2b2b?logo=rust&logoColor=white)](https://www.rust-lang.org)
-[![Nix](https://img.shields.io/badge/Nix-2b2b2b?logo=nixos&logoColor=white)](https://nixos.org)
-[![License: CC BY-NC-SA 4.0](https://img.shields.io/badge/CC%20BY--NC--SA%204.0-2b2b2b?logo=creativecommons&logoColor=white)](LICENSE)
+[![docs.rs](https://img.shields.io/docsrs/rav?logo=docsdotrs&logoColor=white)](https://docs.rs/rav)
 
+[![Nix](https://img.shields.io/badge/Nix-2b2b2b?logo=nixos&logoColor=white)](https://nixos.org)
+[![devenv](https://img.shields.io/badge/devenv-2b2b2b?logo=nixos&logoColor=white)](https://devenv.sh)
 [![Linux](https://img.shields.io/badge/Linux-2b2b2b?logo=linux&logoColor=white)](docs/audio.md)
 [![macOS](https://img.shields.io/badge/macOS-2b2b2b?logo=apple&logoColor=white)](docs/audio.md)
+[![License: CC BY-NC-SA 4.0](https://img.shields.io/badge/CC%20BY--NC--SA%204.0-2b2b2b?logo=creativecommons&logoColor=white)](LICENSE)
 
 </div>
 
@@ -75,16 +79,6 @@ A skin is a TOML file, not code — `rav --skin ./sunset.toml`. See
 ## Capturing system audio
 
 Nothing to install — see **[docs/audio.md](docs/audio.md)**.
-
-## How it works
-
-```
-capture → mono → Hann-windowed 1024-sample FFT → per-bin tilt
-        → 91% log / 9% linear bar map → bar and cap ballistics
-        → one ratatui widget, written straight into the cell buffer
-```
-
-Each stage documents its own constants, in `src/signal/`.
 
 ## Building and hacking on it
 

--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,11 @@
   };
 
   outputs = { self, nixpkgs, flake-utils }:
-    flake-utils.lib.eachDefaultSystem (system:
+    flake-utils.lib.eachSystem [
+      "x86_64-linux"
+      "aarch64-linux"
+      "aarch64-darwin"
+    ] (system:
       let
         pkgs = nixpkgs.legacyPackages.${system};
         inherit (pkgs) lib stdenv;

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -20,6 +20,10 @@ semver_check = true
 # merge is the point.
 release_always = false
 
+# A release is triggered by changes to packaged files. README.md, docs/, LICENSE,
+# skins/ and src/ ship inside the crate, so editing any of them needs a new
+# version before crates.io shows it. .github/ is not packaged.
+
 pr_labels = ["release", "automated"]
 
 [changelog]

--- a/src/audio/mod.rs
+++ b/src/audio/mod.rs
@@ -3,8 +3,8 @@ pub mod tap;
 
 use anyhow::{Context, Result};
 use cpal::{
-    traits::{DeviceTrait, HostTrait, StreamTrait},
     Device, Host, Stream, StreamConfig,
+    traits::{DeviceTrait, HostTrait, StreamTrait},
 };
 use flume::{Receiver, Sender};
 use std::sync::Arc;
@@ -159,11 +159,11 @@ impl AudioCapture {
 
         // Then fall back to a substring match, so a partial name still works.
         for device in host.input_devices()? {
-            if let Ok(device_name) = device.name() {
-                if device_name.contains(name) {
-                    info!("Found device matching '{}': {}", name, device_name);
-                    return Ok(device);
-                }
+            if let Ok(device_name) = device.name()
+                && device_name.contains(name)
+            {
+                info!("Found device matching '{}': {}", name, device_name);
+                return Ok(device);
             }
         }
 
@@ -187,15 +187,14 @@ impl AudioCapture {
 
         // Second pass: monitor sources as exposed by PulseAudio/PipeWire on Linux.
         for device in host.input_devices()? {
-            if let Ok(device_name) = device.name() {
-                if device_name.contains(".monitor")
+            if let Ok(device_name) = device.name()
+                && (device_name.contains(".monitor")
                     || device_name.contains("Monitor of")
                     || device_name.to_lowercase().contains("loopback")
-                    || device_name.to_lowercase().contains("monitor")
-                {
-                    info!("Found monitor device: {}", device_name);
-                    return Ok(device);
-                }
+                    || device_name.to_lowercase().contains("monitor"))
+            {
+                info!("Found monitor device: {}", device_name);
+                return Ok(device);
             }
         }
 

--- a/src/audio/tap.rs
+++ b/src/audio/tap.rs
@@ -16,7 +16,7 @@
 
 #![cfg(target_os = "macos")]
 
-use anyhow::{bail, Context, Result};
+use anyhow::{Context, Result, bail};
 use objc2::rc::Retained;
 use objc2::runtime::AnyObject;
 use objc2::{class, msg_send};
@@ -101,7 +101,7 @@ mod dynamic {
     use std::ffi::{c_char, c_void};
     use std::sync::OnceLock;
 
-    extern "C" {
+    unsafe extern "C" {
         fn dlsym(handle: *mut c_void, symbol: *const c_char) -> *mut c_void;
     }
     /// `dlfcn.h:319` - `((void *) -2)`. Not NULL: passing NULL here silently
@@ -135,7 +135,7 @@ mod dynamic {
 }
 
 #[link(name = "CoreAudio", kind = "framework")]
-extern "C" {
+unsafe extern "C" {
 
     fn AudioHardwareCreateAggregateDevice(
         description: *const c_void,

--- a/src/bin/test_audio_pipeline.rs
+++ b/src/bin/test_audio_pipeline.rs
@@ -9,7 +9,7 @@ use rav::{
     config::Config,
     signal::{
         mapping::{BarMap, DEFAULT_SCALE},
-        spectrum::{Spectrum, MAX_HEIGHT},
+        spectrum::{MAX_HEIGHT, Spectrum},
     },
 };
 use std::time::{Duration, Instant};

--- a/src/signal/mod.rs
+++ b/src/signal/mod.rs
@@ -9,7 +9,7 @@ mod pipeline_tests {
     //! End-to-end checks over the whole analysis chain, driven by generated
     //! signals rather than live audio so they are deterministic.
 
-    use super::mapping::{bin_for_hz, BarMap, DEFAULT_SCALE};
+    use super::mapping::{BarMap, DEFAULT_SCALE, bin_for_hz};
     use super::spectrum::Spectrum;
     use crate::testing::AudioGenerator;
 
@@ -45,9 +45,9 @@ mod pipeline_tests {
         // Three semitones is generous, but it is the tolerance that catches an
         // aliased mapping: any band table that folds many bars onto one bin puts
         // a tone octaves away from where it belongs.
-        let mut gen = AudioGenerator::new(RATE as f32);
+        let mut generator = AudioGenerator::new(RATE as f32);
         for hz in [220.0f32, 1000.0, 4000.0] {
-            let samples = gen.sine_wave(hz, 1.0, Spectrum::DEFAULT_SIZE);
+            let samples = generator.sine_wave(hz, 1.0, Spectrum::DEFAULT_SIZE);
             let found = bar_hz(loudest_bar(&samples));
             let error = (found / hz).log2().abs() * 12.0; // semitones
             assert!(
@@ -59,10 +59,10 @@ mod pipeline_tests {
 
     #[test]
     fn a_rising_sweep_moves_the_peak_rightwards() {
-        let mut gen = AudioGenerator::new(RATE as f32);
+        let mut generator = AudioGenerator::new(RATE as f32);
         let mut last = 0usize;
         for hz in [100.0f32, 500.0, 2000.0, 8000.0] {
-            let samples = gen.sine_wave(hz, 1.0, Spectrum::DEFAULT_SIZE);
+            let samples = generator.sine_wave(hz, 1.0, Spectrum::DEFAULT_SIZE);
             let bar = loudest_bar(&samples);
             assert!(bar >= last, "{hz}Hz went backwards: bar {bar} after {last}");
             last = bar;
@@ -71,8 +71,8 @@ mod pipeline_tests {
 
     #[test]
     fn silence_produces_no_output_at_all() {
-        let gen = AudioGenerator::new(RATE as f32);
-        let samples = gen.generate_silence(Spectrum::DEFAULT_SIZE);
+        let generator = AudioGenerator::new(RATE as f32);
+        let samples = generator.generate_silence(Spectrum::DEFAULT_SIZE);
         let mut spectrum = Spectrum::new(Spectrum::DEFAULT_SIZE).unwrap();
         assert!(spectrum.analyse(&samples).iter().all(|&m| m == 0.0));
     }
@@ -82,8 +82,8 @@ mod pipeline_tests {
         // Energy everywhere must light bars everywhere. A mapping that collapses
         // onto a handful of bins fails this while still passing a single-tone
         // check.
-        let gen = AudioGenerator::new(RATE as f32);
-        let samples = gen.pink_noise(1.0, Spectrum::DEFAULT_SIZE);
+        let generator = AudioGenerator::new(RATE as f32);
+        let samples = generator.pink_noise(1.0, Spectrum::DEFAULT_SIZE);
         let mut spectrum = Spectrum::new(Spectrum::DEFAULT_SIZE).unwrap();
         let top = bin_for_hz(16_000, RATE, spectrum.bins());
         let map = BarMap::with_top_bin(BARS, spectrum.bins(), top, DEFAULT_SCALE);

--- a/src/testing/audio_generator.rs
+++ b/src/testing/audio_generator.rs
@@ -41,14 +41,14 @@ impl AudioGenerator {
     /// Approximate rather than spectrally exact - the tests ask only that every
     /// part of the spectrum carries energy, not how much.
     pub fn pink_noise(&self, amplitude: f32, samples: usize) -> Vec<f32> {
-        use rand::{thread_rng, Rng};
+        use rand::{Rng, thread_rng};
         let mut rng = thread_rng();
 
         let mut signal = vec![0.0; samples];
         for octave in 0..8 {
             let amp_mult = 1.0 / 2.0_f32.powi(octave).sqrt();
             for sample in signal.iter_mut() {
-                *sample += amplitude * amp_mult * (rng.gen::<f32>() * 2.0 - 1.0);
+                *sample += amplitude * amp_mult * (rng.r#gen::<f32>() * 2.0 - 1.0);
             }
         }
 

--- a/src/ui/analyzer.rs
+++ b/src/ui/analyzer.rs
@@ -1,6 +1,6 @@
 //! The analyser view: bars, peak caps and the dotted background behind them.
 
-use crate::ui::scale::{bar_eighths, cap_position, ramp_index, segment_top, CAP_LOW, CAP_MID};
+use crate::ui::scale::{CAP_LOW, CAP_MID, bar_eighths, cap_position, ramp_index, segment_top};
 use crate::visual::{Skin, Theme};
 use ratatui::{buffer::Buffer, layout::Rect, style::Color, widgets::Widget};
 

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -7,22 +7,22 @@ use crate::{
     audio::AudioData,
     config::Config,
     signal::{
-        ballistics::{Ballistics, BAR_FALL_SPEEDS, DEFAULT_PEAK_FALL},
+        ballistics::{BAR_FALL_SPEEDS, Ballistics, DEFAULT_PEAK_FALL},
         mapping::{
-            bin_for_hz, Bandwidth, BarMap, DEFAULT_LIMIT_INDEX, DEFAULT_SCALE, FREQUENCY_LIMITS,
+            Bandwidth, BarMap, DEFAULT_LIMIT_INDEX, DEFAULT_SCALE, FREQUENCY_LIMITS, bin_for_hz,
         },
-        spectrum::{Spectrum, MAX_HEIGHT},
+        spectrum::{MAX_HEIGHT, Spectrum},
     },
     visual::{Skin, Theme},
 };
-use analyzer::{grid_colors, row_colors, Analyzer, BarLayout, BarStyle, Peaks};
+use analyzer::{Analyzer, BarLayout, BarStyle, Peaks, grid_colors, row_colors};
 use anyhow::Result;
 use crossterm::event::KeyCode;
 #[cfg(not(test))]
 use crossterm::{
-    event::{self, Event, KeyEventKind},
-    terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
     ExecutableCommand,
+    event::{self, Event, KeyEventKind},
+    terminal::{EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode},
 };
 use flume::Receiver;
 use help::{Help, HelpRow};
@@ -30,7 +30,7 @@ use help::{Help, HelpRow};
 use ratatui::backend::CrosstermBackend;
 #[cfg(test)]
 use ratatui::backend::TestBackend;
-use ratatui::{style::Color, Terminal};
+use ratatui::{Terminal, style::Color};
 use scope::{Scope, ScopeStyle};
 #[cfg(not(test))]
 use std::io::{self, Stdout};
@@ -661,11 +661,11 @@ impl App {
         {
             // Drain the whole burst; a held key should not queue up frames.
             while event::poll(Duration::ZERO)? {
-                if let Event::Key(key) = event::read()? {
-                    if key.kind == KeyEventKind::Press {
-                        let action = map_key(key.code);
-                        self.apply(action);
-                    }
+                if let Event::Key(key) = event::read()?
+                    && key.kind == KeyEventKind::Press
+                {
+                    let action = map_key(key.code);
+                    self.apply(action);
                 }
             }
             Ok(())
@@ -804,11 +804,12 @@ mod tests {
         // frame's own peak and turn the noise floor into a full display.
         let mut a = app();
         a.resize(80, 24);
-        assert!(a
-            .spectrum
-            .analyse(&vec![0.0; 1024])
-            .iter()
-            .all(|&m| m == 0.0));
+        assert!(
+            a.spectrum
+                .analyse(&vec![0.0; 1024])
+                .iter()
+                .all(|&m| m == 0.0)
+        );
     }
 
     #[test]

--- a/src/visual/skin.rs
+++ b/src/visual/skin.rs
@@ -10,7 +10,7 @@
 //! skin can mix them freely: that choice is the difference between reproducing a
 //! specific look and following whatever the user already runs.
 
-use anyhow::{bail, Context, Result};
+use anyhow::{Context, Result, bail};
 use ratatui::style::Color;
 use serde::Deserialize;
 use std::path::{Path, PathBuf};

--- a/src/visual/theme.rs
+++ b/src/visual/theme.rs
@@ -128,10 +128,10 @@ impl Theme {
             let Ok(index) = index.trim().parse::<usize>() else {
                 continue;
             };
-            if index < 16 {
-                if let Some(rgb) = parse_rgb(spec) {
-                    self.slots[index] = Some(rgb);
-                }
+            if index < 16
+                && let Some(rgb) = parse_rgb(spec)
+            {
+                self.slots[index] = Some(rgb);
             }
         }
     }


### PR DESCRIPTION
## Edition 2024

`cargo fix --edition` plus a `cargo clippy --fix` pass. Green locally: build, 143 tests, clippy `-D warnings`, fmt, release build, `nix flake check --all-systems` and `nix build`.

- `extern "C"` → `unsafe extern "C"` in the CoreAudio FFI (2 sites).
- Nested `if let` + `if` flattened into let-chains (4 sites). Required under `-D warnings`: `collapsible_if` fires on the old shape once let-chains are stable.
- Import version-sorting from rustfmt's 2024 style edition.
- Locals named `gen` renamed to `generator`. The remaining `rng.r#gen::<f32>()` is forced — rand 0.8 has no `.random()`.

Edition 2024 switches on resolver 3, which is what makes `rust-version` affect resolution. Resolver 2 ignored it, so `cargo update` could pull past the floor — the drift that produced the 1.88 requirement.

`tail_expr_drop_order` changes when the per-callback `tx` clone drops in the cpal callback. Benign: the move-captured clone and `self.sender` both outlive it, so the sender refcount never reaches zero. Confirmed at runtime.

## MSRV 1.88

```toml
rust-version = "1.88"
```

Measured two ways: `cargo-msrv find` → 1.88.0, and `cargo check --locked` fails at 1.87.0, passes at 1.88.0. The floor is `instability 0.3.13` (via `ratatui 0.28.1`) and the `darling 0.24` family, not rav's source. Edition 2024 needs 1.85, below it.

## Flake

`nix flake check --all-systems` exits 1 on master: `eachDefaultSystem` includes x86_64-darwin, which nixpkgs dropped in 26.11, and evaluating it is a hard error. Now an explicit list of x86_64-linux, aarch64-linux and aarch64-darwin.

A `nix` job in ci.yml runs `nix flake check --all-systems`, `nix build` and the resulting binary. A flake sees only git-tracked files, so it catches what cargo cannot.

## Badges

Rust now reads MSRV rather than linking to rust-lang.org; renders `msrv: unknown` until the next publish, since shields reads crates.io metadata. Added devenv, crates.io, downloads and docs.rs.

docs.rs carries no colour override so it renders green and goes red on failure, matching CI. Version and downloads stay flat — a number is not a status.