### PR TITLE
dev: restore the rustfmt git-hook

### DIFF
--- a/devenv.nix
+++ b/devenv.nix
@@ -331,14 +331,16 @@
     echo "✅ $OUT ($(du -h "$OUT" | cut -f1))"
   '';
 
-  # There are deliberately no git-hooks. devenv wires `devenv:git-hooks:run`
-  # with `before = [ "devenv:enterTest" ]`, so a rustfmt or clippy hook runs
-  # inside `devenv test` too - under the hook's own default flags (no
-  # --all-targets, no --all-features, warnings not denied). That is a different
-  # cargo fingerprint from the test:clippy task below, so it compiles the crate
-  # under clippy a second time and cannot fail anything the task does not. The
-  # tasks are the check suite; a pre-commit gate costs that second compile on
-  # every run, locally and in CI.
+  # rustfmt only. devenv wires `devenv:git-hooks:run` before
+  # `devenv:enterTest`, so every hook also runs inside `devenv test` and
+  # therefore in CI. A clippy hook there would use its own default flags - no
+  # --all-targets, no --all-features, warnings not denied - which is a different
+  # cargo fingerprint from the test:clippy task, so it compiles the crate under
+  # clippy a second time and cannot fail anything that task does not.
+  # Formatting is the part worth catching before the commit rather than after.
+  git-hooks.hooks = {
+    rustfmt.enable = true;
+  };
 
   # Environment variables
   env = {


### PR DESCRIPTION
Removing git-hooks entirely was an over-correction. The hooks failing in CI was a separate bug — devenv.nix did not provide `alsa-lib`/`pkg-config` on Linux, so cargo could not compile cpal inside the shell at all. That is fixed, and the hooks work.

What remains is a cost, not a fault, and it applies only to clippy. devenv runs `devenv:git-hooks:run` before `devenv:enterTest`, so every hook also runs inside `devenv test` and therefore in CI. A clippy hook uses its own default flags — no `--all-targets`, no `--all-features`, warnings not denied — which is a different cargo fingerprint from the `test:clippy` task, so it compiles the crate under clippy a second time and cannot fail anything that task does not.

rustfmt has no such problem: it does not compile. Formatting is also the part worth catching before the commit rather than after, which is what a hook is for.

`devenv test` passes with the hook restored, and `.pre-commit-config.yaml` regenerates on shell entry.

Also removes the need for the `prek uninstall` step: a repo with the hook installed now has the config it expects.