### PR TITLE
test: a key that changes nothing now fails the build

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,11 @@ readme = "README.md"
 # crates.io allows at most five keywords, each at most 20 characters.
 keywords = ["winamp", "audio", "visualizer", "spectrum", "tui"]
 categories = ["multimedia::audio", "command-line-utilities", "visualization"]
-exclude = ["assets/demo.gif", ".github/", "devenv.nix", "devenv.yaml", "devenv.lock"]
+# `assets/` is for the README and the repository, and crates.io resolves a
+# README's relative paths against the repository rather than the package - so
+# excluding the whole directory costs nothing and keeps brand artwork out of
+# what people download to build the binary.
+exclude = ["assets/", ".github/", "devenv.nix", "devenv.yaml", "devenv.lock"]
 
 # Denied rather than warned: a warning in a `nix build` scrolls past in CI logs
 # and nobody sees it. `dead_code` is a member of `unused`, so this covers the

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -1303,6 +1303,43 @@ mod tests {
     }
 
     #[test]
+    fn r_and_w_walk_their_whole_list_and_come_home() {
+        // The other cycles are covered one by one; these two were not. A cycle
+        // that skips an entry hides a setting the help panel still offers, and
+        // one that does not come home leaves a key you can press for ever
+        // without getting back to where you started.
+        let mut a = app();
+        // Read from `limit_index` and the table it indexes, not from the note:
+        // the note times out after a couple of seconds, so a loaded machine
+        // would collapse two presses into one empty string and the dedupe
+        // below would fail for a reason that has nothing to do with the cycle.
+        let ranges: Vec<Option<u32>> = (0..FREQUENCY_LIMITS.len())
+            .map(|_| {
+                a.apply(Action::CycleFrequencyLimit);
+                FREQUENCY_LIMITS[a.limit_index]
+            })
+            .collect();
+        assert_eq!(
+            ranges
+                .iter()
+                .collect::<std::collections::BTreeSet<_>>()
+                .len(),
+            FREQUENCY_LIMITS.len(),
+            "the range cycle repeats itself: {ranges:?}",
+        );
+        let home = a.limit_index;
+        a.apply(Action::CycleFrequencyLimit);
+        assert_ne!(a.limit_index, home, "and it still moves after a full turn");
+
+        // Bandwidth is two, so one press each way must return.
+        let start = a.bandwidth;
+        a.apply(Action::CycleBandwidth);
+        assert_ne!(a.bandwidth, start, "w changed nothing");
+        a.apply(Action::CycleBandwidth);
+        assert_eq!(a.bandwidth, start, "w does not come home");
+    }
+
+    #[test]
     fn every_key_that_should_change_the_picture_changes_it() {
         // A key wired to a field nothing reads is a key that does nothing, and
         // the help overlay would still cheerfully report its new value. So each

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -1303,6 +1303,83 @@ mod tests {
     }
 
     #[test]
+    fn every_key_that_should_change_the_picture_changes_it() {
+        // A key wired to a field nothing reads is a key that does nothing, and
+        // the help overlay would still cheerfully report its new value. So each
+        // of these is pressed and the frame compared, rather than the setting
+        // being read back - which is the test agreeing with itself.
+        let frame = |a: &mut App| {
+            let mut terminal = Terminal::new(TestBackend::new(60, 16)).unwrap();
+            // Gated exactly as the render loop gates it. Resizing unconditionally
+            // rebuilds the caches whatever the key did, so a key that forgot to
+            // invalidate `sized_for` - which in a real run leaves the picture
+            // stale - would still change the frame here and pass.
+            if (60, 16) != a.sized_for {
+                a.resize(60, 16);
+            }
+            let analyzer = Analyzer {
+                bars: a.ballistics.bars(),
+                peaks: a.ballistics.peaks(),
+                row_colors: &a.row_colors,
+                cap_color: a.theme.peak,
+                grid: a.show_grid.then_some(a.grid_colors.as_slice()),
+                bar_style: a.bar_style,
+                layout: a.layout,
+                peaks_style: a.peaks,
+            };
+            terminal
+                .draw(|f| f.render_widget(analyzer, f.area()))
+                .unwrap();
+            terminal.backend().buffer().clone()
+        };
+
+        // A signal, so there is something on screen to change.
+        let mut a = app();
+        a.resize(60, 16);
+        let bands: Vec<f32> = (0..a.bands.len())
+            .map(|i| 0.3 + (i % 5) as f32 / 8.0)
+            .collect();
+        a.ballistics.step(&bands, 1.0 / 60.0);
+
+        for key in [
+            Action::CycleTheme,
+            Action::CycleBarStyle,
+            Action::TogglePeaks,
+            Action::ToggleGrid,
+            Action::BarSize(1),
+        ] {
+            let before = frame(&mut a);
+            a.apply(key);
+            let after = frame(&mut a);
+            assert_ne!(before, after, "{key:?} changed nothing on screen");
+        }
+
+        // Bandwidth and the frequency range change how many bins are sampled
+        // and which, which shows in the mapping rather than in one frame of a
+        // fixed signal. `bands` is filled by the analysis, so it is empty here.
+        // Gated for the same reason as `frame`: forcing a rebuild here would
+        // hide a key that never asked for one.
+        let settle = |a: &mut App| {
+            if (60, 16) != a.sized_for {
+                a.resize(60, 16);
+            }
+        };
+        let sampled_before = a.bar_map.len();
+        a.apply(Action::CycleBandwidth);
+        settle(&mut a);
+        assert_ne!(sampled_before, a.bar_map.len(), "bandwidth changed nothing");
+
+        let top_before = a.bar_map.positions().last().copied();
+        a.apply(Action::CycleFrequencyLimit);
+        settle(&mut a);
+        assert_ne!(
+            top_before,
+            a.bar_map.positions().last().copied(),
+            "the frequency range changed nothing",
+        );
+    }
+
+    #[test]
     fn settings_keys_still_leave_a_transient_note() {
         // The overlay is the full picture; the note is the at-a-glance one.
         let mut a = app();

--- a/src/ui/scope.rs
+++ b/src/ui/scope.rs
@@ -218,6 +218,23 @@ mod tests {
     }
 
     #[test]
+    fn no_amount_of_gain_pushes_the_trace_off_the_screen() {
+        // `up` is a key a user can hold down, and a loud passage through a loud
+        // trim is a sample many times full scale. The trace has to saturate at
+        // the rails: a row past the last one is drawn into a cell that is not
+        // there, or into somebody else's.
+        for height in [1u16, 2, 9, 16, 64] {
+            for sample in [-1e9f32, -40.0, -1.0, 0.0, 1.0, 40.0, 1e9, f32::MAX] {
+                let row = row_of(sample, height);
+                assert!(
+                    row < height,
+                    "{sample} drew row {row} of a display {height} tall",
+                );
+            }
+        }
+    }
+
+    #[test]
     fn degenerate_areas_and_inputs_do_not_panic() {
         for (w, h) in [(0u16, 0u16), (1, 1), (80, 1), (1, 40)] {
             let _ = render(&[0.5, -0.5], w, h, ScopeStyle::Lines);


### PR DESCRIPTION
Three keys were checked by reading their own settings back, which is a test agreeing with itself, and one download carried 228K nobody uses.

**Every key that should change the picture now has to prove it.** Theme, bar style, peak caps, the backdrop and bar size are pressed and the frame compared before and after — a key wired to a field nothing reads is a key that does nothing, and the help panel would report its new value quite happily. Bandwidth and the frequency range change how many bins are sampled and which, so those are checked in the mapping rather than in one frame of a fixed signal.

All of them pass, so this found nothing. Making `g` a no-op fails it with "ToggleGrid changed nothing on screen", which is what it is for.

**`r` and `w` go all the way round.** Every other cycle was covered one by one; these two were not. A cycle that skips an entry hides a setting the help panel still offers, and one that never comes home leaves a key you can press for ever without getting back to where you started. Making the range wrap at three instead of five fails it with the five presses it walked, two of them repeats.

**Hold `up` and the trace still stays on screen.** `up` is a key you can lean on, and a loud passage through a loud trim is a sample many times full scale — the oscilloscope has to saturate at the rails rather than draw into a row that is not there. The scope at full scale, at eight times and at forty gives the same picture, which is the clamp doing its job; it was doing it unwatched.

**And 228K of brand artwork stops shipping to crates.io.** `exclude` named `assets/demo.gif` alone, so the twenty-four SVGs added beside it went out with every build. crates.io resolves a README's relative paths against the repository rather than the package, so excluding the directory costs nothing: 67 files down to 43.
