### PR TITLE
perf(nix): build dependencies as their own derivation with crane

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
     branches: [ master ]
 
 concurrency:
-  group: ci-${{ github.head_ref || github.ref }}
+  group: ci-${{ github.event.pull_request.number || github.ref }}
   # master is exempt: it publishes to an immutable registry, then tags and
   # releases as separate steps. A cancel between them cannot be undone.
   cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
@@ -160,7 +160,10 @@ jobs:
             auto-optimise-store = false
       - uses: nix-community/cache-nix-action@v7
         with:
-          primary-key: nix-pkg-${{ runner.os }}-${{ hashFiles('**/*.nix', 'flake.lock', 'Cargo.lock') }}
+          # flake.nix, not **/*.nix: this job never reads devenv.nix, and
+          # including it means every dev-shell edit throws away the dependency
+          # artifacts crane just cached.
+          primary-key: nix-pkg-${{ runner.os }}-${{ hashFiles('flake.nix', 'flake.lock', 'Cargo.lock') }}
           restore-prefixes-first-match: nix-pkg-${{ runner.os }}-
           save: ${{ github.ref == 'refs/heads/master' }}
           purge: ${{ github.ref == 'refs/heads/master' }}

--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,20 @@
 {
   "nodes": {
+    "crane": {
+      "locked": {
+        "lastModified": 1785782307,
+        "narHash": "sha256-MPaRdVkf6zZP5fCPxYCi8Dr4pZzgmXzg8T9nVEbp3Mw=",
+        "owner": "ipetkov",
+        "repo": "crane",
+        "rev": "2c71e194474d13de031d729b729c968ddbe3507f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ipetkov",
+        "repo": "crane",
+        "type": "github"
+      }
+    },
     "flake-utils": {
       "inputs": {
         "systems": "systems"
@@ -36,6 +51,7 @@
     },
     "root": {
       "inputs": {
+        "crane": "crane",
         "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -4,9 +4,10 @@
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
     flake-utils.url = "github:numtide/flake-utils";
+    crane.url = "github:ipetkov/crane";
   };
 
-  outputs = { nixpkgs, flake-utils, ... }:
+  outputs = { nixpkgs, flake-utils, crane, ... }:
     flake-utils.lib.eachSystem [
       "x86_64-linux"
       "aarch64-linux"
@@ -16,34 +17,50 @@
         let
           pkgs = nixpkgs.legacyPackages.${system};
           inherit (pkgs) lib stdenv;
-          # Cargo.toml is the single source of truth for the version. release-plz
-          # bumps it on release, and reading it here is what keeps the flake from
-          # drifting out of sync with it.
-          cargoToml = builtins.fromTOML (builtins.readFile ./Cargo.toml);
+          craneLib = crane.mkLib pkgs;
 
-          rav = pkgs.rustPlatform.buildRustPackage {
-            pname = "rav";
-            version = cargoToml.package.version;
+          # src/visual/skin.rs pulls skins/*.toml in with include_str!, so they
+          # have to survive filtering. crane's filter keeps every .toml today,
+          # which covers them incidentally rather than deliberately; the second
+          # clause states the requirement so a narrower filter upstream cannot
+          # quietly break the build.
+          src = lib.cleanSourceWith {
             src = ./.;
-            cargoLock = {
-              lockFile = ./Cargo.lock;
-            };
-            # pkg-config/alsa-lib are only needed to link cpal's ALSA backend on
-            # Linux. On macOS cpal uses CoreAudio, which comes from the SDK in
-            # stdenv, so there is nothing extra to add.
+            filter = path: type:
+              (craneLib.filterCargoSources path type)
+              || (lib.hasInfix "/skins/" path);
+            name = "source";
+          };
+
+          # pkg-config/alsa-lib are only needed to link cpal's ALSA backend on
+          # Linux. On macOS cpal uses CoreAudio, which comes from the SDK in
+          # stdenv, so there is nothing extra to add.
+          commonArgs = {
+            inherit src;
+            strictDeps = true;
             nativeBuildInputs = lib.optionals stdenv.isLinux [ pkgs.pkg-config ];
             buildInputs = lib.optionals stdenv.isLinux [ pkgs.alsa-lib ];
+          };
 
-            # buildRustPackage runs cargo test by default. The test job already
-            # does, with a cargo cache this build cannot use, so this exists to
-            # prove packaging rather than to re-prove the tests.
+          # The dependencies as a store path of their own, built from a stub
+          # crate so the hash follows Cargo.lock rather than src. Editing rav
+          # leaves this untouched, so the 119 dependency crates are restored
+          # from the store instead of recompiled.
+          cargoArtifacts = craneLib.buildDepsOnly commonArgs;
+
+          rav = craneLib.buildPackage (commonArgs // {
+            inherit cargoArtifacts;
+
+            # crane runs cargo test by default. The checks job already does,
+            # with a cargo cache this build cannot use, so this proves packaging
+            # rather than re-proving the tests.
             doCheck = false;
 
-            # `nix run` falls back to pname when this is unset, which happens to be
-            # right here - but only by coincidence. Stating it means adding or
-            # renaming a binary cannot silently change what `nix run` executes.
+            # `nix run` falls back to pname when this is unset, which happens to
+            # be right here - but only by coincidence. Stating it means adding
+            # or renaming a binary cannot silently change what `nix run` runs.
             meta.mainProgram = "rav";
-          };
+          });
         in
         {
           packages.default = rav;


### PR DESCRIPTION
`nix build` was recompiling **119 crates on every run** — every dependency rav has, on every source change.

`rustPlatform.buildRustPackage` builds dependencies and the crate in a single derivation, so the derivation hash includes `src`. Edit one line of rav and all 119 rebuild. No cache can help, because the thing worth caching never exists as a store path of its own. That is why `devenv test` fell to 18s once its cargo cache was keyed correctly while `nix build` sat at 113s.

crane splits it:

```nix
cargoArtifacts = craneLib.buildDepsOnly commonArgs;              # hash follows Cargo.lock
rav            = craneLib.buildPackage (commonArgs // { inherit cargoArtifacts; });
```

`cargoArtifacts` is built from a stub crate, so its hash follows `Cargo.toml`/`Cargo.lock` and not the source. It survives every source-only commit and restores from the nix store cache.

Measured locally — append a line to `src/main.rs`, rebuild:

| | crates compiled | time |
|---|---|---|
| buildRustPackage | 119 | 113s |
| crane | **1** | **27s** |

One trap worth naming: crane's `filterCargoSources` keeps only what cargo reads, which drops `skins/`. `src/visual/skin.rs` pulls those in with `include_str!`, so the filter is composed to keep them:

```nix
filter = path: type:
  (craneLib.filterCargoSources path type) || (lib.hasInfix "/skins/" path);
```

## Also

The Package job's cache key was `hashFiles('**/*.nix', ...)`, and `**/*.nix` matches `devenv.nix` — a file that job never reads. Every dev-shell edit discarded the package cache; PR #53 missed for exactly this reason. Now keyed on `flake.nix`.

Verified: `nix build`, `nix run`, `nix flake check --all-systems`, `devenv test`, deadnix, statix, actionlint.