### PR TITLE
feat: ask the terminal whether it can draw images, and say so

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,10 +45,8 @@ rav --clean           # keep logging out of the display
 rav --surface kitty   # auto, glyphs, kitty or window
 ```
 
-`--surface` is reported and not yet obeyed: `h` shows which one rav *would* draw
-on, and block glyphs draw the frame either way. It is out early so the startup
-probe behind it — which asks your terminal a question and waits 120ms for an
-answer — gets a release of exposure before anything depends on it.
+`--surface` only reports for now. Press `h` and rav tells you which surface it
+would draw on and why; block characters draw the picture either way.
 
 Everything else is a keypress, and `h` shows the lot with their current values:
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,13 @@ rav --theme winamp    # rav, winamp, terminal, mono, or a path to a theme
 rav --list-devices    # what rav can capture from
 rav -d "<name>"       # capture from a named device
 rav --clean           # keep logging out of the display
+rav --surface kitty   # auto, glyphs, kitty or window
 ```
+
+`--surface` is reported and not yet obeyed: `h` shows which one rav *would* draw
+on, and block glyphs draw the frame either way. It is out early so the startup
+probe behind it — which asks your terminal a question and waits 120ms for an
+answer — gets a release of exposure before anything depends on it.
 
 Everything else is a keypress, and `h` shows the lot with their current values:
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@ pub mod audio;
 pub mod config;
 pub mod render;
 pub mod signal;
+pub mod surface;
 pub mod testing;
 pub mod ui;
 pub mod visual;

--- a/src/main.rs
+++ b/src/main.rs
@@ -39,6 +39,24 @@ struct Args {
     /// Theme: `rav`, `winamp`, `terminal`, `mono`, or a name/path of a theme file
     #[arg(long, value_name = "NAME|PATH")]
     theme: Option<String>,
+
+    /// Which surface to draw on. Reported in the help overlay; nothing draws on
+    /// it yet, so today this only changes what rav says it would use.
+    #[arg(
+        long,
+        value_name = "auto|glyphs|kitty|window",
+        default_value = "auto",
+        value_parser = surface
+    )]
+    surface: rav::surface::Choice,
+}
+
+/// Reject an unknown surface rather than falling back to `auto`.
+///
+/// A typo that silently means `auto` is a bug report about rav ignoring a flag.
+fn surface(text: &str) -> Result<rav::surface::Choice, String> {
+    rav::surface::Choice::parse(text)
+        .ok_or_else(|| format!("unknown surface `{text}` - try auto, glyphs, kitty or window"))
 }
 
 #[tokio::main]
@@ -152,6 +170,21 @@ async fn main() -> Result<()> {
         app.set_theme(rav::visual::theme::load(theme)?);
         info!("Using theme: {theme}");
     }
+
+    // Here, and not inside `App`, because asking the terminal has to happen
+    // before the alternate screen is entered and while nothing else is reading
+    // stdin - the same constraint the palette query above runs under.
+    let chosen = rav::surface::choose(
+        args.surface,
+        rav::surface::multiplexed(),
+        rav::surface::probe,
+    );
+    info!(
+        "Would draw on {} ({})",
+        chosen.surface.label(),
+        chosen.because
+    );
+    app.set_surface(chosen);
 
     // Prefer a CoreAudio process tap. It captures every process' output ahead of
     // the system volume, so playback level does not drive the display, and it

--- a/src/surface/mod.rs
+++ b/src/surface/mod.rs
@@ -99,7 +99,7 @@ impl Chosen {
     /// answer when there is no answer.
     pub const UNASKED: Self = Self {
         surface: Surface::Glyphs,
-        because: "nothing asked",
+        because: "not asked yet",
     };
 }
 
@@ -137,17 +137,17 @@ pub fn choose(asked: Choice, multiplexed: bool, answers: impl FnOnce() -> bool) 
         // passes through. Image escapes do not survive that intact, and the
         // failure is a garbled screen rather than a missing picture - so auto
         // never picks pixels there, however the terminal answers.
-        Choice::Auto if multiplexed => glyphs("under a multiplexer"),
+        Choice::Auto if multiplexed => glyphs("tmux or screen is in the way"),
         // Not a guard, because calling `answers` consumes it and a match guard
         // only gets a borrow.
         Choice::Auto => {
             if answers() {
                 Chosen {
                     surface: Surface::Kitty,
-                    because: "the terminal answered",
+                    because: "your terminal can draw images",
                 }
             } else {
-                glyphs("the terminal said nothing")
+                glyphs("your terminal cannot draw images")
             }
         }
     }
