### PR TITLE
docs: say what the code does, not what it was meant to do

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ rav                   # analyser
 rav --theme winamp    # rav, winamp, terminal, mono, or a path to a theme
 rav --list-devices    # what rav can capture from
 rav -d "<name>"       # capture from a named device
-rav --clean           # keep logging out of the display
+rav --clean           # log almost nothing
 rav --surface kitty   # auto, glyphs, kitty or window
 ```
 

--- a/crates/rav-appearance/src/lib.rs
+++ b/crates/rav-appearance/src/lib.rs
@@ -7,8 +7,9 @@
 //! than merely working.
 //!
 //! It is a layer beside the core rather than inside it, because appearance has
-//! to be portable in its own right. The same theme dresses a glyph grid, a
-//! kitty image, a window and an LED matrix; only the last mile differs.
+//! to be portable in its own right. One theme dresses a glyph grid today, and
+//! is meant to dress a kitty image, a window and an LED matrix on the same
+//! terms; only the last mile differs.
 //!
 //! # The awkward case that shapes the API
 //!
@@ -21,10 +22,14 @@
 //!
 //! # Why no rasteriser
 //!
-//! Because the boundary is worth having, and the previous attempt at it was a
-//! comment. `Ramp` lived in the same file as `use tiny_skia`, under a doc
-//! comment claiming the renderer was meant to survive being made `no_std` -
-//! which was untrue as written. A crate cannot pick up a rasteriser by accident.
+//! Because a crate cannot pick one up by accident and a comment saying so can
+//! be ignored. Nothing here draws: [`Ramp`] hands back the stripes a screen
+//! should be painted in and never paints them, so the same ramp answers a
+//! rasteriser, a glyph grid and a strip of LEDs - none of which agree on what
+//! painting means. `tiny-skia` lives one crate up, with the surface that owns a
+//! pixmap.
+//!
+//! [`Ramp`]: ramp::Ramp
 
 #![no_std]
 

--- a/crates/rav-appearance/src/scene.rs
+++ b/crates/rav-appearance/src/scene.rs
@@ -9,12 +9,11 @@
 //! Nothing here can draw. A scene that knew how to rasterise itself would be a
 //! scene only a rasteriser could consume, and the LED matrix has none.
 //!
-//! # One surface takes it so far
+//! # Taken by one thing
 //!
-//! The pixel surface. The glyph renderer is handed levels and colours directly
-//! and quantises them itself, which is the freedom above being used rather than
-//! a gap - but it does mean this is the seam for one surface today and the
-//! shared seam only once a second one is built on it.
+//! The `tiny-skia` rasteriser, and only from the graphics spike so far. The
+//! glyph renderer takes levels and colours directly and quantises them itself,
+//! so this is the seam for one consumer until a second is built on it.
 
 use crate::ink::Colour;
 use crate::ramp::Ramp;

--- a/crates/rav-appearance/src/scene.rs
+++ b/crates/rav-appearance/src/scene.rs
@@ -4,10 +4,17 @@
 //! retained scene graph: a glyph renderer has to quantise to cells with its own
 //! rules - the fill-versus-glyph backdrop, cap lifting, partial blocks - and
 //! quantising a shared list of rectangles back into cells cannot reproduce them.
-//! Every surface takes the same scene and each is free to be itself.
+//! A surface takes the scene and is then free to be itself.
 //!
 //! Nothing here can draw. A scene that knew how to rasterise itself would be a
 //! scene only a rasteriser could consume, and the LED matrix has none.
+//!
+//! # One surface takes it so far
+//!
+//! The pixel surface. The glyph renderer is handed levels and colours directly
+//! and quantises them itself, which is the freedom above being used rather than
+//! a gap - but it does mean this is the seam for one surface today and the
+//! shared seam only once a second one is built on it.
 
 use crate::ink::Colour;
 use crate::ramp::Ramp;
@@ -65,11 +72,10 @@ impl Band {
 
 /// Everything a surface needs to draw one frame.
 ///
-/// The seam between the analyser and whatever is drawing. Deliberately not a
-/// retained scene graph: the glyph renderer has to quantise to cells with its
-/// own rules - the fill-versus-glyph backdrop, cap lifting, partial blocks - and
-/// quantising a shared list of rectangles back into cells cannot reproduce them.
-/// Every surface takes the same scene and each is free to be itself.
+/// Borrowed throughout, and built fresh each frame rather than kept: a scene is
+/// what the analyser currently reads, so holding one across frames would be
+/// holding a picture of the past. See the module note for why it is a flat list
+/// rather than a graph, and for which surfaces take it.
 pub struct Scene<'a> {
     pub bands: &'a [Band],
     pub layout: BarLayout,

--- a/crates/rav-appearance/src/skin.rs
+++ b/crates/rav-appearance/src/skin.rs
@@ -25,6 +25,20 @@
 //! partial *brightness* and `steps` is how many levels of it are worth asking
 //! for. That is the same number, read differently - which is the whole reason
 //! the core deals in counts.
+//!
+//! # Nothing builds one yet
+//!
+//! No [`Skin`] is constructed anywhere in rav. The terminal's shapes come from
+//! `BarStyle`, an enum of the six styles `b` cycles, and it names its glyphs
+//! directly rather than asking a skin for them.
+//!
+//! So this is the shape of the answer rather than the answer being used, and
+//! the two differ in one way worth knowing: `BarStyle` carries the glyphs
+//! themselves, while a [`Skin`] is meant to carry only how many steps there are
+//! and let each surface decide what a step looks like. Wiring the terminal to
+//! this is what would let one setting dress a glyph grid, a pixel surface and a
+//! strip of LEDs at once - and it is why the artwork these describe is not here
+//! either.
 
 /// How a skin covers a partial rung.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/crates/rav-appearance/src/skin.rs
+++ b/crates/rav-appearance/src/skin.rs
@@ -26,19 +26,13 @@
 //! for. That is the same number, read differently - which is the whole reason
 //! the core deals in counts.
 //!
-//! # Nothing builds one yet
+//! # Not yet read
 //!
-//! No [`Skin`] is constructed anywhere in rav. The terminal's shapes come from
-//! `BarStyle`, an enum of the six styles `b` cycles, and it names its glyphs
-//! directly rather than asking a skin for them.
-//!
-//! So this is the shape of the answer rather than the answer being used, and
-//! the two differ in one way worth knowing: `BarStyle` carries the glyphs
-//! themselves, while a [`Skin`] is meant to carry only how many steps there are
-//! and let each surface decide what a step looks like. Wiring the terminal to
-//! this is what would let one setting dress a glyph grid, a pixel surface and a
-//! strip of LEDs at once - and it is why the artwork these describe is not here
-//! either.
+//! Every preset names a skin and nothing looks at one, and none carries
+//! artwork. The terminal draws from `BarStyle`, which names its glyphs
+//! directly; a [`Skin`] carries only the step count and leaves the glyphs to
+//! the surface. That difference is what would let one setting dress a glyph
+//! grid, a pixel surface and an LED strip at once.
 
 /// How a skin covers a partial rung.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/crates/rav-core/src/ballistics.rs
+++ b/crates/rav-core/src/ballistics.rs
@@ -33,20 +33,12 @@ pub struct Spec {
 }
 
 impl Spec {
-    /// The bar-fall dial read per second instead of per frame.
+    /// The dial reading per second rather than per frame.
     ///
-    /// **A speed for comparing presets, not a distance.** It is
-    /// [`bar_fall`](Self::bar_fall) - the number on the dial, in the units the
-    /// original counted in - multiplied out to a second. Turning it into a
-    /// fraction of full scale takes two more constants that belong with the
-    /// integrator rather than here, so this is 240 times the distance a bar
-    /// actually covers: at the shipped preset it reads 720 where a bar falls
-    /// three full scales a second.
-    ///
-    /// Useful for what it is used for - one preset against another, and one
-    /// reading of the reference rate against another - and wrong for anything
-    /// that wants to know where a bar will be. The integrator answers that, and
-    /// `bar_fall_matches_the_original_rate` pins it at a third of a second.
+    /// For comparing presets and reference rates, not for placing a bar. The
+    /// conversion to a fraction of full scale needs two constants held by the
+    /// integrator, so this reads 240 times the distance covered: 720 at the
+    /// shipped preset, where a bar falls three full scales a second.
     pub fn bar_fall_per_second(&self) -> f32 {
         self.bar_fall * self.reference_fps
     }

--- a/crates/rav-core/src/ballistics.rs
+++ b/crates/rav-core/src/ballistics.rs
@@ -33,12 +33,25 @@ pub struct Spec {
 }
 
 impl Spec {
-    /// How far a bar falls in one second.
+    /// The bar-fall dial read per second instead of per frame.
+    ///
+    /// **A speed for comparing presets, not a distance.** It is
+    /// [`bar_fall`](Self::bar_fall) - the number on the dial, in the units the
+    /// original counted in - multiplied out to a second. Turning it into a
+    /// fraction of full scale takes two more constants that belong with the
+    /// integrator rather than here, so this is 240 times the distance a bar
+    /// actually covers: at the shipped preset it reads 720 where a bar falls
+    /// three full scales a second.
+    ///
+    /// Useful for what it is used for - one preset against another, and one
+    /// reading of the reference rate against another - and wrong for anything
+    /// that wants to know where a bar will be. The integrator answers that, and
+    /// `bar_fall_matches_the_original_rate` pins it at a third of a second.
     pub fn bar_fall_per_second(&self) -> f32 {
         self.bar_fall * self.reference_fps
     }
 
-    /// How far a cap falls in one second.
+    /// The cap's fall in the same units, and with the same caveat.
     pub fn peak_fall_per_second(&self) -> f32 {
         self.bar_fall * self.peak_fall * self.reference_fps
     }

--- a/crates/rav-core/src/capability.rs
+++ b/crates/rav-core/src/capability.rs
@@ -16,18 +16,12 @@
 //! its own, smaller [`Capabilities`], so a visualisation that fits alone may not
 //! fit beside another - which is the honest answer rather than a special case.
 //!
-//! # Nothing consults this yet
+//! # Not yet consulted
 //!
-//! `space` cycles the analyser and the oscilloscope without asking either of
-//! them anything, and no surface is refused a visualisation. This module is the
-//! rule written down and tested, not the rule being applied - and on a terminal
-//! the difference is invisible, because a terminal always has columns enough
-//! for both.
-//!
-//! It becomes load-bearing on the first surface that cannot show everything: a
-//! four-light bar, where offering an oscilloscope means offering a waveform with
-//! nowhere to put time. Until then this describes what should happen rather than
-//! what does.
+//! Nothing calls this. `space` cycles both visualisations unconditionally, and
+//! no surface is refused one. A terminal always has columns enough for both, so
+//! the check first matters on a display that does not - a four-light bar, where
+//! an oscilloscope has nowhere to put its time axis.
 
 use crate::units::Cells;
 

--- a/crates/rav-core/src/capability.rs
+++ b/crates/rav-core/src/capability.rs
@@ -7,13 +7,27 @@
 //! shrinking fixes it. A VU meter needs one column and two rungs and is happy.
 //!
 //! So a surface reports what it has, a visualisation states what it needs, and
-//! the ones that cannot say anything useful are never offered. That makes the
-//! small end a first-class target rather than a degraded one: on a four-light
-//! bar the answer is "this shows a VU meter", not "this shows a broken spectrum".
+//! the ones that cannot say anything useful should never be offered. That makes
+//! the small end a first-class target rather than a degraded one: on a
+//! four-light bar the answer is "this shows a VU meter", not "this shows a
+//! broken spectrum".
 //!
 //! Composition falls out of the same check. Splitting a screen gives each half
 //! its own, smaller [`Capabilities`], so a visualisation that fits alone may not
 //! fit beside another - which is the honest answer rather than a special case.
+//!
+//! # Nothing consults this yet
+//!
+//! `space` cycles the analyser and the oscilloscope without asking either of
+//! them anything, and no surface is refused a visualisation. This module is the
+//! rule written down and tested, not the rule being applied - and on a terminal
+//! the difference is invisible, because a terminal always has columns enough
+//! for both.
+//!
+//! It becomes load-bearing on the first surface that cannot show everything: a
+//! four-light bar, where offering an oscilloscope means offering a waveform with
+//! nowhere to put time. Until then this describes what should happen rather than
+//! what does.
 
 use crate::units::Cells;
 

--- a/crates/rav-core/src/lib.rs
+++ b/crates/rav-core/src/lib.rs
@@ -23,12 +23,16 @@
 //!
 //! No allocator, so nothing returns a `Vec`; geometry hands back one rectangle
 //! at a time and iterators do the rest. No clock, so anything with memory takes
-//! an [`Elapsed`] and the caller keeps the clock. No floating-point maths beyond
-//! what `core` provides - [`Curve`]'s logarithm and power forms are the one
-//! exception, and they say so.
+//! an [`Elapsed`] and the caller keeps the clock.
+//!
+//! And one dependency, which is the honest cost rather than a convenience.
+//! `f32::floor`, `round`, `ceil`, `log10` and `powf` are `std` methods and not
+//! `core` ones, however ordinary they look - rounding a level onto a step needs
+//! one, and so does fitting bars across a screen. [`math`] gathers them behind
+//! `libm` so the call sites still read as arithmetic and the dependency is
+//! visible in one place.
 //!
 //! [`Elapsed`]: units::Elapsed
-//! [`Curve`]: units::Curve
 
 #![no_std]
 

--- a/crates/rav-core/src/math.rs
+++ b/crates/rav-core/src/math.rs
@@ -1,17 +1,27 @@
-//! The floating-point operations `core` does not have.
+//! Arithmetic every surface needs, and the operations `core` does not have.
 //!
-//! Public because the sibling crates need the same ones, and two shims would be
-//! two chances to disagree - which is the failure this workspace exists to make
-//! impossible.
+//! Two things live here, and the difference matters.
 //!
-//! `f32::floor`, `round`, `log10` and `powf` are `std` methods, not `core` ones,
-//! so a `no_std` crate cannot call them however ordinary they look. They are
-//! gathered here rather than spread as `libm::floorf` calls through the
-//! arithmetic, so the call sites still read as maths and the dependency is
-//! visible in one place.
+//! **The shims.** `f32::floor`, `round`, `ceil`, `log10` and `powf` are `std`
+//! methods, not `core` ones, so a `no_std` crate cannot call them however
+//! ordinary they look. They are gathered here rather than spread as
+//! `libm::floorf` calls through the arithmetic, so the call sites still read as
+//! maths and the dependency is visible in one place. Same results as the `std`
+//! methods on every value rav produces; `libm` is the rust-lang port of musl's,
+//! which is what `std` itself uses on many targets.
 //!
-//! Same results as the `std` methods on every value rav produces; `libm` is the
-//! rust-lang port of musl's, which is what `std` itself uses on many targets.
+//! **The equations.** Arithmetic that is the same on a terminal, a window and a
+//! strip of LEDs, and that a microcontroller needs verbatim. The bar is high:
+//! it must be pure, allocate nothing, and answer a question nothing else in
+//! this crate already answers. A survey of all sixty-one equations in rav
+//! proposed twenty-seven for this module and twenty-five turned out to be
+//! duplicates of [`crate::units`] or [`crate::geometry`] - which is the outcome
+//! the crate boundary exists to prevent, not one it should collect.
+//!
+//! Everything else stays where it is used. A rate written per frame, a ramp's
+//! stripe placement, how much of the width a display spends on the bass: those
+//! are judgements about a picture, and this crate answers how many and which
+//! one, never what anything looks like.
 
 /// Toward negative infinity.
 pub fn floor(value: f32) -> f32 {

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -36,15 +36,18 @@ as an uneven 2/1 cadence.
 
 ## Bars stay flat with no warning
 
-rav is capturing a device with no signal on it. The log settles it in one line —
-rav reports the level of the first audio that arrives:
+rav is capturing a device with no signal on it. `rav.log`, beside wherever you
+started rav, settles it in one line — rav reports the level of the first audio
+that arrives:
 
 ```
