### PR TITLE
fix: rav says why it will not start, and survives a crash

### DIFF
--- a/src/audio/mod.rs
+++ b/src/audio/mod.rs
@@ -224,7 +224,17 @@ impl AudioCapture {
             return Ok(device.clone());
         }
 
-        Err(anyhow::anyhow!("Audio device '{}' not found", name))
+        // Naming what is there rather than only what is not: the names carry
+        // punctuation and capitals nobody guesses, and a partial one matches, so
+        // the list is usually the whole answer.
+        Err(anyhow::anyhow!(
+            "no capture device matching '{name}'. rav can see: {}",
+            devices
+                .iter()
+                .map(|(_, n)| n.as_str())
+                .collect::<Vec<_>>()
+                .join(", ")
+        ))
     }
 
     fn find_monitor_device(host: &Host) -> Result<Device> {

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -5,17 +5,23 @@
 //! peaks, frequency range, gain - is a runtime key, and the colours come from a
 //! theme file, so none of it belongs here.
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
 use std::path::Path;
 
+/// Everything here has a default, so a file may say only what it wants to
+/// change. Requiring the whole shape means someone who writes three lines to
+/// slow the redraw is told their file is missing a section they had no reason
+/// to know about, and rav does not start.
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(default)]
 pub struct Config {
     pub audio: AudioConfig,
     pub display: DisplayConfig,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(default)]
 pub struct AudioConfig {
     /// Requested capture rate. The device may renegotiate it; whatever it lands
     /// on is what the analysis chain uses.
@@ -25,9 +31,22 @@ pub struct AudioConfig {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(default)]
 pub struct DisplayConfig {
     /// Redraw rate, clamped to 1..=240 at use.
     pub refresh_rate: u32,
+}
+
+impl Default for AudioConfig {
+    fn default() -> Self {
+        Config::default().audio
+    }
+}
+
+impl Default for DisplayConfig {
+    fn default() -> Self {
+        Config::default().display
+    }
 }
 
 impl Default for Config {
@@ -45,9 +64,7 @@ impl Default for Config {
 impl Config {
     pub async fn load(config_path: Option<&Path>) -> Result<Self> {
         if let Some(path) = config_path {
-            // Load from specified path
-            let content = tokio::fs::read_to_string(path).await?;
-            return Ok(toml::from_str(&content)?);
+            return Self::read(path).await;
         }
 
         let Some(config_dir) = dirs::config_dir() else {
@@ -56,14 +73,23 @@ impl Config {
 
         let default_path = config_dir.join("rav").join("config.toml");
         if default_path.exists() {
-            let content = tokio::fs::read_to_string(&default_path).await?;
-            Ok(toml::from_str(&content)?)
+            Self::read(&default_path).await
         } else {
             // Write the defaults out, so the file exists to be edited.
             let config = Self::default();
             config.save_to_default_location().await?;
             Ok(config)
         }
+    }
+
+    /// Read one config file, naming it in whatever goes wrong. "No such file or
+    /// directory" on its own leaves the user to guess which path rav tried.
+    async fn read(path: &Path) -> Result<Self> {
+        let content = tokio::fs::read_to_string(path)
+            .await
+            .with_context(|| format!("cannot read {}", path.display()))?;
+        toml::from_str(&content)
+            .with_context(|| format!("{} is not a valid config", path.display()))
     }
 
     pub async fn save_to_default_location(&self) -> Result<()> {
@@ -100,6 +126,41 @@ mod tests {
         let config: Config = toml::from_str(text).expect("should parse");
         assert_eq!(config.audio.sample_rate, 48_000);
         assert_eq!(config.display.refresh_rate, 30);
+    }
+
+    #[test]
+    fn a_file_may_say_only_what_it_wants_to_change() {
+        // Three lines to slow the redraw is a reasonable thing to write. Being
+        // told the file is missing a section you had no reason to know about,
+        // and rav not starting, is not a reasonable thing to be told.
+        let only_display: Config = toml::from_str("[display]\nrefresh_rate = 30\n")
+            .expect("a file that sets one thing must load");
+        assert_eq!(only_display.display.refresh_rate, 30);
+        assert_eq!(
+            only_display.audio.sample_rate,
+            Config::default().audio.sample_rate,
+            "the section it did not mention lost its default",
+        );
+
+        let only_rate: Config =
+            toml::from_str("[audio]\nsample_rate = 48000\n").expect("half a section must load");
+        assert_eq!(only_rate.audio.sample_rate, 48_000);
+        assert_eq!(
+            only_rate.audio.buffer_size,
+            Config::default().audio.buffer_size,
+        );
+
+        assert!(
+            toml::from_str::<Config>("").is_ok(),
+            "an empty file is a file that changes nothing",
+        );
+    }
+
+    #[test]
+    fn a_setting_of_the_wrong_shape_is_still_refused() {
+        // Defaults fill in what is absent, not what is wrong. A number written
+        // as a word is a mistake worth being told about.
+        assert!(toml::from_str::<Config>("[audio]\nsample_rate = \"loud\"\n").is_err());
     }
 
     #[test]

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -13,7 +13,7 @@ use std::path::Path;
 /// change. Requiring the whole shape means someone who writes three lines to
 /// slow the redraw is told their file is missing a section they had no reason
 /// to know about, and rav does not start.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(default)]
 pub struct Config {
     pub audio: AudioConfig,
@@ -39,25 +39,16 @@ pub struct DisplayConfig {
 
 impl Default for AudioConfig {
     fn default() -> Self {
-        Config::default().audio
+        Self {
+            sample_rate: 44100,
+            buffer_size: 1024,
+        }
     }
 }
 
 impl Default for DisplayConfig {
     fn default() -> Self {
-        Config::default().display
-    }
-}
-
-impl Default for Config {
-    fn default() -> Self {
-        Self {
-            audio: AudioConfig {
-                sample_rate: 44100,
-                buffer_size: 1024,
-            },
-            display: DisplayConfig { refresh_rate: 60 },
-        }
+        Self { refresh_rate: 60 }
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -42,7 +42,22 @@ struct Args {
 }
 
 #[tokio::main]
-async fn main() -> Result<()> {
+async fn main() -> std::process::ExitCode {
+    match rav_main().await {
+        Ok(()) => std::process::ExitCode::SUCCESS,
+        Err(problem) => {
+            // To stdout, deliberately. Everything rav can fail at happens after
+            // stderr has been pointed at the log file, so reporting the usual
+            // way means a mistyped `--theme` looks like rav dying in silence:
+            // exit 1, a blank terminal, and the reason in a file the user has
+            // no reason to look in.
+            println!("rav: {problem:#}");
+            std::process::ExitCode::FAILURE
+        }
+    }
+}
+
+async fn rav_main() -> Result<()> {
     let args = Args::parse();
 
     // Initialize logging with clean mode support

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -588,11 +588,7 @@ impl App {
 
     pub async fn run(&mut self, audio_receiver: Receiver<AudioData>) -> Result<()> {
         #[cfg(not(test))]
-        {
-            enable_raw_mode()?;
-            io::stdout().execute(EnterAlternateScreen)?;
-            guard_the_terminal();
-        }
+        let _terminal = TerminalGuard::take_the_terminal()?;
         self.terminal.clear()?;
         info!("🎨 Starting analyser");
 
@@ -859,8 +855,6 @@ impl App {
             })?;
         }
 
-        #[cfg(not(test))]
-        hand_the_terminal_back();
         info!("👋 Analyser shut down");
         Ok(())
     }
@@ -885,25 +879,66 @@ fn hand_the_terminal_back() {
     let _ = io::stdout().execute(crossterm::cursor::Show);
 }
 
-/// Make sure a panic hands the terminal back too.
-///
-/// Without this a panic leaves the user on the alternate screen in raw mode:
-/// no echo, no line editing, and a backtrace they cannot see. The way out is to
-/// type `reset` blind.
-///
-/// The previous hook still runs, so the panic still reports itself - and it
-/// reports to `rav.log`, since `main` points stderr there before anything
-/// touches the terminal.
-///
-/// `panic = "abort"` in the release profile does not skip this: hooks run
-/// before the abort.
 #[cfg(not(test))]
-fn guard_the_terminal() {
-    let previous = std::panic::take_hook();
-    std::panic::set_hook(Box::new(move |panicked| {
+type PanicHook = Box<dyn Fn(&std::panic::PanicHookInfo<'_>) + Sync + Send + 'static>;
+
+/// Holds the terminal for as long as rav is drawing on it.
+///
+/// Every way out has to hand it back: returning normally, returning an error
+/// through `?`, and panicking. Drop covers the first two. The panic hook covers
+/// the third, because `panic = "abort"` in the release build never unwinds and
+/// so never drops anything - and without it a panic leaves the user on the
+/// alternate screen in raw mode, with no echo, no line editing, and a backtrace
+/// they cannot see.
+///
+/// The hook rav replaces still runs, so a panic still reports itself, into
+/// `rav.log` where `main` points stderr before anything touches the terminal.
+#[cfg(not(test))]
+struct TerminalGuard {
+    replaced_hook: Option<std::sync::Arc<PanicHook>>,
+}
+
+#[cfg(not(test))]
+impl TerminalGuard {
+    fn take_the_terminal() -> Result<Self> {
+        enable_raw_mode()?;
+        io::stdout().execute(EnterAlternateScreen)?;
+
+        let replaced = std::sync::Arc::new(std::panic::take_hook());
+        let on_panic = std::sync::Arc::clone(&replaced);
+        std::panic::set_hook(Box::new(move |panicked| {
+            hand_the_terminal_back();
+            (*on_panic)(panicked);
+        }));
+        Ok(Self {
+            replaced_hook: Some(replaced),
+        })
+    }
+}
+
+#[cfg(not(test))]
+impl Drop for TerminalGuard {
+    fn drop(&mut self) {
         hand_the_terminal_back();
-        previous(panicked);
-    }));
+
+        // `take_hook` and `set_hook` panic when called from a panicking thread,
+        // and a second panic during an unwind aborts. The hook has already done
+        // this work by the time an unwind reaches here, and the process is on
+        // its way out regardless.
+        if std::thread::panicking() {
+            return;
+        }
+
+        // The hook is process-wide, so leaving rav's in place would have a
+        // later panic restore a terminal nobody is holding - and a second run
+        // would stack another on top.
+        let _ = std::panic::take_hook();
+        if let Some(replaced) = self.replaced_hook.take()
+            && let Ok(hook) = std::sync::Arc::try_unwrap(replaced)
+        {
+            std::panic::set_hook(hook);
+        }
+    }
 }
 
 /// Terminal events, on a channel the render loop can wait on.

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -591,6 +591,7 @@ impl App {
         {
             enable_raw_mode()?;
             io::stdout().execute(EnterAlternateScreen)?;
+            guard_the_terminal();
         }
         self.terminal.clear()?;
         info!("🎨 Starting analyser");
@@ -859,11 +860,7 @@ impl App {
         }
 
         #[cfg(not(test))]
-        {
-            disable_raw_mode()?;
-            io::stdout().execute(LeaveAlternateScreen)?;
-            self.terminal.show_cursor()?;
-        }
+        hand_the_terminal_back();
         info!("👋 Analyser shut down");
         Ok(())
     }
@@ -876,6 +873,38 @@ impl App {
 /// that dies outright leaves the bars resting on the floor rather than frozen
 /// part-way down.
 const WATCHDOG: Duration = Duration::from_millis(250);
+
+/// Put the terminal back the way it was found.
+///
+/// Raw mode off, off the alternate screen, cursor visible. The one place that
+/// knows what setting rav up did, so the way out cannot drift from the way in.
+#[cfg(not(test))]
+fn hand_the_terminal_back() {
+    let _ = disable_raw_mode();
+    let _ = io::stdout().execute(LeaveAlternateScreen);
+    let _ = io::stdout().execute(crossterm::cursor::Show);
+}
+
+/// Make sure a panic hands the terminal back too.
+///
+/// Without this a panic leaves the user on the alternate screen in raw mode:
+/// no echo, no line editing, and a backtrace they cannot see. The way out is to
+/// type `reset` blind.
+///
+/// The previous hook still runs, so the panic still reports itself - and it
+/// reports to `rav.log`, since `main` points stderr there before anything
+/// touches the terminal.
+///
+/// `panic = "abort"` in the release profile does not skip this: hooks run
+/// before the abort.
+#[cfg(not(test))]
+fn guard_the_terminal() {
+    let previous = std::panic::take_hook();
+    std::panic::set_hook(Box::new(move |panicked| {
+        hand_the_terminal_back();
+        previous(panicked);
+    }));
+}
 
 /// Terminal events, on a channel the render loop can wait on.
 ///


### PR DESCRIPTION
Three things that could happen on a first run, none of which told you anything.

**A typo in a flag looked like rav dying in silence.** `rav --theme puce` gave you an exit code and a blank terminal. The reason was written down — but into `rav.log`, because stderr is pointed at the log before anything loads so ALSA cannot scribble device names across the display while it enumerates your inputs. Startup failures now reach the terminal, and name the file or the device they are about:

```
rav: no theme 'puce': not built in, and no such file
rav: cannot read ~/.config/rav/config.toml: No such file or directory (os error 2)
rav: ~/.config/rav/config.toml is not a valid config: invalid type: string "loud", expected u32
rav: no capture device matching 'Blackhole'. rav can see: Background Music, MacBook Pro Microphone
```

That last one is the flag most likely to be mistyped, since device names carry punctuation and capitals nobody guesses. A partial name matches, so seeing the list is usually the whole answer — better than being told to go and run another command for it.

**A config file had to be complete or rav refused to start.** Three lines to slow the redraw down is a reasonable thing to write; being told the file is missing an `[audio]` section you had no reason to know about is not. What you leave out now takes its default. What you get wrong is still refused — a sample rate written as a word is a mistake worth hearing about.

**A crash left your terminal unusable.** rav takes over the screen and turns off echo and line editing while it runs, and only handed them back on the ordinary way out. Anything that panicked skipped it: you were left on the alternate screen with a dead keyboard, typing `reset` blind to get a prompt back. A guard now holds the terminal for the length of the run, so every way out hands it back — returning normally, returning an error through `?`, and panicking. `panic = "abort"` in the release build does not skip it, since hooks run before the abort.

Recorded through a terminal on each path: a panic exits 101 and an error exits 1, both showing the screen restored and the cursor back before anything is printed. An ordinary session still measures 60 frames from 98 wakes, unchanged.

Nothing about the picture changes.