@@ -323,7 +323,7 @@ mod tests {
         // missing picture, which is worse than not trying.
         let under_tmux = choose(Choice::Auto, true, || true);
         assert_eq!(under_tmux.surface, Surface::Glyphs);
-        assert_eq!(under_tmux.because, "under a multiplexer");
+        assert_eq!(under_tmux.because, "tmux or screen is in the way");
     }
 
     #[test]

--- a/src/surface/mod.rs
+++ b/src/surface/mod.rs
@@ -1,0 +1,285 @@
+//! Which surface rav would draw on, and asking the terminal whether it can.
+//!
+//! Reporting only. Nothing here changes what is drawn - the choice is made,
+//! logged and shown in the help overlay, and the glyph renderer draws every
+//! frame regardless. A probe that hangs or garbles a terminal is the worst bug
+//! class in this area, so it ships first with its only possible symptom being a
+//! wrong label.
+
+use crate::render::Capabilities;
+use rav_core::units::Cells;
+use std::io::{Read, Write};
+use std::os::fd::AsRawFd;
+use std::time::{Duration, Instant};
+
+/// How long to wait for a terminal to answer the capability query.
+///
+/// The same budget the palette query allows, for the same reason: a terminal
+/// that does not implement this says nothing at all, so the deadline is the only
+/// thing that ends the wait.
+const PROBE_TIMEOUT: Duration = Duration::from_millis(120);
+
+/// Where a frame is drawn.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum Surface {
+    /// Unicode block glyphs in a cell grid. Works everywhere, and is what every
+    /// terminal that cannot do better gets.
+    #[default]
+    Glyphs,
+    /// Pixels, over the kitty graphics protocol.
+    Kitty,
+    /// A window of rav's own.
+    Window,
+}
+
+impl Surface {
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Glyphs => "glyphs",
+            Self::Kitty => "pixels",
+            Self::Window => "window",
+        }
+    }
+
+    /// What this surface can show, for deciding which visualisations to offer.
+    ///
+    /// A glyph grid cannot layer: one cell holds one symbol and one background,
+    /// which is why a cap drawn over the backdrop replaces it (#65) and why a
+    /// written cell blanks a kitty image.
+    pub fn capabilities(self, columns: Cells, rows: Cells) -> Capabilities {
+        let grid = Capabilities::terminal(columns, rows);
+        match self {
+            Self::Glyphs => grid,
+            // Sub-cell resolution and real compositing, at the same extent.
+            Self::Kitty | Self::Window => Capabilities {
+                shades: 256,
+                layers: true,
+                ..grid
+            },
+        }
+    }
+}
+
+/// What the user asked for.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum Choice {
+    /// Ask the terminal, and take the best it admits to.
+    #[default]
+    Auto,
+    Glyphs,
+    Kitty,
+    Window,
+}
+
+impl Choice {
+    pub fn parse(text: &str) -> Option<Self> {
+        match text {
+            "auto" => Some(Self::Auto),
+            "glyphs" => Some(Self::Glyphs),
+            "kitty" | "pixels" => Some(Self::Kitty),
+            "window" | "gui" => Some(Self::Window),
+            _ => None,
+        }
+    }
+}
+
+/// Why a surface was chosen, so a wrong choice can be argued with.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Chosen {
+    pub surface: Surface,
+    pub because: &'static str,
+}
+
+/// Decide which surface to draw on.
+///
+/// `asked` is what the user typed; `multiplexed` is whether rav is running under
+/// tmux or screen; `answers` is whether the terminal admitted to the kitty
+/// protocol. Split from the probe so the decision is testable without a
+/// terminal - the probe needs one and this does not.
+pub fn choose(asked: Choice, multiplexed: bool, answers: bool) -> Chosen {
+    let glyphs = |because| Chosen {
+        surface: Surface::Glyphs,
+        because,
+    };
+    match asked {
+        Choice::Window => Chosen {
+            surface: Surface::Window,
+            because: "asked for",
+        },
+        // An explicit request is honoured even where auto would decline, so a
+        // terminal that does not answer the query but does draw images is still
+        // reachable. It is the user's terminal and they can see the result.
+        Choice::Kitty => Chosen {
+            surface: Surface::Kitty,
+            because: "asked for",
+        },
+        Choice::Glyphs => glyphs("asked for"),
+        // A multiplexer sits between rav and the terminal and rewrites what
+        // passes through. Image escapes do not survive that intact, and the
+        // failure is a garbled screen rather than a missing picture - so auto
+        // never picks pixels there, however the terminal answers.
+        Choice::Auto if multiplexed => glyphs("running under a multiplexer"),
+        Choice::Auto if answers => Chosen {
+            surface: Surface::Kitty,
+            because: "the terminal answered the graphics query",
+        },
+        Choice::Auto => glyphs("the terminal did not answer the graphics query"),
+    }
+}
+
+/// Whether rav is running under a terminal multiplexer.
+pub fn multiplexed() -> bool {
+    std::env::var_os("TMUX").is_some()
+        || std::env::var("TERM").is_ok_and(|term| term.starts_with("screen"))
+}
+
+/// Ask the terminal whether it speaks the kitty graphics protocol.
+///
+/// Must run before the alternate screen is entered and while nothing else is
+/// reading stdin. Costs one round trip, bounded by [`PROBE_TIMEOUT`].
+///
+/// **No test reaches this body** - it needs a pty, so the raw-mode handling and
+/// its restore are exercised by running rav and by nothing else. [`answered`] is
+/// the testable half.
+#[cfg(not(test))]
+pub fn probe() -> bool {
+    let was_raw = crossterm::terminal::is_raw_mode_enabled().unwrap_or(false);
+    if !was_raw && crossterm::terminal::enable_raw_mode().is_err() {
+        return false;
+    }
+    let answer = probe_via(&mut std::io::stdout(), &mut std::io::stdin());
+    if !was_raw {
+        let _ = crossterm::terminal::disable_raw_mode();
+    }
+    answer
+}
+
+/// No terminal under test, so nothing answers.
+#[cfg(test)]
+pub fn probe() -> bool {
+    false
+}
+
+fn probe_via<W: Write, R: Read + AsRawFd>(out: &mut W, input: &mut R) -> bool {
+    // One opaque pixel, transmitted and queried rather than displayed: `a=q`
+    // asks whether the terminal *could* take it and draws nothing either way.
+    let pixel = "AAAA"; // three zero bytes, base64
+    if write!(out, "\x1b_Gi=31,s=1,v=1,a=q,t=d,f=24;{pixel}\x1b\\").is_err() || out.flush().is_err()
+    {
+        return false;
+    }
+
+    let deadline = Instant::now() + PROBE_TIMEOUT;
+    let mut seen = Vec::new();
+    let mut chunk = [0u8; 256];
+    while let Some(left) = deadline.checked_duration_since(Instant::now()) {
+        if !crate::visual::palette::readable(input.as_raw_fd(), left) {
+            break;
+        }
+        match input.read(&mut chunk) {
+            Ok(0) | Err(_) => break,
+            Ok(n) => {
+                seen.extend_from_slice(&chunk[..n]);
+                if let Some(verdict) = answered(&seen) {
+                    return verdict;
+                }
+            }
+        }
+    }
+    false
+}
+
+/// Read a reply, if it is complete enough to be one.
+///
+/// `None` means keep waiting: a reply split across two reads is ordinary, and
+/// treating a partial one as a refusal would decline terminals that do support
+/// this.
+pub fn answered(bytes: &[u8]) -> Option<bool> {
+    let text = String::from_utf8_lossy(bytes);
+    let reply = text.split("\x1b_G").nth(1)?;
+    // The terminator has to have arrived, or the payload may still be growing.
+    let body = reply.split("\x1b\\").next()?;
+    if !reply.contains("\x1b\\") {
+        return None;
+    }
+    Some(body.contains(";OK"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn the_probe_gives_up_rather_than_blocking() {
+        // A terminal that takes the query and never answers must not hang rav at
+        // startup - and most terminals are exactly that, since not implementing
+        // the protocol means saying nothing at all. /dev/null is readable-at-EOF,
+        // the closest stand-in for a terminal that will never reply.
+        let mut sink = Vec::new();
+        let mut null = std::fs::File::open("/dev/null").unwrap();
+        let start = Instant::now();
+        let answered = probe_via(&mut sink, &mut null);
+        assert!(
+            start.elapsed() < PROBE_TIMEOUT * 2,
+            "took too long to give up"
+        );
+        assert!(!answered, "silence is not support");
+        assert!(!sink.is_empty(), "it should still have asked");
+    }
+
+    #[test]
+    fn a_multiplexer_declines_pixels_however_the_terminal_answers() {
+        // tmux and screen rewrite what passes through, and an image escape does
+        // not survive that intact. The failure is a garbled screen rather than a
+        // missing picture, which is worse than not trying.
+        let under_tmux = choose(Choice::Auto, true, true);
+        assert_eq!(under_tmux.surface, Surface::Glyphs);
+        assert_eq!(under_tmux.because, "running under a multiplexer");
+    }
+
+    #[test]
+    fn auto_follows_the_terminals_answer() {
+        assert_eq!(choose(Choice::Auto, false, true).surface, Surface::Kitty);
+        assert_eq!(choose(Choice::Auto, false, false).surface, Surface::Glyphs);
+    }
+
+    #[test]
+    fn an_explicit_request_is_honoured_even_where_auto_would_decline() {
+        // It is the user's terminal and they can see the result. A terminal that
+        // draws images without answering the query is reachable this way.
+        assert_eq!(choose(Choice::Kitty, false, false).surface, Surface::Kitty);
+        assert_eq!(choose(Choice::Kitty, true, false).surface, Surface::Kitty);
+        assert_eq!(choose(Choice::Glyphs, false, true).surface, Surface::Glyphs);
+    }
+
+    #[test]
+    fn a_partial_reply_is_waited_out_rather_than_read_as_refusal() {
+        // A reply split across two reads is ordinary. Calling the first half a
+        // refusal would decline terminals that do support this.
+        assert_eq!(answered(b"\x1b_Gi=31;O"), None, "still arriving");
+        assert_eq!(answered(b""), None, "nothing yet");
+        assert_eq!(answered(b"\x1b_Gi=31;OK\x1b\\"), Some(true));
+        assert_eq!(answered(b"\x1b_Gi=31;ENOTSUPPORTED\x1b\\"), Some(false));
+    }
+
+    #[test]
+    fn a_glyph_grid_cannot_layer_and_a_pixel_surface_can() {
+        // The measured behaviour behind #65 and the kitty occlusion result,
+        // carried into what each surface reports it can do.
+        let grid = Surface::Glyphs.capabilities(Cells(80), Cells(24));
+        let pixels = Surface::Kitty.capabilities(Cells(80), Cells(24));
+        assert!(!grid.layers);
+        assert!(pixels.layers);
+        assert!(pixels.shades > grid.shades, "sub-cell resolution");
+        assert_eq!(pixels.columns, grid.columns, "the same extent either way");
+    }
+
+    #[test]
+    fn every_spelling_a_user_might_type_is_understood() {
+        assert_eq!(Choice::parse("auto"), Some(Choice::Auto));
+        assert_eq!(Choice::parse("kitty"), Some(Choice::Kitty));
+        assert_eq!(Choice::parse("pixels"), Some(Choice::Kitty));
+        assert_eq!(Choice::parse("gui"), Some(Choice::Window));
+        assert_eq!(Choice::parse("sixel"), None, "deliberately not offered");
+    }
+}

--- a/src/surface/mod.rs
+++ b/src/surface/mod.rs
@@ -12,11 +12,13 @@ use std::io::{Read, Write};
 use std::os::fd::AsRawFd;
 use std::time::{Duration, Instant};
 
-/// How long to wait for a terminal to answer the capability query.
+/// How long to wait before giving up on a terminal that answers nothing at all.
 ///
-/// The same budget the palette query allows, for the same reason: a terminal
-/// that does not implement this says nothing at all, so the deadline is the only
-/// thing that ends the wait.
+/// A backstop, not the mechanism. The graphics query is chained with a device
+/// attributes request that every terminal answers, so the usual "no" arrives in
+/// a millisecond rather than by running this out. Reaching it means the terminal
+/// ignored *both* questions, which is rare enough that a stall is the right
+/// price for not guessing.
 const PROBE_TIMEOUT: Duration = Duration::from_millis(120);
 
 /// Where a frame is drawn.
@@ -109,10 +111,10 @@ impl Chosen {
 /// - the probe needs one and this does not.
 ///
 /// `answers` is a closure rather than a `bool` so the arms that ignore it never
-/// ask. That is not a micro-optimisation: asking writes escape sequences and
-/// reads stdin, and costs [`PROBE_TIMEOUT`] against a terminal that will never
-/// reply. Passing a `bool` would make every startup pay for an answer three of
-/// the five arms discard.
+/// ask. That is not a micro-optimisation: asking writes escape sequences to the
+/// terminal and swallows what comes back off stdin, so it is a thing that
+/// happens rather than a value that is read. Passing a `bool` would do it on
+/// every startup for an answer three of the five arms discard.
 pub fn choose(asked: Choice, multiplexed: bool, answers: impl FnOnce() -> bool) -> Chosen {
     let glyphs = |because| Chosen {
         surface: Surface::Glyphs,
@@ -187,8 +189,15 @@ pub fn probe() -> bool {
 fn probe_via<W: Write, R: Read + AsRawFd>(out: &mut W, input: &mut R) -> bool {
     // One opaque pixel, transmitted and queried rather than displayed: `a=q`
     // asks whether the terminal *could* take it and draws nothing either way.
+    //
+    // Chained with a device attributes request in the same write, because a
+    // terminal that does not implement graphics answers the first question with
+    // silence and there is nothing to wait for. Terminals answer queries in the
+    // order they arrive, so a `CSI c` reply with no graphics reply ahead of it
+    // is a definite no, available immediately.
     let pixel = "AAAA"; // three zero bytes, base64
-    if write!(out, "\x1b_Gi=31,s=1,v=1,a=q,t=d,f=24;{pixel}\x1b\\").is_err() || out.flush().is_err()
+    if write!(out, "\x1b_Gi=31,s=1,v=1,a=q,t=d,f=24;{pixel}\x1b\\\x1b[c").is_err()
+        || out.flush().is_err()
     {
         return false;
     }
@@ -220,13 +229,28 @@ fn probe_via<W: Write, R: Read + AsRawFd>(out: &mut W, input: &mut R) -> bool {
 /// this.
 pub fn answered(bytes: &[u8]) -> Option<bool> {
     let text = String::from_utf8_lossy(bytes);
-    let reply = text.split("\x1b_G").nth(1)?;
-    // The terminator has to have arrived, or the payload may still be growing.
-    let body = reply.split("\x1b\\").next()?;
-    if !reply.contains("\x1b\\") {
-        return None;
+    if let Some(reply) = text.split("\x1b_G").nth(1) {
+        // The terminator has to have arrived, or the payload may still be
+        // growing - and a graphics reply outranks whatever follows it.
+        return reply
+            .split_once("\x1b\\")
+            .map(|(body, _)| body.contains(";OK"));
     }
-    Some(body.contains(";OK"))
+    // No graphics reply, but the terminal has answered the question chained
+    // behind it - so it read the first one, understood it well enough to ignore
+    // it, and moved on. That is the answer.
+    device_attributes(&text).then_some(false)
+}
+
+/// Whether a Primary Device Attributes reply - `CSI ? … c` - has arrived.
+///
+/// The parameters are digits and semicolons and say which VT the terminal claims
+/// to be, which rav does not care about. What matters is that one arrived.
+fn device_attributes(text: &str) -> bool {
+    text.split("\x1b[?").skip(1).any(|rest| {
+        rest.split_once('c')
+            .is_some_and(|(params, _)| params.bytes().all(|b| b.is_ascii_digit() || b == b';'))
+    })
 }
 
 #[cfg(test)]
@@ -257,6 +281,39 @@ mod tests {
             asked.set(true);
             yes
         }
+    }
+
+    /// Run the probe against a socket playing the part of a terminal that has
+    /// already replied `reply`, and report the verdict and how long it took.
+    ///
+    /// A socket rather than a pty because `probe_via` only needs something
+    /// readable with a descriptor to poll, which is all a terminal is to it. The
+    /// reply is waiting before the query goes out, which a real terminal cannot
+    /// do - the point here is what happens once bytes arrive, not the round trip.
+    fn against_a_terminal_saying(reply: &[u8]) -> (bool, Duration) {
+        use std::os::unix::net::UnixStream;
+        let (mut terminal, mut rav) = UnixStream::pair().unwrap();
+        terminal.write_all(reply).unwrap();
+        terminal.flush().unwrap();
+        let mut sink = Vec::new();
+        let start = Instant::now();
+        let verdict = probe_via(&mut sink, &mut rav);
+        (verdict, start.elapsed())
+    }
+
+    #[test]
+    fn a_terminal_without_graphics_is_taken_at_its_word_immediately() {
+        // The one path every user of Terminal.app, Alacritty and xterm takes. A
+        // graphics query alone is answered with silence there, so believing
+        // silence would put the whole timeout on the common case - a visible
+        // stall at startup, shipped under a change that draws nothing.
+        let (verdict, took) = against_a_terminal_saying(b"\x1b[?62;1;6c");
+        assert!(!verdict, "it declined");
+        assert!(took < PROBE_TIMEOUT / 4, "waited it out instead: {took:?}");
+
+        let (verdict, took) = against_a_terminal_saying(b"\x1b_Gi=31;OK\x1b\\\x1b[?62c");
+        assert!(verdict, "it accepted");
+        assert!(took < PROBE_TIMEOUT / 4, "waited it out instead: {took:?}");
     }
 
     #[test]
@@ -325,6 +382,32 @@ mod tests {
         assert_eq!(answered(b""), None, "nothing yet");
         assert_eq!(answered(b"\x1b_Gi=31;OK\x1b\\"), Some(true));
         assert_eq!(answered(b"\x1b_Gi=31;ENOTSUPPORTED\x1b\\"), Some(false));
+    }
+
+    #[test]
+    fn the_no_arrives_rather_than_being_waited_out() {
+        // The whole reason the graphics query is chained with `CSI c`. Silence
+        // is what a terminal without graphics says, so waiting for it would put
+        // the full timeout on the one path every user of every other terminal
+        // takes - a startup stall on Terminal.app, Alacritty and xterm.
+        assert_eq!(
+            answered(b"\x1b[?62;1;6c"),
+            Some(false),
+            "answered, not mute"
+        );
+        assert_eq!(answered(b"\x1b[?6c"), Some(false), "a short one counts");
+
+        // Order settles it: terminals answer queries as they arrive, so a
+        // graphics reply is always ahead of the attributes reply behind it.
+        assert_eq!(answered(b"\x1b_Gi=31;OK\x1b\\\x1b[?62c"), Some(true));
+
+        // Half an attributes reply is not one, or a terminal that is mid-word
+        // gets read as a refusal it has not made.
+        assert_eq!(answered(b"\x1b[?62;1"), None, "no final byte yet");
+        assert_eq!(answered(b"\x1b[?"), None);
+        // Not every CSI is this one - a mouse or bracketed-paste report shares
+        // the prefix and says nothing about graphics.
+        assert_eq!(answered(b"\x1b[?1000;1006$y"), None, "a different report");
     }
 
     #[test]

--- a/src/surface/mod.rs
+++ b/src/surface/mod.rs
@@ -162,7 +162,7 @@ pub fn multiplexed() -> bool {
 /// Ask the terminal whether it speaks the kitty graphics protocol.
 ///
 /// Must run before the alternate screen is entered and while nothing else is
-/// reading stdin. Costs one round trip, bounded by [`PROBE_TIMEOUT`].
+/// reading stdin. Costs one round trip, bounded by `PROBE_TIMEOUT`.
 ///
 /// **No test reaches this body** - it needs a pty, so the raw-mode handling and
 /// its restore are exercised by running rav and by nothing else. [`answered`] is

--- a/src/surface/mod.rs
+++ b/src/surface/mod.rs
@@ -90,13 +90,30 @@ pub struct Chosen {
     pub because: &'static str,
 }
 
+impl Chosen {
+    /// What to hold before anything has been decided.
+    ///
+    /// Glyphs, because they work everywhere - which is what makes them the
+    /// answer when there is no answer.
+    pub const UNASKED: Self = Self {
+        surface: Surface::Glyphs,
+        because: "nothing asked",
+    };
+}
+
 /// Decide which surface to draw on.
 ///
 /// `asked` is what the user typed; `multiplexed` is whether rav is running under
-/// tmux or screen; `answers` is whether the terminal admitted to the kitty
-/// protocol. Split from the probe so the decision is testable without a
-/// terminal - the probe needs one and this does not.
-pub fn choose(asked: Choice, multiplexed: bool, answers: bool) -> Chosen {
+/// tmux or screen; `answers` asks the terminal whether it admits to the kitty
+/// protocol. Split from the probe so the decision is testable without a terminal
+/// - the probe needs one and this does not.
+///
+/// `answers` is a closure rather than a `bool` so the arms that ignore it never
+/// ask. That is not a micro-optimisation: asking writes escape sequences and
+/// reads stdin, and costs [`PROBE_TIMEOUT`] against a terminal that will never
+/// reply. Passing a `bool` would make every startup pay for an answer three of
+/// the five arms discard.
+pub fn choose(asked: Choice, multiplexed: bool, answers: impl FnOnce() -> bool) -> Chosen {
     let glyphs = |because| Chosen {
         surface: Surface::Glyphs,
         because,
@@ -118,12 +135,19 @@ pub fn choose(asked: Choice, multiplexed: bool, answers: bool) -> Chosen {
         // passes through. Image escapes do not survive that intact, and the
         // failure is a garbled screen rather than a missing picture - so auto
         // never picks pixels there, however the terminal answers.
-        Choice::Auto if multiplexed => glyphs("running under a multiplexer"),
-        Choice::Auto if answers => Chosen {
-            surface: Surface::Kitty,
-            because: "the terminal answered the graphics query",
-        },
-        Choice::Auto => glyphs("the terminal did not answer the graphics query"),
+        Choice::Auto if multiplexed => glyphs("under a multiplexer"),
+        // Not a guard, because calling `answers` consumes it and a match guard
+        // only gets a borrow.
+        Choice::Auto => {
+            if answers() {
+                Chosen {
+                    surface: Surface::Kitty,
+                    because: "the terminal answered",
+                }
+            } else {
+                glyphs("the terminal said nothing")
+            }
+        }
     }
 }
 
@@ -227,29 +251,70 @@ mod tests {
         assert!(!sink.is_empty(), "it should still have asked");
     }
 
+    /// Say `yes`, and record whether anyone asked.
+    fn asking(asked: &std::cell::Cell<bool>, yes: bool) -> impl FnOnce() -> bool + '_ {
+        move || {
+            asked.set(true);
+            yes
+        }
+    }
+
     #[test]
     fn a_multiplexer_declines_pixels_however_the_terminal_answers() {
         // tmux and screen rewrite what passes through, and an image escape does
         // not survive that intact. The failure is a garbled screen rather than a
         // missing picture, which is worse than not trying.
-        let under_tmux = choose(Choice::Auto, true, true);
+        let under_tmux = choose(Choice::Auto, true, || true);
         assert_eq!(under_tmux.surface, Surface::Glyphs);
-        assert_eq!(under_tmux.because, "running under a multiplexer");
+        assert_eq!(under_tmux.because, "under a multiplexer");
     }
 
     #[test]
     fn auto_follows_the_terminals_answer() {
-        assert_eq!(choose(Choice::Auto, false, true).surface, Surface::Kitty);
-        assert_eq!(choose(Choice::Auto, false, false).surface, Surface::Glyphs);
+        assert_eq!(choose(Choice::Auto, false, || true).surface, Surface::Kitty);
+        assert_eq!(
+            choose(Choice::Auto, false, || false).surface,
+            Surface::Glyphs
+        );
     }
 
     #[test]
     fn an_explicit_request_is_honoured_even_where_auto_would_decline() {
         // It is the user's terminal and they can see the result. A terminal that
         // draws images without answering the query is reachable this way.
-        assert_eq!(choose(Choice::Kitty, false, false).surface, Surface::Kitty);
-        assert_eq!(choose(Choice::Kitty, true, false).surface, Surface::Kitty);
-        assert_eq!(choose(Choice::Glyphs, false, true).surface, Surface::Glyphs);
+        assert_eq!(
+            choose(Choice::Kitty, false, || false).surface,
+            Surface::Kitty
+        );
+        assert_eq!(
+            choose(Choice::Kitty, true, || false).surface,
+            Surface::Kitty
+        );
+        assert_eq!(
+            choose(Choice::Glyphs, false, || true).surface,
+            Surface::Glyphs
+        );
+    }
+
+    #[test]
+    fn the_terminal_is_only_asked_when_the_answer_could_change_the_outcome() {
+        // Asking is not free and not invisible: it writes escape sequences,
+        // reads stdin, and waits out the timeout against a terminal that will
+        // never reply. Every arm that ignores the answer must cost nothing.
+        for (asked, multiplexed) in [
+            (Choice::Glyphs, false),
+            (Choice::Kitty, false),
+            (Choice::Window, false),
+            (Choice::Auto, true),
+        ] {
+            let probed = std::cell::Cell::new(false);
+            choose(asked, multiplexed, asking(&probed, true));
+            assert!(!probed.get(), "{asked:?} asked and did not need to");
+        }
+
+        let probed = std::cell::Cell::new(false);
+        choose(Choice::Auto, false, asking(&probed, true));
+        assert!(probed.get(), "auto has nothing else to go on");
     }
 
     #[test]

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -15,6 +15,7 @@ use crate::{
         },
         spectrum::{MAX_HEIGHT, Spectrum},
     },
+    surface::Chosen,
     units::{Curve, Level},
     visual::{Palette, Theme},
 };
@@ -199,6 +200,13 @@ pub struct App {
     /// Size the cached mapping and colours were built for.
     sized_for: (u16, u16),
 
+    /// Which surface rav would draw on, and why.
+    ///
+    /// Reported, not obeyed - the glyph renderer draws every frame whatever this
+    /// says. It is here so the choice is visible in the help overlay for a beta
+    /// before anything depends on it being right.
+    surface: Chosen,
+
     visualisation: Visualisation,
     scope_style: ScopeStyle,
     peaks: Peaks,
@@ -273,6 +281,7 @@ impl App {
             palette: Palette::default(),
             layout: BarLayout::default(),
             sized_for: (0, 0),
+            surface: Chosen::UNASKED,
             visualisation: Visualisation::default(),
             scope_style: ScopeStyle::default(),
             peaks: Peaks::default(),
@@ -306,6 +315,15 @@ impl App {
         }
         self.theme = theme;
         self.sized_for = (0, 0);
+    }
+
+    /// Record which surface was chosen, for the help overlay to report.
+    ///
+    /// Nothing downstream reads it yet. Deciding is separate from drawing so the
+    /// probe that makes the decision can be in users' hands - and shown to be
+    /// harmless - a beta before the renderer that would act on it.
+    pub fn set_surface(&mut self, chosen: Chosen) {
+        self.surface = chosen;
     }
 
     /// Append a capture buffer to the rolling window, de-interleaving to mono.
@@ -573,6 +591,18 @@ impl App {
                 key: "q",
                 description: "quit",
                 value: None,
+            },
+            // No key, because there is none: `--surface` is a flag. "Would"
+            // rather than "does" is the literal truth for this beta - the glyph
+            // renderer draws the frame you are looking at whatever this says.
+            HelpRow {
+                key: "",
+                description: "would draw on",
+                value: Some(format!(
+                    "{} ({})",
+                    self.surface.surface.label(),
+                    self.surface.because
+                )),
             },
         ]
     }
@@ -1184,6 +1214,25 @@ mod tests {
 
         a.apply(Action::ToggleHelp);
         assert!(!a.show_help);
+    }
+
+    #[test]
+    fn the_overlay_reports_the_surface_and_why() {
+        // The one place a user can see what the startup probe concluded. Without
+        // the reason it is unarguable: "glyphs" alone does not say whether the
+        // terminal was asked and declined or never asked.
+        let mut a = app();
+        a.set_surface(crate::surface::choose(
+            crate::surface::Choice::Auto,
+            true,
+            || true,
+        ));
+        let readout = a
+            .help_rows()
+            .into_iter()
+            .find(|r| r.description == "would draw on")
+            .and_then(|r| r.value);
+        assert_eq!(readout, Some("glyphs (under a multiplexer)".to_string()));
     }
 
     #[test]

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -1232,7 +1232,10 @@ mod tests {
             .into_iter()
             .find(|r| r.description == "would draw on")
             .and_then(|r| r.value);
-        assert_eq!(readout, Some("glyphs (under a multiplexer)".to_string()));
+        assert_eq!(
+            readout,
+            Some("glyphs (tmux or screen is in the way)".to_string())
+        );
     }
 
     #[test]

--- a/src/visual/palette.rs
+++ b/src/visual/palette.rs
@@ -101,7 +101,7 @@ fn query_via<W: Write, R: Read + AsRawFd>(out: &mut W, input: &mut R) -> Palette
     }
     palette
 }
-fn readable(fd: i32, within: Duration) -> bool {
+pub(crate) fn readable(fd: i32, within: Duration) -> bool {
     let mut poll = libc::pollfd {
         fd,
         events: libc::POLLIN,


### PR DESCRIPTION
rav now asks your terminal whether it can draw images, and tells you the answer. Press `h` and the panel says which surface it would use and why:

```
would draw on    glyphs (your terminal cannot draw images)
```

**Nothing about the picture changes.** Block characters draw every frame exactly as before, whatever the answer is. `--surface auto|glyphs|kitty|window` says what you want; today it only changes what rav reports.

That is the point of sending it out on its own. The question rav asks your terminal is the risky part — a startup probe that hangs, or that leaks escape codes onto the screen, is the worst thing in this area, and here its only possible symptom is a wrong label.

The question is asked in a way that costs nothing when the answer is no. A terminal without image support answers a graphics query with silence, so waiting for it would put a 120ms stall on the common path — Terminal.app, Alacritty, xterm. A device-attributes request goes out in the same write, terminals answer in order, so a reply with no graphics answer ahead of it is a definite no, arriving in about a millisecond. The timeout survives only as a backstop for a terminal that ignores both questions.

Under tmux or screen, auto stays on block characters however the terminal answers. A multiplexer rewrites what passes through, and a garbled screen is worse than a missing picture.