-Capture delivering audio (peak 0.500)
+Capture delivering audio (peak 0.500)        # a capture device
+Process tap delivering audio (peak 0.500)    # macOS, capturing system output
 ```
 
-No such line at all means nothing is arriving; a peak near zero means the source
-is silent rather than absent.
+Which of the two depends on where the sound is coming from, and the line above
+it says which rav chose. Neither line at all means nothing is arriving; a peak
+near zero means the source is silent rather than absent.
 
 `rav --list-devices` shows what rav can see and `rav -d "<name>"` selects one.
 On Linux that list is ALSA PCMs only — a PipeWire/PulseAudio `.monitor` source

--- a/src/main.rs
+++ b/src/main.rs
@@ -213,9 +213,12 @@ async fn rav_main() -> Result<()> {
                 tap.sample_rate(),
                 tap.channels()
             );
-            // The cpal stream is already running, and its channel is unbounded.
-            // Leaving it feeding a receiver the app will never drain again grows
-            // the queue by ~350 KB/s until the process is killed.
+            // The cpal stream is already running and nothing will drain it
+            // again. Its queue is bounded and drops its oldest block when full,
+            // so this is not about memory - it is a capture device held open
+            // and a callback woken a hundred times a second to fill a queue
+            // whose contents are thrown away, with the microphone light on to
+            // say so.
             audio_capture.stop();
             app.use_tap(tap);
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -213,12 +213,9 @@ async fn rav_main() -> Result<()> {
                 tap.sample_rate(),
                 tap.channels()
             );
-            // The cpal stream is already running and nothing will drain it
-            // again. Its queue is bounded and drops its oldest block when full,
-            // so this is not about memory - it is a capture device held open
-            // and a callback woken a hundred times a second to fill a queue
-            // whose contents are thrown away, with the microphone light on to
-            // say so.
+            // Nothing drains the cpal stream once the tap takes over. Its queue
+            // is bounded and drops its oldest block, so this frees a capture
+            // device and a callback rather than memory.
             audio_capture.stop();
             app.use_tap(tap);
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,7 +32,7 @@ struct Args {
     #[arg(long)]
     test_audio: bool,
 
-    /// Enable clean mode (minimal logging for better TUI)
+    /// Log almost nothing. `RUST_LOG` still wins if it is set
     #[arg(long)]
     clean: bool,
 

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -4,15 +4,12 @@
 //! same geometry has to serve a terminal that draws glyphs, a terminal that
 //! carries pixels, and a window - see issue #65.
 //!
-//! Almost none of it lives here. Geometry and capability come from `rav-core`,
-//! colour and scenes from `rav-appearance`, and both are `no_std` - so a
-//! microcontroller gets the same ones. What is left is [`raster`], the one part
-//! that genuinely cannot go with them: it owns a `tiny-skia` pixmap, and a
-//! pixmap needs an allocator.
+//! Geometry and capability come from `rav-core`, colour and scenes from
+//! `rav-appearance`, both `no_std`. Only [`raster`] is defined here, because it
+//! owns a `tiny-skia` pixmap and a pixmap needs an allocator.
 //!
-//! The rest of this module is the re-exports directly below, so a surface can
-//! reach a scene, a ramp and a rectangle from one place without knowing which
-//! crate each came from.
+//! The re-exports below let a surface reach a scene, a ramp and a rectangle
+//! from one place.
 
 pub use rav_appearance::{ink, ramp, scene};
 pub use rav_core::{capability, geometry};

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -4,9 +4,15 @@
 //! same geometry has to serve a terminal that draws glyphs, a terminal that
 //! carries pixels, and a window - see issue #65.
 //!
-//! Geometry and capability come from `rav-core`, which is `no_std` and needs no
-//! allocator. What stays here is the part that cannot: the colour model, and the
-//! rasteriser that owns a `tiny-skia` pixmap.
+//! Almost none of it lives here. Geometry and capability come from `rav-core`,
+//! colour and scenes from `rav-appearance`, and both are `no_std` - so a
+//! microcontroller gets the same ones. What is left is [`raster`], the one part
+//! that genuinely cannot go with them: it owns a `tiny-skia` pixmap, and a
+//! pixmap needs an allocator.
+//!
+//! The rest of this module is the re-exports directly below, so a surface can
+//! reach a scene, a ramp and a rectangle from one place without knowing which
+//! crate each came from.
 
 pub use rav_appearance::{ink, ramp, scene};
 pub use rav_core::{capability, geometry};


### PR DESCRIPTION
No code changes. Twelve places where a comment described a design rather than the code under it — the kind of thing that reads as documentation and works as misdirection.

The ones that would actually cost someone time:

- **`bar_fall_per_second` said "how far a bar falls in one second"** and returns 720. It is a dial reading: the conversion to a fraction of full scale needs two constants the integrator holds, so the figure is 240× the distance. A bar falls three full scales a second, not 720.
- **The capability check reads as if it runs.** It does not — `space` cycles both visualisations unconditionally and no surface is refused one. It first matters on a display that has nowhere to put a time axis, like a four-light bar.
- **Skins read as if they were in use.** Every preset names one and nothing looks at one; none carries artwork yet.
- **The scene reads as the seam every surface takes.** One thing takes it today, the `tiny-skia` rasteriser, and only from the graphics spike.
- **`rav-core`'s own page said "no floating-point maths beyond what `core` provides"** while `math.rs` next door explained the `libm` dependency it has. `floor`, `round`, `ceil`, `log10` and `powf` are `std` methods, not `core` ones — rounding a level onto a step needs one. The page now names the cost instead of denying it.
- **`--clean` said "keep logging out of the display".** Logging has not been in the display for some time; it goes to `rav.log`. What the flag does is quiet that file almost completely, and `RUST_LOG` still wins — worth knowing before wondering why it had no effect.
- **Troubleshooting told you to look for one line that may never appear.** There are two, depending on whether rav is on a capture device or a macOS process tap, and neither is on screen — they are in `rav.log`, beside wherever you started rav.

Plus a comment claiming the capture queue was unbounded and growing at ~350 KB/s, which it has not been since the queue was bounded; and the `rav-appearance` crate page arguing with a design it no longer has.
