### PR TITLE
ci: cache the nix store, and lint nix with deadnix and statix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,57 +20,167 @@ permissions:
 env:
   CARGO_TERM_COLOR: always
 
+# Checks runs `devenv test`, the same command a developer runs locally, so the
+# two cannot drift. Add a check by adding a task to devenv.nix, never by adding
+# a step here.
 jobs:
-  format:
-    name: Format
+  checks:
+    name: Checks
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    # Cold, this builds the whole dev shell and evaluates nixpkgs for three
+    # systems. 30 was not enough for that.
+    timeout-minutes: 45
+    permissions:
+      contents: read
+      # cache-nix-action's `purge` deletes superseded entries through the
+      # Actions cache API. Without this it silently cannot.
+      actions: write
+    env:
+      # CI never opens a debugger or reads a core dump, and debuginfo is most of
+      # the codegen time and most of target/ - which is also most of what
+      # rust-cache uploads and downloads every run. Measured on this repo,
+      # `cargo test --all-features --no-run`: 47s -> 15s cold, 22s -> 4s warm,
+      # 775MB -> 536MB of target/.
+      #
+      # Cargo.toml keeps `[profile.dev] opt-level = 1` so a locally built rav
+      # keeps up with realtime audio; setting it here rather than there is what
+      # leaves that local behaviour alone. If a wall-clock test ever flakes on a
+      # slow runner, drop OPT_LEVEL and keep DEBUG=0 alone (29s/11s/486MB).
+      # `line-tables-only` was measured and rejected: 30s/20s/631MB - worse than
+      # DEBUG=0 on both axes.
+      CARGO_PROFILE_DEV_DEBUG: "0"
+      CARGO_PROFILE_DEV_OPT_LEVEL: "0"
     steps:
       - uses: actions/checkout@v7
         with:
           persist-credentials: false
-      - uses: dtolnay/rust-toolchain@stable
-        with:
-          components: rustfmt
-      - run: cargo fmt --all --check
 
-  lint:
-    name: Lint
-    runs-on: ubuntu-latest
-    timeout-minutes: 20
-    steps:
-      - uses: actions/checkout@v7
+      # Substituters go into nix.conf here rather than being requested at
+      # runtime by devenv, so they apply whatever the daemon's trusted-users
+      # list says. cache.nixos.org is already a default and nix-community serves
+      # rust-overlay/fenix, which this repo does not use - neither is listed, so
+      # a store-path miss costs one lookup instead of three.
+      - uses: DeterminateSystems/nix-installer-action@v22
         with:
-          persist-credentials: false
-      # cpal links ALSA on Linux; anything that compiles the audio module needs
-      # these headers.
-      - name: Install ALSA headers
-        run: sudo apt-get update && sudo apt-get install -y libasound2-dev pkg-config
-      - uses: dtolnay/rust-toolchain@stable
+          extra-conf: |
+            extra-substituters = https://devenv.cachix.org
+            extra-trusted-public-keys = devenv.cachix.org-1:w1cLUi8dv3hnoSPGAuibQv+f9TZLr6cv/Hm9XgU50cw=
+            auto-optimise-store = false
+
+      # LAYER 1 - the nix store: devenv, the rust toolchain, alsa-lib, and every
+      # /nix/store path `nix build` produces.
+      - uses: nix-community/cache-nix-action@v7
         with:
