### PR TITLE
feat(core): a cap's fall is arithmetic an LED strip can reach

### DIFF
--- a/crates/rav-core/src/lib.rs
+++ b/crates/rav-core/src/lib.rs
@@ -46,5 +46,5 @@ pub mod units;
 pub use capability::{Capabilities, Requirements, Shortfall};
 pub use geometry::{Anchor, BarLayout, Column, Rectangle, Screen};
 pub use units::{
-    Bounded, CellSize, Cells, Curve, Elapsed, Fill, Hz, Length, Level, SampleRate, Step,
+    Bounded, CellSize, Cells, Curve, Elapsed, Fill, Frames, Hz, Length, Level, SampleRate, Step,
 };

--- a/crates/rav-core/src/math.rs
+++ b/crates/rav-core/src/math.rs
@@ -38,9 +38,73 @@ pub fn powf(value: f32, exponent: f32) -> f32 {
     libm::powf(value, exponent)
 }
 
+/// How far something travels when its speed is multiplied by `growth` every
+/// frame, in units of the speed it started at.
+///
+/// A peak cap does not fall at a steady rate. Its velocity compounds, so the
+/// distance it covers is the sum of a geometric series and not speed times
+/// frames. Writing it the obvious way gives motion that is nearly right at the
+/// rate it was tuned against and visibly wrong at any other, which is the kind
+/// of mistake that survives being looked at.
+///
+/// `growth` of 1 is a steady speed, where the series degenerates to the frame
+/// count - handled directly, because the closed form divides by zero there.
+///
+/// ```
+/// use rav_core::{math::compounded_travel, Frames};
+/// // Steady speed for ten frames covers ten frames' worth of ground.
+/// assert!((compounded_travel(1.0, Frames::count(10.0)) - 10.0).abs() < 1e-4);
+/// // Speed doubling each frame covers 1 + 2 + 4 + 8 over four.
+/// assert!((compounded_travel(2.0, Frames::count(4.0)) - 15.0).abs() < 1e-4);
+/// ```
+pub fn compounded_travel(growth: f32, frames: crate::units::Frames) -> f32 {
+    let frames = frames.get();
+    if (growth - 1.0).abs() < f32::EPSILON {
+        return frames;
+    }
+    (powf(growth, frames) - 1.0) / (growth - 1.0)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::units::Frames;
+
+    #[test]
+    fn a_compounding_speed_covers_the_sum_of_the_series() {
+        // The whole reason this is not speed times frames.
+        assert!((compounded_travel(2.0, Frames::count(1.0)) - 1.0).abs() < 1e-4);
+        assert!((compounded_travel(2.0, Frames::count(3.0)) - 7.0).abs() < 1e-4);
+        assert!((compounded_travel(3.0, Frames::count(3.0)) - 13.0).abs() < 1e-4);
+        assert_eq!(compounded_travel(2.0, Frames::NONE), 0.0);
+    }
+
+    #[test]
+    fn a_steady_speed_is_just_the_frame_count() {
+        // The closed form divides by zero at a growth of one, and a rate that
+        // does not compound is a perfectly ordinary thing to ask for.
+        for frames in [0.0f32, 1.0, 7.5, 240.0] {
+            assert_eq!(compounded_travel(1.0, Frames::count(frames)), frames);
+        }
+    }
+
+    #[test]
+    fn cutting_the_frames_finer_covers_the_same_ground() {
+        // What makes a rate written per-frame survive a different display. Ten
+        // frames in one step and ten frames in twenty must arrive together, or
+        // the same music falls at different speeds on different machines.
+        let whole = compounded_travel(1.1, Frames::count(10.0));
+        let mut piecewise = 0.0;
+        let mut speed = 1.0f32;
+        for _ in 0..20 {
+            piecewise += speed * compounded_travel(1.1, Frames::count(0.5));
+            speed *= powf(1.1, 0.5);
+        }
+        assert!(
+            (whole - piecewise).abs() < 1e-3,
+            "{whole} in one step, {piecewise} in twenty",
+        );
+    }
 
     #[test]
     fn these_agree_with_the_std_methods_they_stand_in_for() {

--- a/crates/rav-core/src/units.rs
+++ b/crates/rav-core/src/units.rs
@@ -496,6 +496,43 @@ impl Elapsed {
     pub const fn as_seconds(self) -> f32 {
         self.0
     }
+
+    /// This much time counted in frames of a display running at `fps`.
+    ///
+    /// The bridge every rate written per-frame has to cross. Constants copied
+    /// from something that drew sixty times a second mean nothing until they
+    /// are told how many of those frames have gone by.
+    pub fn frames_at(self, fps: f32) -> Frames {
+        Frames(self.0 * fps.max(1.0))
+    }
+}
+
+/// A count of frames of the display a rate was written against.
+///
+/// Not a count of frames rav drew, and not a duration. A cap's velocity is
+/// multiplied by 1.1 "per frame", which is meaningless until it says *whose*
+/// frames - and 1.1 per frame at 30 a second is not 1.1 per frame at 60, nor
+/// 1.21. Keeping this apart from [`Elapsed`] is what stops a rate tuned on one
+/// display being applied unchanged to another.
+#[derive(Debug, Clone, Copy, PartialEq, PartialOrd, Default)]
+#[repr(transparent)]
+pub struct Frames(f32);
+
+impl Frames {
+    pub const NONE: Self = Self(0.0);
+
+    /// For a caller that genuinely has a frame count rather than a duration.
+    pub fn count(value: f32) -> Self {
+        Self(if value.is_nan() { 0.0 } else { value.max(0.0) })
+    }
+
+    pub const fn get(self) -> f32 {
+        self.0
+    }
+
+    pub fn is_none(self) -> bool {
+        self.0 <= 0.0
+    }
 }
 
 #[cfg(test)]

--- a/crates/rav-core/src/units.rs
+++ b/crates/rav-core/src/units.rs
@@ -502,8 +502,11 @@ impl Elapsed {
     /// The bridge every rate written per-frame has to cross. Constants copied
     /// from something that drew sixty times a second mean nothing until they
     /// are told how many of those frames have gone by.
+    ///
+    /// A rate below one a second gives a fraction of a frame, which is the
+    /// honest answer; a nonsensical one gives none.
     pub fn frames_at(self, fps: f32) -> Frames {
-        Frames(self.0 * fps.max(1.0))
+        Frames::count(self.0 * fps)
     }
 }
 
@@ -829,6 +832,24 @@ mod tests {
     fn time_never_runs_backwards() {
         assert_eq!(Elapsed::seconds(-1.0).as_seconds(), 0.0);
         assert_eq!(Elapsed::seconds(f32::NAN).as_seconds(), 0.0);
+    }
+
+    #[test]
+    fn a_duration_counts_frames_of_the_display_it_is_asked_about() {
+        // The same half second is thirty frames of one display and fifteen of
+        // another, which is why a rate written per frame has to say whose.
+        assert_eq!(Elapsed::seconds(0.5).frames_at(60.0), Frames::count(30.0));
+        assert_eq!(Elapsed::seconds(0.5).frames_at(30.0), Frames::count(15.0));
+
+        // A display slower than a frame a second gets a fraction of one, not a
+        // whole one - rounding up here would make a rate fall faster than asked
+        // on exactly the hardware least able to hide it.
+        assert_eq!(Elapsed::seconds(1.0).frames_at(0.5), Frames::count(0.5));
+
+        // A rate nobody could run at counts nothing, rather than running the
+        // motion backwards or filling it with NaN.
+        assert!(Elapsed::seconds(1.0).frames_at(f32::NAN).is_none());
+        assert!(Elapsed::seconds(1.0).frames_at(-60.0).is_none());
     }
 
     #[test]

--- a/crates/rav-core/src/units.rs
+++ b/crates/rav-core/src/units.rs
@@ -557,8 +557,36 @@ mod tests {
     type Rungs = Bounded<4, 4096>;
 
     /// The amplitude of a signal `db` below full scale.
+    ///
+    /// Shares the 20 with [`Curve::Decibel`] on purpose - it is the same
+    /// definition - which is exactly why it cannot be the only thing checking
+    /// it. See `a_decibel_is_the_amplitude_kind_not_the_power_kind`.
     fn at_dbfs(db: f32) -> Level {
         Level::new(10f32.powf(db / 20.0))
+    }
+
+    #[test]
+    fn a_decibel_is_the_amplitude_kind_not_the_power_kind() {
+        // A level is an amplitude, so dBFS is 20*log10 of it. The power form,
+        // 10*log10, halves every figure: a four-light strip's boundaries would
+        // land at -6, -3 and -1.25 instead of the -12, -6 and -2.5 this type
+        // documents, and every strip preset would be tuned against a window
+        // twice the size it thought.
+        //
+        // Literal pairs on purpose. `at_dbfs` above shares the definition with
+        // the implementation, so the two agree whatever the coefficient says -
+        // change both together and nothing else notices.
+        let window = Curve::Decibel { floor: -12.0 };
+
+        // Full scale is 0 dBFS: the top of any window.
+        assert!((window.apply(Level::FULL).fraction() - 1.0).abs() < 1e-3);
+
+        // Half amplitude is -6.02 dBFS, which is halfway up a 12 dB window.
+        let half = window.apply(Level::new(0.5)).fraction();
+        assert!((half - 0.4983).abs() < 1e-3, "0.5 amplitude read {half}");
+
+        // A quarter is -12.04 dBFS, which is under the floor and draws nothing.
+        assert!(window.apply(Level::new(0.25)).fraction() < 0.01);
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,13 @@
-// RAV Audio Visualizer Library
+//! A real-time audio spectrum analyser and oscilloscope.
+//!
+//! The binary is argument parsing and wiring; everything else is here, so the
+//! tests and `rav` compile one copy of the tree rather than two.
+//!
+//! Capture is in [`audio`], analysis in [`signal`], and what a level looks like
+//! in [`visual`] and [`render`]. [`ui`] holds the event loop and the widgets.
+//! The portable half - levels, geometry, colours, themes - lives in `rav-core`
+//! and `rav-appearance`, re-exported below.
+
 pub mod audio;
 pub mod config;
 pub mod render;
@@ -18,5 +27,5 @@ pub use rav_core::units;
 // Re-export commonly used types
 pub use config::Config;
 pub use rav_core::{
-    Bounded, CellSize, Cells, Curve, Elapsed, Fill, Hz, Length, Level, SampleRate, Step,
+    Bounded, CellSize, Cells, Curve, Elapsed, Fill, Frames, Hz, Length, Level, SampleRate, Step,
 };

--- a/src/signal/ballistics.rs
+++ b/src/signal/ballistics.rs
@@ -28,6 +28,8 @@
 //! geometric decay does not survive a frame-rate change otherwise: `v *= 1.1` at
 //! 30fps is not `v *= 1.1` at 60fps, nor `v *= 1.21`.
 
+use rav_core::Frames;
+
 /// The divisor in the original's `saFalloff -= falloff / 16.0`. This is part of
 /// the rate expression, not the display height, and the two must not be
 /// conflated - see [`FULL_SCALE_PIXELS`].
@@ -183,14 +185,11 @@ impl Ballistics {
         let bar_drop = self.bar_step() * frames;
         let seed = self.velocity_seed();
         let k = self.peak_fall;
-        // Distance covered by a geometric velocity over `frames` frames is the sum
-        // of the series, not velocity * frames. k == 1 degenerates to linear.
+        // A cap's velocity compounds, so how far it falls is the sum of a
+        // series rather than speed times frames. The sum lives in `rav-core`
+        // with the rest of the arithmetic an LED strip would need.
         let growth = k.powf(frames);
-        let distance_factor = if (k - 1.0).abs() < f32::EPSILON {
-            frames
-        } else {
-            (growth - 1.0) / (k - 1.0)
-        };
+        let distance_factor = rav_core::math::compounded_travel(k, Frames::count(frames));
 
         // Indexing rather than zipping: four parallel arrays, and three of them
         // are mutated, so the nested zip needed to satisfy the lint is markedly

--- a/src/signal/ballistics.rs
+++ b/src/signal/ballistics.rs
@@ -187,8 +187,11 @@ impl Ballistics {
         let k = self.peak_fall;
         // A cap's velocity compounds, so how far it falls is the sum of a
         // series rather than speed times frames. The sum lives in `rav-core`
-        // with the rest of the arithmetic an LED strip would need.
-        let growth = k.powf(frames);
+        // with the rest of the arithmetic an LED strip would need, and the new
+        // velocity is raised by the same `powf` the sum uses - two
+        // implementations of it could disagree in the last bit and leave the
+        // cap a hair from where the distance says it landed.
+        let growth = rav_core::math::powf(k, frames);
         let distance_factor = rav_core::math::compounded_travel(k, Frames::count(frames));
 
         // Indexing rather than zipping: four parallel arrays, and three of them

--- a/src/signal/mapping.rs
+++ b/src/signal/mapping.rs
@@ -34,10 +34,14 @@ pub const DEFAULT_LIMIT_INDEX: usize = 2;
 
 /// FFT bin that `hz` falls in, for a stream at `sample_rate`.
 pub fn bin_for_hz(hz: u32, sample_rate: u32, bins: usize) -> usize {
+    // The guard stays even though the type below knows its own Nyquist. A rate
+    // of zero gives `Hz(0.0)`, and dividing by that is NaN - which survives the
+    // clamp, saturates to nothing, and lands on bin 1. "Unknown rate is the
+    // full range" would silently become the narrowest one.
     if sample_rate == 0 {
         return bins;
     }
-    let nyquist = sample_rate as f32 / 2.0;
+    let nyquist = rav_core::SampleRate(sample_rate).nyquist().get();
     let fraction = (hz as f32 / nyquist).clamp(0.0, 1.0);
     ((fraction * bins as f32).round() as usize).clamp(1, bins)
 }
@@ -146,6 +150,21 @@ impl Bandwidth {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn a_rate_of_zero_is_the_whole_spectrum_and_not_a_sliver_of_it() {
+        // Reachable before a device has said what it runs at. The guard in
+        // `bin_for_hz` is what makes that the full range, and the temptation is
+        // to drop it now that `SampleRate` knows its own Nyquist - but
+        // `SampleRate(0).nyquist()` is `Hz(0.0)`, and dividing by that gives
+        // NaN, which survives the clamp, saturates to nothing and lands on bin
+        // one. The widest answer would quietly become the narrowest.
+        assert_eq!(bin_for_hz(16_000, 0, 512), 512, "not the full spectrum");
+        assert_eq!(bin_for_hz(0, 0, 512), 512);
+
+        // And with a rate, the ordinary answer is unchanged.
+        assert_eq!(bin_for_hz(16_000, 48_000, 512), 341);
+    }
 
     #[test]
     fn spans_the_spectrum_and_increases() {


### PR DESCRIPTION
Nothing on screen changes. This is arithmetic moving to where an LED strip can reach it, and one place rav disagreed with itself.

**A peak cap's fall is a series, not a speed.** A cap's velocity is multiplied by 1.1 every frame, so how far it drops over a stretch of frames is the sum of a geometric series. Write it as speed times frames and the motion is nearly right at the rate it was tuned against and visibly wrong at any other. That sum now lives in `rav-core::math` with the rest of the numbers — pure arithmetic, no allocator, no clock, which is exactly what a strip of lights on a speaker needs.

And "1.1 per frame" now has to say *whose* frames. `Frames` is a type, and `Elapsed::frames_at` is the only way to get one, so a duration cannot be handed to something expecting a count. 1.1 per frame at 30 a second is not 1.1 per frame at 60, and it is not 1.21 either — that is the mistake the type exists to make impossible.

**One Nyquist.** `SampleRate::nyquist` sat in the core with no callers while the bin lookup worked its own out by hand. One rule, two spellings; there is now one. The guard for a rate of zero stays, and a test says why: a device that has not yet reported what it runs at should get the whole spectrum, and the arithmetic without that guard gives NaN, which saturates to the *narrowest* answer instead. Remove the guard and the test fails.

**A decibel here is the amplitude kind.** A level is an amplitude, so dBFS is 20·log₁₀ of it, and nothing checked that. The test helper computes the same conversion the implementation does, so both would move together and the suite would stay green. The new test uses figures that come from the definition rather than from rav: full scale is the top of the window, half amplitude sits halfway up a 12 dB one, a quarter is under its floor. The power form halves every figure — a four-light strip's boundaries would land at −6, −3 and −1.25 instead of −12, −6 and −2.5, and every preset written for one would be tuned against a window twice the size it thought it had.

Also: `rav::Frames` is re-exported, since `Elapsed::frames_at` returned a type callers could not name without reaching past `rav` into `rav-core`; and `src/lib.rs` opened with a plain `//` line, so the crate had no docs.rs page at all.