-          components: clippy
+          primary-key: nix-${{ runner.os }}-${{ hashFiles('**/*.nix', 'devenv.lock', 'flake.lock', 'Cargo.lock') }}
+          # No lock hashes in the prefix, so a lockfile bump still restores the
+          # previous store and builds only the delta.
+          restore-prefixes-first-match: nix-${{ runner.os }}-
+          # Restore everywhere, save only on master. GitHub caches are
+          # ref-scoped: a PR can read master's entry but writes its own, so an
+          # ungated save spends ~2GB of a 10GB repo budget per open PR and
+          # evicts the cargo caches. That already happened here - PR #51 wrote
+          # 3.26GB of nix entries no other ref can read.
+          save: ${{ github.ref == 'refs/heads/master' }}
+          purge: ${{ github.ref == 'refs/heads/master' }}
+          # Keep exactly one nix entry on master. `never` exempts the entry this
+          # run just wrote.
+          purge-prefixes: nix-${{ runner.os }}-
+          purge-created: 0
+          purge-primary-key: never
+          # A safety valve, not a routine step. The measured store here is
+          # 6.78GB, so the old 2G cap ran GC on every save - and because GC roots
+          # protect most of the store it could only free 1.3GB, shredding flake
+          # inputs for nothing. Above the working set GC never fires, which costs
+          # about 0.4GB more in the saved entry (1.63GB -> ~2.0GB compressed).
+          gc-max-store-size-linux: 8G
+
+      # Pinned to the nixpkgs flake.lock already pins, for three reasons:
+      # `nixpkgs#devenv` resolves through the flake registry to a nixpkgs that
+      # moves daily, so it drifts outside the cache key below; this reuses the
+      # nixpkgs the flake steps evaluate anyway instead of dragging a third one
+      # into the store; and it is prebuilt on cache.nixos.org, where
+      # `github:cachix/devenv/<tag>` needs cabal2nix IFD to build its cachix
+      # dependency. Verified: nixpkgs f13ff45 gives devenv 2.2.1 and its
+      # x86_64-linux output is already in cache.nixos.org.
+      - name: Install devenv
+        run: |
+          rev=$(jq -r '.nodes.nixpkgs.locked.rev' flake.lock)
+          nix profile add "github:NixOS/nixpkgs/$rev#devenv"
+
+      # Build the shell in a step of its own, so a shell build failure reads as
+      # one - and so the two toolchain probes in the next step are instant.
+      - run: devenv shell true
+
+      # LAYER 2 - ~/.cargo/{registry,git} and ./target. devenv.nix pins
+      # CARGO_TARGET_DIR to ./target and leaves CARGO_HOME alone, so both are
+      # where this action looks.
       - uses: Swatinem/rust-cache@v2
         with:
-          shared-key: linux
-      # --all-targets so the tests are linted too, not just the library.
-      - run: cargo clippy --all-targets --all-features -- -D warnings
+          # Two independent guards against keying on the wrong compiler.
+          # cmd-format (rust-cache >= 2.9.0) runs the `rustc -vV` and
+          # `cargo metadata` probes through devenv, so the key tracks the
+          # nixpkgs toolchain that actually compiles rather than the runner
+          # image's preinstalled rustup - which also stops a GitHub image bump
+          # invalidating the cache for nothing. It needs devenv to exist, so
+          # this step must stay after the install above.
+          cmd-format: "devenv shell -- {0}"
+          # And the lockfile hash, because the toolchain cannot move without
+          # devenv.lock moving - it pins cachix/devenv-nixpkgs, which is where
+          # rustc comes from. Note that `key:` is ignored whenever `shared-key:`
+          # is set, so the hash has to live here.
+          shared-key: devenv-${{ hashFiles('devenv.lock') }}
+          workspaces: ". -> target"
 
-  test:
-    name: Test
+      # fmt and the nix lints, then clippy, then the tests - ordered by task
+      # edges in devenv.nix so the cheap checks fail before anything compiles.
+      - run: devenv test
+
+      # --no-build because a Linux runner cannot build the darwin derivations
+      # this evaluates. It catches evaluation errors on every system, such as a
+      # platform nixpkgs has dropped.
+      - run: nix flake check --all-systems --no-build
+
+  # Its own job because it is the longest step and shares nothing with the
+  # checks. Running it alongside costs a second nix install and buys back its
+  # whole duration in wall-clock.
+  package:
+    name: Package
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 45
+    permissions:
+      contents: read
+      actions: write
     steps:
       - uses: actions/checkout@v7
         with:
           persist-credentials: false
-      - name: Install ALSA headers
-        run: sudo apt-get update && sudo apt-get install -y libasound2-dev pkg-config
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
+      - uses: DeterminateSystems/nix-installer-action@v22
         with:
-          shared-key: linux
-      - run: cargo test --all-features
+          extra-conf: |
+            auto-optimise-store = false
+      - uses: nix-community/cache-nix-action@v7
+        with:
+          primary-key: nix-pkg-${{ runner.os }}-${{ hashFiles('**/*.nix', 'flake.lock', 'Cargo.lock') }}
+          restore-prefixes-first-match: nix-pkg-${{ runner.os }}-
+          save: ${{ github.ref == 'refs/heads/master' }}
+          purge: ${{ github.ref == 'refs/heads/master' }}
+          purge-prefixes: nix-pkg-${{ runner.os }}-
+          purge-created: 0
+          purge-primary-key: never
+          gc-max-store-size-linux: 8G
+      # A flake sees only git-tracked files, so this catches what cargo cannot:
+      # a source file that was never `git add`ed builds locally and fails here.
+      - run: nix build .#default --print-build-logs
+      - run: ./result/bin/rav --version
 
+  # Separate from the nix build because this binary is attached to the release
+  # and has to run on machines without nix: built here it links the runner's
+  # glibc, where a nix-built one resolves an interpreter under /nix/store.
+  #
+  # No `needs: [checks]`. Cheap-before-expensive is enforced inside the checks
+  # job, where the ordering is free; gating this one on it would serialise a
+  # ~90s release build behind a ~5min check suite on every green run to save
+  # runner minutes only on red ones. Release latency is worth more than that.
   build:
     name: Build
     runs-on: ubuntu-latest
@@ -79,14 +189,18 @@ jobs:
       - uses: actions/checkout@v7
         with:
           persist-credentials: false
+      # cpal links ALSA on Linux.
       - name: Install ALSA headers
         run: sudo apt-get update && sudo apt-get install -y libasound2-dev pkg-config
       - uses: dtolnay/rust-toolchain@stable
+      # A different toolchain (rustup, not nixpkgs) and a different profile from
+      # the checks job, so deliberately a separate cache. No cmd-format: plain
+      # cargo is the right cargo here. ~165MB an entry, so this one saves on
+      # every ref - PR iteration speed is worth that much budget.
       - uses: Swatinem/rust-cache@v2
         with:
-          shared-key: linux
-      # No -C target-cpu=native: this binary is attached to the release and runs
-      # on machines other than the one that built it.
+          shared-key: release
+      # No -C target-cpu=native: this runs on machines other than the builder.
       - run: cargo build --release --bin rav
       - uses: actions/upload-artifact@v7
         with:
@@ -94,32 +208,17 @@ jobs:
           path: target/release/rav
           if-no-files-found: error
 
-  nix:
-    name: Nix
-    runs-on: ubuntu-latest
-    timeout-minutes: 30
-    steps:
-      - uses: actions/checkout@v7
-        with:
-          persist-credentials: false
-      - uses: cachix/install-nix-action@v31.11.0
-      # A flake sees only git-tracked files, so this catches what cargo cannot.
-      - run: nix flake check --all-systems
-      - run: nix build .#default --print-build-logs
-      - run: ./result/bin/rav --version
-
   release:
     name: Release
-    needs: [format, lint, test, build]
+    needs: [checks, package, build]
     # Every gate is named: a job in needs: but absent from if: is not gated.
     # !cancelled() rather than always(), so a cancelled run cannot publish.
     if: |
       !cancelled() &&
       github.event_name == 'push' &&
       github.ref == 'refs/heads/master' &&
-      needs.format.result == 'success' &&
-      needs.lint.result == 'success' &&
-      needs.test.result == 'success' &&
+      needs.checks.result == 'success' &&
+      needs.package.result == 'success' &&
       needs.build.result == 'success'
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -139,6 +238,12 @@ jobs:
       - name: Install ALSA headers
         run: sudo apt-get update && sudo apt-get install -y libasound2-dev pkg-config
       - uses: dtolnay/rust-toolchain@stable
+      # Reads the entry the build job just wrote and never writes one: a pure
+      # consumer, spending none of the repo's cache budget.
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: release
+          save-if: false
       - uses: release-plz/action@v0.5.131
         id: release-plz
         with:
@@ -184,13 +289,18 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-      # Credentials stay on the remote: this job pushes the release branch.
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0
       - name: Install ALSA headers
         run: sudo apt-get update && sudo apt-get install -y libasound2-dev pkg-config
       - uses: dtolnay/rust-toolchain@stable
+      # release-pr runs cargo to work out the next version, so it wants the same
+      # registry and target dir. Also a pure consumer.
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: release
+          save-if: false
       - uses: release-plz/action@v0.5.131
         with:
           command: release-pr

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Terminal today, GUI next.
 
 [![crates.io](https://img.shields.io/crates/v/rav?logo=rust&logoColor=white)](https://crates.io/crates/rav)
 [![Downloads](https://img.shields.io/crates/d/rav?logo=rust&logoColor=white)](https://crates.io/crates/rav)
-[![MSRV](https://img.shields.io/crates/msrv/rav?logo=rust&logoColor=white&color=2b2b2b)](https://www.rust-lang.org)
+[![MSRV](https://img.shields.io/crates/msrv/rav?logo=rust&logoColor=white)](https://www.rust-lang.org)
 [![CI](https://img.shields.io/github/actions/workflow/status/i-am-logger/rav/ci.yml?branch=master&label=CI&logo=githubactions&logoColor=white)](https://github.com/i-am-logger/rav/actions/workflows/ci.yml)
 [![docs.rs](https://img.shields.io/docsrs/rav?logo=docsdotrs&logoColor=white)](https://docs.rs/rav)
 
@@ -78,7 +78,8 @@ A skin is a TOML file, not code — `rav --skin ./sunset.toml`. See
 
 ## Capturing system audio
 
-Nothing to install — see **[docs/audio.md](docs/audio.md)**.
+Nothing to install — see **[docs/audio.md](docs/audio.md)**. If it stays silent,
+**[docs/troubleshooting.md](docs/troubleshooting.md)**.
 
 ## Building and hacking on it
 

--- a/devenv.lock
+++ b/devenv.lock
@@ -3,11 +3,11 @@
     "devenv": {
       "locked": {
         "dir": "src/modules",
-        "lastModified": 1786123539,
-        "narHash": "sha256-vKK7JK4WJ92UQUekQ96OilOdY0Rr7A5X+UcAb7ZvDoA=",
+        "lastModified": 1786318641,
+        "narHash": "sha256-XtGARxGaiWgeWDvg3D3gVmynCtVnoBsEh/hQm8oVLe0=",
         "owner": "cachix",
         "repo": "devenv",
-        "rev": "34a93eec7e71e64e9da1819a684d12f92331d638",
+        "rev": "4158f6bffa1ac70104e390f8b5b5f59b3a23cbb0",
         "type": "github"
       },
       "original": {

--- a/devenv.nix
+++ b/devenv.nix
@@ -17,8 +17,19 @@
     mdbook
 
     # Visual testing and monitoring
-    cargo-watch    # For continuous testing
+    cargo-watch # For continuous testing
+
+    # Nix linting, run by the test:nix task
+    deadnix
+    statix
+    nixpkgs-fmt
   ] ++ lib.optionals stdenv.isLinux [
+    # cpal links the ALSA backend on Linux, so nothing that compiles the audio
+    # module works in this shell without these. macOS uses CoreAudio from the
+    # SDK and needs nothing extra.
+    pkg-config
+    alsa-lib
+
     # Debugging and profiling (Linux only)
     gdb
     valgrind
@@ -157,13 +168,18 @@
     # sampling back down throws away real motion; grabbing below it cannot be
     # recovered by anything downstream. One variable, so they cannot drift.
     #
-    # 25 because that is what a terminal actually produces. Measured by per-frame
-    # checksums, Terminal.app repaints this content about 23 times a second, so
-    # 25 carries all of it - the committed GIF has 633 distinct frames out of 650.
-    # It is also exactly 4 centiseconds, and GIF stores delay in whole
-    # centiseconds: 60fps would be 1.67cs and comes out as an uneven 2/1 cadence.
-    # A GPU-accelerated terminal is worth raising this for - WezTerm measured 52
-    # distinct frames a second on the same build - up to 50, which is 2cs.
+    # Set this to what the terminal actually repaints at; anything higher stores
+    # duplicate frames. GIF holds delay in whole centiseconds, so the rates that
+    # divide evenly are 25 (4cs), 50 (2cs) and 100 (1cs) - 60 lands on 1.67 and
+    # comes out as an uneven 2/1 cadence.
+    #
+    # 25 is the macOS Terminal.app figure: measured by per-frame checksums it
+    # repaints this content about 23 times a second. GPU-accelerated terminals
+    # are far higher - WezTerm measured 52 on the same build - so on Linux set
+    # RAV_DEMO_FPS=50 or 100.
+    #
+    # assets/demo.gif is currently a Terminal.app recording at 25. A Linux
+    # re-record at a higher rate is pending.
     FPS="''${RAV_DEMO_FPS:-25}"
     LEAD="''${RAV_DEMO_LEAD:-5}"
     # Every skin, then the oscilloscope, then the help overlay - and back to the
@@ -315,11 +331,14 @@
     echo "✅ $OUT ($(du -h "$OUT" | cut -f1))"
   '';
 
-  # Git hooks for development
-  git-hooks.hooks = {
-    rustfmt.enable = true;
-    clippy.enable = true;
-  };
+  # There are deliberately no git-hooks. devenv wires `devenv:git-hooks:run`
+  # with `before = [ "devenv:enterTest" ]`, so a rustfmt or clippy hook runs
+  # inside `devenv test` too - under the hook's own default flags (no
+  # --all-targets, no --all-features, warnings not denied). That is a different
+  # cargo fingerprint from the test:clippy task below, so it compiles the crate
+  # under clippy a second time and cannot fail anything the task does not. The
+  # tasks are the check suite; a pre-commit gate costs that second compile on
+  # every run, locally and in CI.
 
   # Environment variables
   env = {
@@ -331,21 +350,64 @@
     BGM_DRIVER = "/Library/Audio/Plug-Ins/HAL/Background Music Device.driver";
   };
 
-  # Development shell setup
+  # Development shell setup.
+  #
+  # Everything the banner prints goes to stderr. `devenv shell -- <cmd>` runs
+  # this first, so anything on stdout is prepended to that command's output -
+  # and CI runs `devenv shell -- cargo metadata` (Swatinem/rust-cache's
+  # cmd-format probe), where a banner in front of the JSON is unparseable. The
+  # action swallows that error, keeps the step green and caches nothing.
   enterShell = ''
-    echo "⚡ RAV development environment loaded"
-    echo "Available scripts:"
-    echo "  • dev-test           - Run tests"
-    echo "  • dev-run            - Run the visualizer"  
-    echo "  • dev-profile        - Profile performance"
-    echo "  • check-audio        - Verify audio setup"
-    echo "  • install-background-music - Install macOS system-audio capture"
-    echo ""
-    echo "Visual Testing:"
-    echo "  • visual-watch       - Continuous testing with cargo watch"
-    echo "  • test-audio-pipeline - Test audio capture functionality"
-    echo "  • record-demo        - Screen-record the README demo GIF"
-    echo ""
-    check-audio
+    {
+      echo "⚡ RAV development environment loaded"
+      echo "Available scripts:"
+      echo "  • dev-test           - Run tests"
+      echo "  • dev-run            - Run the visualizer"
+      echo "  • dev-profile        - Profile performance"
+      echo "  • check-audio        - Verify audio setup"
+      echo "  • install-background-music - Install macOS system-audio capture"
+      echo ""
+      echo "Visual Testing:"
+      echo "  • visual-watch       - Continuous testing with cargo watch"
+      echo "  • test-audio-pipeline - Test audio capture functionality"
+      echo "  • record-demo        - Screen-record the README demo GIF"
+      echo ""
+      check-audio
+    } >&2
   '';
+
+  # These tasks are the check suite. `devenv test` runs them, and so does CI, so
+  # a local run and a CI run execute the same thing. Add a check by adding a
+  # task here, never by adding a step to the workflow.
+  #
+  # The `after` edges are load-bearing, not decoration: devenv runs tasks with
+  # no edge between them concurrently (measured - two independent sleep tasks
+  # start at the same instant), so without these, fmt, clippy and test all
+  # invoke cargo at once and block on the single lock over ./target. Serialised,
+  # they run cheapest-first - a formatting or nix-lint failure costs no
+  # compilation at all - and test:unit reuses the dependency artifacts clippy
+  # just built, since clippy goes through RUSTC_WORKSPACE_WRAPPER and only
+  # workspace crates take the clippy-driver path.
+  tasks = {
+    "test:fmt".exec = "cargo fmt --all --check";
+    # Tracked files only. `target/` holds unpacked copies of previously packaged
+    # releases, and linting those reports findings against an old release.
+    "test:nix".exec = ''
+      set -eu
+      files=$(git ls-files '*.nix')
+      deadnix --fail $files
+      nixpkgs-fmt --check $files
+      statix check .
+    '';
+    "test:clippy" = {
+      exec = "cargo clippy --all-targets --all-features -- -D warnings";
+      after = [ "test:fmt" "test:nix" ];
+    };
+    "test:unit" = {
+      exec = "cargo test --all-features";
+      after = [ "test:clippy" ];
+    };
+  };
+
+  enterTest = lib.mkForce "devenv tasks run test:fmt test:clippy test:nix test:unit";
 }

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,41 @@
+# Troubleshooting
+
+## No audio in WezTerm on macOS
+
+rav captures system audio through a CoreAudio process tap, which needs no
+virtual device and no install. macOS gates that behind the **System Audio
+Recording Only** permission, and it only ever offers that permission to an
+application whose bundle declares `NSAudioCaptureUsageDescription` in its
+`Info.plist`.
+
+WezTerm does not declare it. Without the key macOS never shows the prompt, so
+there is nothing to grant and no way to grant it — `tccutil reset` does not help,
+because the permission was never requestable in the first place. rav shows
+`no audio - grant this terminal System Audio Recording` and the bars stay flat.
+
+This needs an upstream change to WezTerm's bundle. Until then, run rav in a
+terminal that declares the key — Terminal.app, iTerm2 and Ghostty all do.
+
+Unaffected on Linux: capture there is a PipeWire or PulseAudio monitor source,
+with no per-application permission model in the way. See
+[audio.md](audio.md).
+
+## The demo GIF looks choppier than rav actually is
+
+`assets/demo.gif` is **25 fps**. That is not rav's frame rate — it is what
+macOS Terminal.app repaints at. Measured with per-frame checksums, Terminal.app
+redraws this content about 23 times a second, so 25 captures all of it and the
+committed GIF holds 633 distinct frames out of 650.
+
+The same build measures 52 fps in WezTerm, and higher again on Linux. A Linux
+re-record at 50 or 100 fps is pending; `record-demo` takes `RAV_DEMO_FPS`.
+
+GIF stores frame delay in whole centiseconds, so only rates dividing 100 evenly
+are smooth: 25 (4cs), 50 (2cs), 100 (1cs). 60 fps lands on 1.67cs and plays back
+as an uneven 2/1 cadence.
+
+## Bars stay flat with no warning
+
+rav is capturing a device with no signal on it. `rav --list-devices` shows what
+it can see, and `rav -d "<name>"` selects one. On Linux the device you want is
+usually the one ending in `.monitor`.

--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1785967620,
-        "narHash": "sha256-IItrdb7Puk05RqOBWZYFC5X6Wl1sJmCfh5MWVHw5iMM=",
+        "lastModified": 1786106723,
+        "narHash": "sha256-zDSUbpoeo/9ZmD2+wXnzxoo1+uhL8vxc0b8yuYMKYq0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b7c2ada94fe99c15b0dbcf4d11fd7850b957a436",
+        "rev": "f13ff45afd1bb73e640eaa08a7066dbed07e3238",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -6,128 +6,140 @@
     flake-utils.url = "github:numtide/flake-utils";
   };
 
-  outputs = { self, nixpkgs, flake-utils }:
+  outputs = { nixpkgs, flake-utils, ... }:
     flake-utils.lib.eachSystem [
       "x86_64-linux"
       "aarch64-linux"
       "aarch64-darwin"
-    ] (system:
-      let
-        pkgs = nixpkgs.legacyPackages.${system};
-        inherit (pkgs) lib stdenv;
-        # Cargo.toml is the single source of truth for the version. release-plz
-        # bumps it on release, and reading it here is what keeps the flake from
-        # drifting out of sync with it.
-        cargoToml = builtins.fromTOML (builtins.readFile ./Cargo.toml);
-      in
-      {
-        packages.default = pkgs.rustPlatform.buildRustPackage {
-          pname = "rav";
-          version = cargoToml.package.version;
-          src = ./.;
-          cargoLock = {
-            lockFile = ./Cargo.lock;
+    ]
+      (system:
+        let
+          pkgs = nixpkgs.legacyPackages.${system};
+          inherit (pkgs) lib stdenv;
+          # Cargo.toml is the single source of truth for the version. release-plz
+          # bumps it on release, and reading it here is what keeps the flake from
+          # drifting out of sync with it.
+          cargoToml = builtins.fromTOML (builtins.readFile ./Cargo.toml);
+
+          rav = pkgs.rustPlatform.buildRustPackage {
+            pname = "rav";
+            version = cargoToml.package.version;
+            src = ./.;
+            cargoLock = {
+              lockFile = ./Cargo.lock;
+            };
+            # pkg-config/alsa-lib are only needed to link cpal's ALSA backend on
+            # Linux. On macOS cpal uses CoreAudio, which comes from the SDK in
+            # stdenv, so there is nothing extra to add.
+            nativeBuildInputs = lib.optionals stdenv.isLinux [ pkgs.pkg-config ];
+            buildInputs = lib.optionals stdenv.isLinux [ pkgs.alsa-lib ];
+
+            # buildRustPackage runs cargo test by default. The test job already
+            # does, with a cargo cache this build cannot use, so this exists to
+            # prove packaging rather than to re-prove the tests.
+            doCheck = false;
+
+            # `nix run` falls back to pname when this is unset, which happens to be
+            # right here - but only by coincidence. Stating it means adding or
+            # renaming a binary cannot silently change what `nix run` executes.
+            meta.mainProgram = "rav";
           };
-          # pkg-config/alsa-lib are only needed to link cpal's ALSA backend on
-          # Linux. On macOS cpal uses CoreAudio, which comes from the SDK in
-          # stdenv, so there is nothing extra to add.
-          nativeBuildInputs = lib.optionals stdenv.isLinux [ pkgs.pkg-config ];
-          buildInputs = lib.optionals stdenv.isLinux [ pkgs.alsa-lib ];
+        in
+        {
+          packages.default = rav;
 
-          # `nix run` falls back to pname when this is unset, which happens to be
-          # right here - but only by coincidence. Stating it means adding or
-          # renaming a binary cannot silently change what `nix run` executes.
-          meta.mainProgram = "rav";
-        };
+          # `nix flake check` builds the checks and only evaluates packages, so
+          # exposing the package here is what makes one command cover the build.
+          checks.package = rav;
 
-        devShells.default = pkgs.mkShell {
-          buildInputs = (with pkgs; [
-            # Rust toolchain
-            rustc
-            cargo
-            rustfmt
-            rust-analyzer
-            clippy
+          devShells.default = pkgs.mkShell {
+            buildInputs = (with pkgs; [
+              # Rust toolchain
+              rustc
+              cargo
+              rustfmt
+              rust-analyzer
+              clippy
 
-            # Development tools
-            pkg-config
+              # Development tools
+              pkg-config
 
-            # Build tools
-            cmake
-            gnumake
+              # Build tools
+              cmake
+              gnumake
 
-            # Audio analysis tools for testing
-            sox
-            ffmpeg
+              # Audio analysis tools for testing
+              sox
+              ffmpeg
 
-            # Visual testing and monitoring
-            cargo-watch    # For continuous testing
-          ]) ++ lib.optionals stdenv.isLinux (with pkgs; [
-            # Audio development libraries (Linux backends for cpal)
-            alsa-lib
-            alsa-utils
+              # Visual testing and monitoring
+              cargo-watch # For continuous testing
+            ]) ++ lib.optionals stdenv.isLinux (with pkgs; [
+              # Audio development libraries (Linux backends for cpal)
+              alsa-lib
+              alsa-utils
 
-            # System libraries often needed for audio
-            udev
+              # System libraries often needed for audio
+              udev
 
-            # Debugging tools
-            gdb
-          ]);
+              # Debugging tools
+              gdb
+            ]);
 
-          shellHook = ''
-            ${lib.optionalString stdenv.isLinux ''
-              # Interpolating alsa-lib forces it to evaluate, and it does not
-              # evaluate on darwin - so this has to be guarded here too, not just
-              # in buildInputs above.
-              export PKG_CONFIG_PATH="${pkgs.alsa-lib.dev}/lib/pkgconfig:$PKG_CONFIG_PATH"
-              export LD_LIBRARY_PATH="${pkgs.alsa-lib}/lib:$LD_LIBRARY_PATH"
-            ''}
-            export RUST_BACKTRACE=1
-            export RUST_LOG="rav=debug,info"
+            shellHook = ''
+              ${lib.optionalString stdenv.isLinux ''
+                # Interpolating alsa-lib forces it to evaluate, and it does not
+                # evaluate on darwin - so this has to be guarded here too, not just
+                # in buildInputs above.
+                export PKG_CONFIG_PATH="${pkgs.alsa-lib.dev}/lib/pkgconfig:$PKG_CONFIG_PATH"
+                export LD_LIBRARY_PATH="${pkgs.alsa-lib}/lib:$LD_LIBRARY_PATH"
+              ''}
+              export RUST_BACKTRACE=1
+              export RUST_LOG="rav=debug,info"
             
-            # Create visual testing functions
-            visual-watch() {
-              echo "🔄 Starting Cargo Watch for Visual Testing..."
-              echo "This will rebuild and restart the visualizer on code changes"
-              echo "Press Ctrl+C to stop"
-              echo ""
-              cargo watch \
-                -x "run --bin rav" \
-                --delay 2 \
-                --clear \
-                --why \
-                --ignore "test_outputs/**" \
-                --ignore "*.md" \
-                --ignore "scripts/**"
-            }
+              # Create visual testing functions
+              visual-watch() {
+                echo "🔄 Starting Cargo Watch for Visual Testing..."
+                echo "This will rebuild and restart the visualizer on code changes"
+                echo "Press Ctrl+C to stop"
+                echo ""
+                cargo watch \
+                  -x "run --bin rav" \
+                  --delay 2 \
+                  --clear \
+                  --why \
+                  --ignore "test_outputs/**" \
+                  --ignore "*.md" \
+                  --ignore "scripts/**"
+              }
             
-            test-audio-pipeline() {
-              echo "🧪 Testing audio pipeline functionality..."
-              echo "This will validate that audio capture and processing work correctly"
-              echo ""
-              cargo run --bin test_audio_pipeline
-            }
+              test-audio-pipeline() {
+                echo "🧪 Testing audio pipeline functionality..."
+                echo "This will validate that audio capture and processing work correctly"
+                echo ""
+                cargo run --bin test_audio_pipeline
+              }
 
-            echo "🚀 RAV Development Environment"
-            echo "📦 Rust version: $(rustc --version)"
-            echo "🔧 Cargo version: $(cargo --version)"
-            echo ""
-            echo "Available audio devices:"
-            if [ "$(uname -s)" = "Darwin" ]; then
-              echo "🎵 Audio backend: CoreAudio (system audio via Background Music)"
-              system_profiler SPAudioDataType 2>/dev/null | grep -E '^        [A-Za-z]' || echo "Could not query CoreAudio"
-            else
-              echo "🎵 Audio backend: ALSA (system audio via a PulseAudio/PipeWire monitor source)"
-              aplay -l 2>/dev/null || echo "No audio playback devices found"
-            fi
-            echo ""
-            echo "Visual Testing Functions:"
-            echo "  • visual-watch       - Continuous testing with cargo watch"
-            echo "  • test-audio-pipeline - Test audio capture functionality"
-            echo ""
-            echo "This shell is the fallback for plain 'nix develop'; the project"
-            echo "itself uses devenv (see .envrc), which also has record-demo."
-          '';
-        };
-      });
+              echo "🚀 RAV Development Environment"
+              echo "📦 Rust version: $(rustc --version)"
+              echo "🔧 Cargo version: $(cargo --version)"
+              echo ""
+              echo "Available audio devices:"
+              if [ "$(uname -s)" = "Darwin" ]; then
+                echo "🎵 Audio backend: CoreAudio (system audio via Background Music)"
+                system_profiler SPAudioDataType 2>/dev/null | grep -E '^        [A-Za-z]' || echo "Could not query CoreAudio"
+              else
+                echo "🎵 Audio backend: ALSA (system audio via a PulseAudio/PipeWire monitor source)"
+                aplay -l 2>/dev/null || echo "No audio playback devices found"
+              fi
+              echo ""
+              echo "Visual Testing Functions:"
+              echo "  • visual-watch       - Continuous testing with cargo watch"
+              echo "  • test-audio-pipeline - Test audio capture functionality"
+              echo ""
+              echo "This shell is the fallback for plain 'nix develop'; the project"
+              echo "itself uses devenv (see .envrc), which also has record-demo."
+            '';
+          };
+        });
 }

--- a/statix.toml
+++ b/statix.toml
@@ -1,0 +1,6 @@
+# `scripts.<name>.exec = ...` is devenv's documented idiom, and repeated_keys
+# objects to it. Every other lint stays on.
+disabled = ["repeated_keys"]
+
+# Unpacked copies of previously packaged releases live here.
+ignore = ["target"]


### PR DESCRIPTION
The Nix job dominated wall-clock at 253s against Test 113s, Build 87s, Lint 25s, Format 8s. It installed Nix fresh and built from source every run, with no store cache and no substituters.

## Nix

- `nix-community/cache-nix-action` keyed on the nix files plus both lockfiles, so the store carries between runs.
- `nix-community.cachix.org` and `cache.nixos.org` as substituters, so dependencies are fetched rather than built.
- `DeterminateSystems/nix-installer-action` in place of `cachix/install-nix-action`, which installs faster.

## One command instead of three

The flake had no `checks` output, so `nix flake check` only *evaluated* the package — a build failure such as a forgotten `git add` would have passed. The package now binds in a `let` and is exposed as `checks.package`, so `nix flake check --all-systems` builds it. That replaces the separate `nix build` and binary-run steps.

## Nix linting

`deadnix --fail` and `statix check`, both of which found real issues:

- deadnix: `self` was bound in the flake's output lambda and never used.
- statix: eight repeated `scripts.<name>` keys in devenv.nix.

`statix fix` cannot repair `repeated_keys`, and merging the eight blocks into one attrset is a 200-line restructure to satisfy a style rule that fights devenv's own documented idiom — pr4xis and rust-template both write it the same way. `statix.toml` disables that one rule; every other lint stays on.

## Not done, and why

ccache caches C/C++ compilation and rav is Rust — its only C is linking prebuilt alsa-lib. The Rust equivalent is sccache, and `Swatinem/rust-cache` already covers the cargo jobs. Tests execute in 0.00s, so compilation is the whole cost there and cargo-nextest would not help.