### PR TITLE
test: does the picture match the music?

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1273,6 +1273,7 @@ dependencies = [
  "libc",
  "objc2",
  "objc2-foundation",
+ "proptest",
  "rand 0.8.7",
  "ratatui",
  "rav-appearance",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -132,6 +132,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -358,7 +373,7 @@ dependencies = [
  "crossterm_winapi",
  "mio",
  "parking_lot",
- "rustix",
+ "rustix 0.38.44",
  "signal-hook",
  "signal-hook-mio",
  "winapi",
@@ -467,6 +482,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fastrand"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -483,6 +504,12 @@ dependencies = [
  "nanorand",
  "spin",
 ]
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foldhash"
@@ -535,13 +562,25 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 5.3.0",
+ "wasip2",
+]
+
+[[package]]
+name = "getrandom"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 6.0.0",
 ]
 
 [[package]]
@@ -739,6 +778,12 @@ name = "linux-raw-sys"
 version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "lock_api"
@@ -1081,6 +1126,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "proptest"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
+dependencies = [
+ "bit-set",
+ "bit-vec",
+ "bitflags 2.13.1",
+ "num-traits",
+ "rand 0.9.5",
+ "rand_chacha 0.9.0",
+ "rand_xorshift",
+ "regex-syntax",
+ "rusty-fork",
+ "tempfile",
+ "unarray",
+]
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+
+[[package]]
 name = "quote"
 version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1088,6 +1158,12 @@ checksum = "1fbf4db142a473a8d80c26bbf18454ed458bf8d26c8219c331daecfdbd079001"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "r-efi"
@@ -1102,8 +1178,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22f6172bdec972074665ed81ed53b71da00bfc44b65a753cfde883ec4c702a1a"
 dependencies = [
  "libc",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -1113,7 +1199,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -1123,6 +1219,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.17",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
+dependencies = [
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -1159,7 +1273,7 @@ dependencies = [
  "libc",
  "objc2",
  "objc2-foundation",
- "rand",
+ "rand 0.8.7",
  "ratatui",
  "rav-appearance",
  "rav-core",
@@ -1186,6 +1300,7 @@ name = "rav-core"
 version = "1.0.0-beta.7"
 dependencies = [
  "libm",
+ "proptest",
 ]
 
 [[package]]
@@ -1275,8 +1390,21 @@ dependencies = [
  "bitflags 2.13.1",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.4.15",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags 2.13.1",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.12.1",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1284,6 +1412,18 @@ name = "rustversion"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
+
+[[package]]
+name = "rusty-fork"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc6bf79ff24e648f6da1f8d1f011e9cac26491b619e6b9280f2b47f1774e6ee2"
+dependencies = [
+ "fnv",
+ "quick-error",
+ "tempfile",
+ "wait-timeout",
+]
 
 [[package]]
 name = "ryu"
@@ -1494,6 +1634,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.4.3",
+ "once_cell",
+ "rustix 1.1.4",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1721,6 +1874,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1762,6 +1921,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "walkdir"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1776,6 +1944,15 @@ name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "wasip2"
+version = "1.0.4+wasi-0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
+dependencies = [
+ "wit-bindgen",
+]
 
 [[package]]
 name = "wasm-bindgen"
@@ -2139,6 +2316,12 @@ checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "zerocopy"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,10 @@ repository = "https://github.com/i-am-logger/rav"
 [workspace.dependencies]
 rav-core = { path = "crates/rav-core", version = "1.0.0-beta.7" }
 rav-appearance = { path = "crates/rav-appearance", version = "1.0.0-beta.7" }
+# Dev-only, so nothing published gains a dependency. Shared here for the same
+# reason the versions are: two crates disagreeing about a test framework is a
+# thing that happens quietly.
+proptest = "1"
 
 [package]
 name = "rav"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,9 @@ repository = "https://github.com/i-am-logger/rav"
 
 # Both a path and a version: the path is what the workspace builds against, and
 # the version is what a published rav requires, so the two cannot drift.
+[dev-dependencies]
+proptest.workspace = true
+
 [workspace.dependencies]
 rav-core = { path = "crates/rav-core", version = "1.0.0-beta.7" }
 rav-appearance = { path = "crates/rav-appearance", version = "1.0.0-beta.7" }

--- a/crates/rav-appearance/src/ramp.rs
+++ b/crates/rav-appearance/src/ramp.rs
@@ -114,3 +114,145 @@ impl Ramp {
             .collect()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rav_core::geometry::Rectangle;
+
+    /// Four stops, each tellable from the others at a glance in a failure.
+    fn ramp() -> Ramp {
+        Ramp::new(vec![
+            Colour::BLACK,
+            Colour::RED,
+            Colour::YELLOW,
+            Colour::WHITE,
+        ])
+    }
+
+    #[test]
+    fn the_stripes_cover_the_screen_exactly_once() {
+        // A gap is an unpainted line across the display and an overlap is a
+        // colour drawn twice; both look like a rendering bug rather than a
+        // ramp bug, which is why this is asserted here and not noticed there.
+        let screen = Length(360.0);
+        let stripes = ramp().stripes(screen);
+
+        assert_eq!(stripes[0].top, Length::NONE, "a gap at the ceiling");
+        assert_eq!(stripes.last().unwrap().bottom, screen, "a gap at the floor",);
+        for pair in stripes.windows(2) {
+            assert_eq!(
+                pair[0].bottom, pair[1].top,
+                "{:?} and {:?} do not meet",
+                pair[0], pair[1],
+            );
+        }
+    }
+
+    #[test]
+    fn the_end_stripes_are_half_as_tall_as_the_rest() {
+        // Not tidiness - it is what `nearest_step` rounding produces, and what
+        // the terminal renderer has always drawn. Spacing the stops evenly
+        // instead would move every colour boundary in the picture, which is
+        // exactly the difference a pixel surface is not allowed to introduce.
+        let stripes = ramp().stripes(Length(300.0));
+        let middle = stripes[1].height().get();
+        assert!((stripes[0].height().get() - middle / 2.0).abs() < 1e-3);
+        assert!((stripes.last().unwrap().height().get() - middle / 2.0).abs() < 1e-3);
+    }
+
+    #[test]
+    fn asking_for_a_colour_and_reading_it_off_a_stripe_give_the_same_answer() {
+        // Two ways to the same fact, which is the shape that drifts: the
+        // rasteriser paints stripes and a surface that samples per bar calls
+        // `at`. A ramp module whose two halves disagreed would be the 679/19980
+        // divergence again, one layer up.
+        //
+        // Sixteen stops, sampled near both edges of each stripe and not only at
+        // its midpoint. A first version did midpoints of a four-stop ramp and
+        // passed happily against evenly-spaced stripes - the two placements
+        // agree in the middle of a stripe and part company towards its ends, so
+        // a midpoint test was checking the half of the range where the bug
+        // cannot show.
+        let screen = Length(480.0);
+        let ramp = Ramp::new((0..16).map(|i| Colour::rgb(i * 16, 0, 0)).collect());
+        for stripe in ramp.stripes(screen) {
+            let height = stripe.height().get();
+            for inset in [0.05, 0.5, 0.95] {
+                let from_top = stripe.top + Length(height * inset);
+                let above_floor = screen - from_top;
+                assert_eq!(
+                    ramp.at(above_floor, screen),
+                    stripe.colour,
+                    "{inset} of the way down {stripe:?}, at {above_floor:?}",
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn the_floor_is_the_first_stop_and_the_ceiling_is_the_last() {
+        // The rule the whole look rests on: a bar's foot is always the bottom of
+        // the ramp and a full-height bar always reaches the top, whatever the
+        // screen is. A theme is written as a ladder and never has to ask how
+        // tall the display is.
+        let screen = Length(200.0);
+        let ramp = ramp();
+        assert_eq!(ramp.at(Length::NONE, screen), Colour::BLACK);
+        assert_eq!(ramp.at(screen, screen), Colour::WHITE);
+    }
+
+    #[test]
+    fn a_ramp_of_one_colour_paints_the_whole_screen_in_it() {
+        let flat = Ramp::new(vec![Colour::CYAN]);
+        let stripes = flat.stripes(Length(120.0));
+        assert_eq!(stripes.len(), 1);
+        assert_eq!(stripes[0].height(), Length(120.0));
+        assert_eq!(flat.at(Length(60.0), Length(120.0)), Colour::CYAN);
+    }
+
+    #[test]
+    fn a_screen_with_no_height_still_answers() {
+        // A terminal mid-resize. Dividing by the height would give NaN, and a
+        // NaN colour index panics at the point of drawing rather than here.
+        let stripes = ramp().stripes(Length::NONE);
+        assert_eq!(stripes.len(), 1, "nothing to divide into");
+        assert_eq!(ramp().at(Length::NONE, Length::NONE), Colour::BLACK);
+    }
+
+    #[test]
+    fn a_ramp_with_no_colours_is_black_rather_than_a_panic() {
+        // Reachable from a theme file with an empty ramp. Black is wrong-looking
+        // and obvious; a panic mid-render loses the terminal.
+        let empty = Ramp::new(vec![]);
+        assert_eq!(empty.len(), 1);
+        assert!(!empty.is_empty());
+        assert_eq!(empty.at(Length(10.0), Length(20.0)), Colour::BLACK);
+    }
+
+    #[test]
+    fn a_bar_cut_into_stripes_reassembles_into_the_bar() {
+        // What the rasteriser does every frame: take one bar and paint it in as
+        // many pieces as it crosses colours. Losing height in the cut would
+        // shorten every bar by a sliver at each boundary.
+        let screen = Length(400.0);
+        let bar = Rectangle::new(Length(10.0), Length(100.0), Length(8.0), Length(250.0));
+        let pieces: Vec<Rectangle> = ramp()
+            .stripes(screen)
+            .iter()
+            .filter_map(|stripe| stripe.clip(bar))
+            .collect();
+
+        assert!(pieces.len() > 1, "the bar crosses more than one colour");
+        let painted: f32 = pieces.iter().map(|piece| piece.height().get()).sum();
+        assert!(
+            (painted - bar.height().get()).abs() < 1e-3,
+            "painted {painted} of {:?}",
+            bar.height(),
+        );
+        // Ceiling-first, so the pieces come back in order and touching.
+        for pair in pieces.windows(2) {
+            assert_eq!(pair[0].bottom(), pair[1].top(), "a seam in the bar");
+        }
+    }
+}

--- a/crates/rav-appearance/src/scene.rs
+++ b/crates/rav-appearance/src/scene.rs
@@ -129,3 +129,120 @@ impl Scene<'_> {
             .or_else(|| self.styles.first())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ink::Colour;
+    use alloc::vec;
+    use alloc::vec::Vec;
+
+    fn ramp(colour: Colour) -> Ramp {
+        Ramp::new(vec![colour])
+    }
+
+    fn scene<'a>(bands: &'a [Band], styles: &'a [Style<'a>], across: f32) -> Scene<'a> {
+        Scene {
+            bands,
+            layout: BarLayout::new(Length(8.0), Length(2.0)),
+            screen: Screen::new(Length(across), Length(100.0)),
+            styles,
+        }
+    }
+
+    #[test]
+    fn a_scene_draws_the_lesser_of_what_fits_and_what_exists() {
+        // The glyph renderer's rule, and the reason it is here rather than in
+        // each surface: one per band regardless puts rectangles past the screen,
+        // where a rasteriser drops them without a word - so two surfaces would
+        // disagree about how many bars there are and neither would say so.
+        let green = ramp(Colour::GREEN);
+        let styles = [Style {
+            bars: &green,
+            grid: None,
+            cap: None,
+        }];
+        let many: Vec<Band> = (0..64).map(|_| Band::default()).collect();
+
+        // 8 wide with a 2 gap is a stride of 10, so 5 fit across 48.
+        assert_eq!(scene(&many, &styles, 48.0).visible_bands(), 5, "clipped");
+        let few = [Band::default(), Band::default()];
+        assert_eq!(
+            scene(&few, &styles, 480.0).visible_bands(),
+            2,
+            "all of them"
+        );
+    }
+
+    #[test]
+    fn a_stereo_pair_is_two_styles_and_one_scene() {
+        // What "a mode can have a different colour per channel" comes to. The
+        // bands carry an index and the surface holds the looks, so a mirrored
+        // pair needs no second scene and no second analyser.
+        let left = ramp(Colour::CYAN);
+        let right = ramp(Colour::MAGENTA);
+        let styles = [
+            Style {
+                bars: &left,
+                grid: None,
+                cap: None,
+            },
+            Style {
+                bars: &right,
+                grid: None,
+                cap: None,
+            },
+        ];
+        let bands = [
+            Band::new(Level::FULL, Level::FULL),
+            Band::new(Level::FULL, Level::FULL).styled(StyleId(1)),
+        ];
+        let scene = scene(&bands, &styles, 480.0);
+        assert_eq!(
+            scene.style_of(&bands[0]).unwrap().bars.stops()[0],
+            Colour::CYAN
+        );
+        assert_eq!(
+            scene.style_of(&bands[1]).unwrap().bars.stops()[0],
+            Colour::MAGENTA,
+        );
+    }
+
+    #[test]
+    fn a_band_wearing_a_style_that_is_gone_is_drawn_in_the_first_one() {
+        // Reachable: a theme change swaps the styles while bands from the
+        // previous frame still name the old ones. A wrong colour for one frame
+        // is a blink; a panic mid-render loses the terminal the user is in.
+        let green = ramp(Colour::GREEN);
+        let styles = [Style {
+            bars: &green,
+            grid: None,
+            cap: None,
+        }];
+        let stale = Band::default().styled(StyleId(9));
+        let bands = [stale];
+        let scene = scene(&bands, &styles, 480.0);
+        assert_eq!(
+            scene.style_of(&stale).unwrap().bars.stops()[0],
+            Colour::GREEN,
+        );
+    }
+
+    #[test]
+    fn a_scene_with_no_styles_draws_nothing_rather_than_inventing_a_colour() {
+        // The alternative is a default, and a default here is rav choosing a
+        // colour the theme did not - which is the one thing the appearance
+        // layer exists to prevent.
+        let band = Band::default();
+        let bands = [band];
+        assert!(scene(&bands, &[], 480.0).style_of(&band).is_none());
+    }
+
+    #[test]
+    fn everything_is_the_first_style_until_something_says_otherwise() {
+        // So the common case costs one byte per band and no thought.
+        assert_eq!(Band::default().style, StyleId::FIRST);
+        assert_eq!(Band::new(Level::FULL, Level::FULL).style, StyleId::FIRST);
+        assert_eq!(StyleId::FIRST.index(), 0);
+    }
+}

--- a/crates/rav-core/Cargo.toml
+++ b/crates/rav-core/Cargo.toml
@@ -20,5 +20,11 @@ categories = ["multimedia::audio", "no-std", "visualization"]
 [dependencies]
 libm = "0.2"
 
+# The properties in `tests/` need a generator and `std`; the library needs
+# neither. A dev-dependency is invisible to anything that depends on this crate,
+# so an embedded target never sees it.
+[dev-dependencies]
+proptest.workspace = true
+
 [lints.rust]
 unused = "deny"

--- a/crates/rav-core/src/geometry.rs
+++ b/crates/rav-core/src/geometry.rs
@@ -232,6 +232,11 @@ impl Column {
         self.width
     }
 
+    /// The far edge, so asking whether a column fits is asking the column.
+    pub fn right(&self) -> Length {
+        self.left + self.width
+    }
+
     pub fn anchor(&self) -> Anchor {
         self.anchor
     }

--- a/crates/rav-core/tests/properties.rs
+++ b/crates/rav-core/tests/properties.rs
@@ -1,0 +1,386 @@
+//! What has to hold for *every* input, not just the ones someone thought of.
+//!
+//! The example-based tests beside each type say what it does; these say what it
+//! can never do. They are the tests that matter most for this crate, because it
+//! is the one part of rav that has to survive being run somewhere nobody tried:
+//! four LEDs on a cap, a 16K display, a screen mid-resize with no area at all.
+//!
+//! An integration test rather than a `#[cfg(test)]` module, which buys two
+//! things. It compiles as an outside consumer, so anything these reach is
+//! genuinely public and anything they cannot reach is not part of the crate's
+//! offer. And it keeps the properties away from the examples, which are
+//! documentation and read as such.
+//!
+//! # Generators are bounded on purpose
+//!
+//! Unbounded `usize` finds `rungs * steps` overflowing in a millisecond, and
+//! unbounded `f32` finds a screen `1e38` wide where every coordinate is `inf`.
+//! Neither is a bug worth the fix: hardening a `no_std` core against inputs no
+//! caller can produce costs arithmetic on the path a microcontroller runs, to
+//! defend against a display larger than the observable universe. The ranges
+//! below are the domain - a four-light strip at one end and a wall of pixels at
+//! the other - and a property that only fails outside them has found nothing.
+
+use proptest::prelude::*;
+use rav_core::{Anchor, BarLayout, Curve, Length, Level, Screen, Step};
+
+/// Rungs on a ladder: four lights on a speaker grille, up to a tall display.
+const RUNGS: core::ops::RangeInclusive<usize> = 1..=4096;
+/// Sub-divisions of a rung: one for a plain LED, eight for a glyph ladder, 256
+/// for a strip whose brightness is a byte.
+const STEPS: core::ops::RangeInclusive<usize> = 1..=256;
+/// Device pixels across or down. Zero is included: a terminal mid-resize.
+const EXTENT: core::ops::RangeInclusive<f32> = 0.0..=8192.0;
+
+prop_compose! {
+    fn a_level()(fraction in 0.0f32..=1.0) -> Level {
+        Level::new(fraction)
+    }
+}
+
+prop_compose! {
+    fn a_screen()(width in EXTENT, height in EXTENT) -> Screen {
+        Screen::new(Length(width), Length(height))
+    }
+}
+
+prop_compose! {
+    fn a_layout()(width in 1.0f32..=64.0, gap in 0.0f32..=16.0) -> BarLayout {
+        BarLayout::new(Length(width), Length(gap))
+    }
+}
+
+fn an_anchor() -> impl Strategy<Value = Anchor> {
+    prop_oneof![
+        Just(Anchor::Floor),
+        Just(Anchor::Ceiling),
+        Just(Anchor::Middle)
+    ]
+}
+
+fn a_curve() -> impl Strategy<Value = Curve> {
+    prop_oneof![
+        Just(Curve::Linear),
+        (-96.0f32..=-6.0).prop_map(|floor| Curve::Decibel { floor }),
+        (0.1f32..=4.0).prop_map(Curve::Gamma),
+    ]
+}
+
+proptest! {
+    /// A louder band never draws shorter, whichever curve is fitted.
+    ///
+    /// The one promise a curve makes. Break it and the display stops being a
+    /// reading of the signal: two passages of different loudness could show the
+    /// same height, or the quieter one could show taller.
+    #[test]
+    fn a_curve_never_turns_louder_into_shorter(
+        curve in a_curve(),
+        quiet in a_level(),
+        louder in a_level(),
+    ) {
+        prop_assume!(quiet <= louder);
+        prop_assert!(
+            curve.apply(quiet) <= curve.apply(louder),
+            "{curve:?} put {quiet:?} above {louder:?}",
+        );
+    }
+
+    /// Silence draws nothing, whichever curve is fitted.
+    ///
+    /// A curve that lifts the quiet end is doing its job right up until it lifts
+    /// *nothing* into something, at which point a dead input lights the display
+    /// and there is no way to tell it from a live one.
+    #[test]
+    fn no_curve_lights_a_dead_signal(curve in a_curve()) {
+        prop_assert!(curve.apply(Level::SILENT).is_silent(), "{curve:?} lit silence");
+    }
+
+    /// Filling more of a ladder never lights fewer of its units.
+    ///
+    /// Stated in units rather than rungs because the rung and the part above it
+    /// move together: going from "two rungs and seven eighths" to "three rungs"
+    /// gains a rung and loses the part, and only the total says that went up.
+    #[test]
+    fn filling_further_never_lights_less(
+        rungs in RUNGS,
+        steps in STEPS,
+        quiet in a_level(),
+        louder in a_level(),
+    ) {
+        prop_assume!(quiet <= louder);
+        let units = |level: Level| {
+            let fill = level.fill(rungs, steps);
+            fill.whole * steps + fill.part.index()
+        };
+        prop_assert!(units(quiet) <= units(louder));
+    }
+
+    /// A full ladder is full rungs and nothing above them.
+    ///
+    /// The rung above the top one does not exist, so a part there would be a
+    /// surface asked to draw off the end of the display.
+    #[test]
+    fn a_full_ladder_has_nothing_above_it(rungs in RUNGS, steps in STEPS) {
+        let fill = Level::FULL.fill(rungs, steps);
+        prop_assert_eq!(fill.whole, rungs, "not full");
+        prop_assert!(!fill.has_part(), "something above the top rung");
+    }
+
+    /// A ladder is only ever as tall as it is.
+    #[test]
+    fn a_ladder_never_overfills(rungs in RUNGS, steps in STEPS, level in a_level()) {
+        let fill = level.fill(rungs, steps);
+        prop_assert!(fill.whole <= rungs, "{} of {rungs} rungs", fill.whole);
+        prop_assert!(fill.whole < rungs || !fill.has_part(), "past the top");
+    }
+
+    /// The ends of a skin stay the ends of it at any resolution.
+    ///
+    /// What lets one setting drive surfaces that disagree about granularity: an
+    /// eight-step glyph ladder and a 200-light strip are the same fraction at
+    /// different resolutions. If the ends drifted, a bar that reads full on the
+    /// terminal would read a shade under full on the strip beside it.
+    #[test]
+    fn rescaling_keeps_the_ends_at_the_ends(from in 2usize..=256, to in 1usize..=256) {
+        let dimmest = Step::new(0, from).rescaled(to);
+        prop_assert!(dimmest.is_first(), "the bottom moved");
+
+        let brightest = Step::new(from - 1, from).rescaled(to);
+        prop_assert!(brightest.is_last(), "the top moved");
+    }
+}
+
+/// A skin with one step rescales to the dimmest, not the brightest.
+///
+/// `Step::new(0, 1)` is both the first step and the last, so there is no answer
+/// to read off it - the position is 0 of 0. Dimmest is the decision: a count of
+/// one carries no brightness to preserve, and reading it as full would have a
+/// plain on/off lamp drive a 200-light strip to maximum for any signal at all.
+///
+/// Written as an example rather than a property because it is a choice, and a
+/// property would only restate whichever choice the code had made.
+#[test]
+fn a_single_step_rescales_to_the_dimmest() {
+    let only = Step::new(0, 1);
+    assert!(only.is_first() && only.is_last(), "one step is both ends");
+    assert!(only.rescaled(200).is_first());
+    assert!(
+        !only.rescaled(200).is_last(),
+        "it did not invent brightness"
+    );
+}
+
+proptest! {
+    /// Every bar the layout says fits, fits.
+    ///
+    /// `fitting_across` is a floating-point division followed by a floor, and a
+    /// division that lands a hair over a whole number would report one bar more
+    /// than there is room for - which draws the last bar off the edge, where a
+    /// rasteriser discards it in silence and the display is short a band with
+    /// nothing to say so.
+    #[test]
+    fn every_bar_that_is_counted_has_room(layout in a_layout(), screen in a_screen()) {
+        let count = layout.fitting_across(&screen);
+        prop_assert!(count >= 1, "there is always at least one bar to draw");
+
+        // A screen narrower than a single bar still reports one, deliberately:
+        // something has to be drawn and the surface clips it. Nothing to check.
+        prop_assume!(screen.width() >= layout.bar_width());
+
+        let last = layout.column(count - 1);
+        prop_assert!(
+            last.right() <= screen.width(),
+            "bar {} ends at {:?} on a screen {:?} wide",
+            count - 1,
+            last.right(),
+            screen.width(),
+        );
+    }
+
+    /// A mirrored pair is a mirror image.
+    ///
+    /// The stereo arrangement on a car dashboard or a speaker grille is one
+    /// channel on `Floor` and the other on `Ceiling`, so any disagreement
+    /// between the two shows up as a pair that is visibly not a pair. They are
+    /// separate arms of a `match`, which is exactly how the two colour-by-height
+    /// rules that this crate exists to unify drifted apart.
+    #[test]
+    fn floor_and_ceiling_are_reflections_of_each_other(
+        level in a_level(),
+        screen in a_screen(),
+    ) {
+        let column = BarLayout::new(Length(8.0), Length(1.0)).column(0);
+        let up = column.anchored(Anchor::Floor).bar(level, &screen);
+        let down = column.anchored(Anchor::Ceiling).bar(level, &screen);
+
+        let height = screen.height().get();
+        prop_assert!(
+            (up.top().get() - (height - down.bottom().get())).abs() < 1e-3,
+            "{up:?} does not mirror {down:?}",
+        );
+        prop_assert!((up.height().get() - down.height().get()).abs() < 1e-3);
+    }
+
+    /// A bar that grows both ways stays centred.
+    #[test]
+    fn a_middle_bar_is_centred(level in a_level(), screen in a_screen()) {
+        let bar = BarLayout::new(Length(8.0), Length(1.0))
+            .column(0)
+            .anchored(Anchor::Middle)
+            .bar(level, &screen);
+        let above = bar.top().get();
+        let below = screen.height().get() - bar.bottom().get();
+        prop_assert!((above - below).abs() < 1e-3, "{above} above, {below} below");
+    }
+
+    /// A cap marks the level without covering it.
+    ///
+    /// The defect a cell grid cannot fix (#65): a terminal cell holds one symbol,
+    /// so drawing a cap there destroys what was beneath it. Here they are two
+    /// rectangles, and the promise is that they do not need to compete - the cap
+    /// sits entirely beyond the bar whenever there is room for it to.
+    #[test]
+    fn a_cap_sits_beyond_its_bar_rather_than_over_it(
+        anchor in an_anchor(),
+        level in a_level(),
+        rise in 0.0f32..=1.0,
+        thickness in 1.0f32..=8.0,
+        height in 1.0f32..=8192.0,
+    ) {
+        // A peak is the high-water mark of the level, never below it.
+        let peak = Level::new(level.fraction() + rise);
+        let screen = Screen::new(Length(256.0), Length(height));
+        let thickness = Length(thickness);
+
+        // Room for the cap beyond the bar, or it is held inside the screen
+        // instead and has to overlap - documented, and the reason a cap at full
+        // scale sits on the bar rather than half off the display. `Middle` needs
+        // twice the room, because it grows from the centre in both directions.
+        let needed = match anchor {
+            Anchor::Middle => thickness.get() * 2.0,
+            _ => thickness.get(),
+        };
+        prop_assume!(screen.risen_to(peak).get() + needed <= height);
+
+        let column = BarLayout::new(Length(8.0), Length(1.0)).column(0).anchored(anchor);
+        let bar = column.bar(level, &screen);
+        let cap = column.cap(peak, thickness, &screen);
+        prop_assert!(
+            !cap.overlaps(&bar),
+            "{anchor:?}: cap {cap:?} over bar {bar:?} at level {level:?} peak {peak:?}",
+        );
+    }
+
+    /// A cap stays on the display.
+    ///
+    /// Held inside at both ends: at full scale it would otherwise hang off the
+    /// far edge, and at rest off the near one. Guarded to screens at least as
+    /// tall as the thinnest cap, since a cap has a floor of one light and a
+    /// display shorter than that has nowhere to put it - the documented collapse
+    /// rather than a defect.
+    #[test]
+    fn a_cap_is_always_somewhere_on_the_display(
+        anchor in an_anchor(),
+        peak in a_level(),
+        thickness in 1.0f32..=8.0,
+        height in 8.0f32..=8192.0,
+    ) {
+        let screen = Screen::new(Length(256.0), Length(height));
+        let cap = BarLayout::new(Length(8.0), Length(1.0))
+            .column(0)
+            .anchored(anchor)
+            .cap(peak, Length(thickness), &screen);
+        prop_assert!(cap.top() >= Length::NONE, "above the top: {cap:?}");
+        prop_assert!(cap.bottom() <= screen.height(), "below the floor: {cap:?}");
+    }
+
+    /// Crossed bounds collapse rather than panicking.
+    ///
+    /// `f32::clamp` panics when the low bound is above the high one, and a
+    /// zero-height display produces exactly that honestly - a cap thicker than
+    /// the screen leaves nowhere to put it. Collapsing to the low bound is the
+    /// documented answer, and it is what keeps a terminal mid-resize from
+    /// bringing rav down.
+    #[test]
+    fn crossing_the_bounds_collapses(value in -1e4f32..=1e4, low in -1e4f32..=1e4, high in -1e4f32..=1e4) {
+        let held = Length(value).held_between(Length(low), Length(high));
+        if low > high {
+            prop_assert_eq!(held, Length(low), "it did not collapse to the low bound");
+        } else {
+            prop_assert!(held >= Length(low) && held <= Length(high));
+        }
+    }
+}
+
+/// A ladder never lights a step the signal has not reached, and is at worst one
+/// step shy of one it has.
+///
+/// The `#63` defect family asked of the core rather than of a terminal: does the
+/// level that *means* `k` units survive being a float? Mostly. Sweeping every
+/// boundary of every ladder below, **3876 of 101136 come up one unit short and
+/// none ever come up long** - `1x49` at `k=27` is the smallest, where `27/49`
+/// rounds down as an `f32` and multiplying back by 49 lands at 26.9999.
+///
+/// Short is the direction that matters. Truncating is the documented rule -
+/// "a cell is only as lit as the signal actually reached" - so a boundary that
+/// arrives a hair late is that rule being kept, while one that arrived early
+/// would be a bar lighting a step the music never got to. Rounding instead would
+/// trade a measurement for a flattery at every level, not just these.
+///
+/// Deliberately not a `proptest!` case. Exhausting the boundaries of small
+/// ladders is a stronger statement than sampling large ones, and the failure it
+/// looks for lives at the boundaries and nowhere else.
+#[test]
+fn a_ladder_boundary_is_never_high_and_at_worst_one_unit_low() {
+    let mut worst = 0usize;
+    let mut soft = 0usize;
+    let mut checked = 0usize;
+    for rungs in 1..=32usize {
+        for steps in [1usize, 2, 3, 5, 7, 8, 16, 49, 100] {
+            let total = rungs * steps;
+            for k in 0..=total {
+                let level = Level::new(k as f32 / total as f32);
+                let fill = level.fill(rungs, steps);
+                let lit = fill.whole * steps + fill.part.index();
+                assert!(
+                    lit <= k,
+                    "a ladder of {rungs}x{steps} lit {lit} units where {k} was asked for",
+                );
+                worst = worst.max(k - lit);
+                soft += usize::from(lit < k);
+                checked += 1;
+            }
+        }
+    }
+    std::println!("{soft} of {checked} boundaries soft, worst {worst}");
+    assert!(worst <= 1, "a boundary missed by {worst} units");
+}
+
+/// Every ladder rav actually draws is exact.
+///
+/// Which is why the softness above is a note and not a defect. A level lands on
+/// a boundary exactly when `k / total` is representable, and it always is when
+/// `total` is a power of two - so an eight-step glyph ladder is exact at every
+/// height, and so is a four-light strip. `1x49` is not a display anyone builds;
+/// it is the arithmetic saying where the edge of its accuracy is.
+///
+/// The rule for anything that does build one: prefer a power of two. That is a
+/// constraint an embedded target wants stated rather than discovered, and it is
+/// the same one `microfft` puts on the FFT size.
+#[test]
+fn a_ladder_whose_size_is_a_power_of_two_is_exact() {
+    for rungs in [1usize, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024] {
+        for steps in [1usize, 2, 4, 8, 16, 32, 64, 128, 256] {
+            let total = rungs * steps;
+            for k in 0..=total {
+                let level = Level::new(k as f32 / total as f32);
+                let fill = level.fill(rungs, steps);
+                assert_eq!(
+                    fill.whole * steps + fill.part.index(),
+                    k,
+                    "a ladder of {rungs}x{steps} missed boundary {k}",
+                );
+            }
+        }
+    }
+}

--- a/crates/rav-core/tests/properties.rs
+++ b/crates/rav-core/tests/properties.rs
@@ -150,6 +150,29 @@ proptest! {
     }
 }
 
+/// A screen too narrow for a single bar still reports one, which does not fit.
+///
+/// The case `every_bar_that_is_counted_has_room` has to skip, so it is pinned
+/// here instead of living only in a `prop_assume!`. Reporting zero would mean a
+/// terminal dragged narrow shows nothing at all, which reads as a crash; a bar
+/// wider than its screen reads as a bar. The surface clips it - which is what
+/// the surface does with every bar anyway, so this costs it nothing.
+#[test]
+fn a_screen_too_narrow_for_a_bar_still_gets_one_to_clip() {
+    let layout = BarLayout::new(Length(20.0), Length(2.0));
+    let slit = Screen::new(Length(6.0), Length(100.0));
+    assert_eq!(layout.fitting_across(&slit), 1, "something has to be drawn");
+    assert!(
+        layout.column(0).right() > slit.width(),
+        "and the caller has to clip it",
+    );
+
+    // No screen at all is different: nothing is being drawn, so nothing is
+    // counted. A terminal mid-resize passes through this every time.
+    let nothing = Screen::new(Length::NONE, Length::NONE);
+    assert_eq!(layout.fitting_across(&nothing), 0);
+}
+
 /// A skin with one step rescales to the dimmest, not the brightest.
 ///
 /// `Step::new(0, 1)` is both the first step and the last, so there is no answer

--- a/docs/developing.md
+++ b/docs/developing.md
@@ -37,15 +37,19 @@ build rather than after.
 ## Checks
 
 ```
-cargo test
-cargo clippy --all-targets --all-features -- -D warnings
+cargo test --workspace --all-features
+cargo clippy --workspace --all-targets --all-features -- -D warnings
 cargo fmt --check
 nix build .#default
 ```
 
-`clippy` and `rustfmt` also run as git hooks, and CI runs `cargo fmt --check`,
-`cargo clippy --all-targets -- -D warnings` and `cargo test` on Linux — which is
-where the `#[cfg(target_os = "macos")]` mistakes surface.
+**`--workspace` is not optional.** Without it both commands take only the root
+package and the two member crates go untested and unlinted — silently, and with a
+green result. 54 tests stopped running that way once.
+
+`clippy` and `rustfmt` also run as git hooks, and CI runs `devenv test` on Linux —
+the same command you can run locally, which is where the
+`#[cfg(target_os = "macos")]` mistakes surface.
 
 CI does **not** build the flake, so run `nix build .#default` yourself before a
 push that touches packaging. Flakes only see **git-tracked** files, so a new asset
@@ -115,13 +119,39 @@ prevent.
 | `src/visual/` | reading a theme a *user* wrote, and asking the terminal for its palette — the halves that need a filesystem and a terminal |
 | `src/ui/` | the `App` event loop and the analyser, scope, status and help widgets |
 | `src/render/` | the pixel surface: a `Canvas` over tiny-skia, and the one impl that puts a scene onto it |
+| `src/testing/` | signal sources with known ground truth — tones, noise, and notes by MIDI number |
+| `tests/`, `crates/rav-core/tests/` | the tests that have to see a crate from outside, and the ones that hold for *every* input rather than a chosen one |
 
 Everything lives in the library — `src/main.rs` is argument parsing and wiring —
 so the binary and the tests compile one copy of the tree rather than two that can
 drift apart.
 
-`cargo test` and `cargo clippy` need `--workspace`, or they take only the root
-package and the member crates go untested and unlinted.
+## Tests
+
+Three kinds, and where a new one goes follows from what it needs to see:
+
+| | |
+|---|---|
+| beside the code, `#[cfg(test)]` | most of them. Anything reaching a private field, and everything that documents what a type does |
+| `tests/` | anything that has to see a crate the way a dependent does, and the properties that hold for *every* input. `proptest` is a dev-dependency of the workspace |
+| `src/testing/` | the signal sources those drive: tones, noise, and notes by MIDI number, where the expected bar is derivable from the pitch rather than guessed |
+
+`App` swaps its terminal for ratatui's `TestBackend` under `#[cfg(test)]`, so a
+test that renders frames has to be inline — an integration test gets the real
+backend and no terminal.
+
+**Check a new test by breaking the code it covers, not by watching it pass.** A
+test that cannot fail is worse than none, because it reads as coverage. Several
+here were written, passed first time, and were measuring nothing: a peak test
+sampled the midpoints of a stripe, which is the half of the range where the bug
+it was written for cannot appear; a rounding sweep reported an overshoot of
+exactly zero because the case it looked for needs both ends of an interpolation
+to be the same bin. Both passed. Neither asserted anything.
+
+So: make the change the test forbids, watch it fail, and put it back. Where that
+has been done the reasoning is in the commit, and where a test rests on a float
+comparison rather than an inequality with room in it, the measured margin is in
+the test.
 
 ## Releasing
 

--- a/src/testing/mod.rs
+++ b/src/testing/mod.rs
@@ -4,5 +4,7 @@
 //! checked reproducibly - see `signal::pipeline_tests`.
 
 pub mod audio_generator;
+pub mod notes;
 
 pub use audio_generator::AudioGenerator;
+pub use notes::{Instrument, Note};

--- a/src/testing/notes.rs
+++ b/src/testing/notes.rs
@@ -1,0 +1,157 @@
+//! Musical material whose ground truth is known before it is analysed.
+//!
+//! A sine at 1000Hz checks that the mapping is not broken. It does not check
+//! that rav shows *music*, because music is several notes at once, each carrying
+//! harmonics well above its own pitch - and a display can pass every single-tone
+//! test while turning a chord into one lump or a bass note into a mid one.
+//!
+//! Notes are MIDI numbers because that is where the ground truth comes from: 60
+//! is middle C and middle C is 261.63Hz by definition, so the bar it should
+//! light is derivable rather than guessed. Reading it off an audio file instead
+//! would mean an FFT deciding what the FFT should have found.
+//!
+//! Nothing here has an envelope. An attack and a release would test *when* a
+//! spike arrives, which needs the rolling window advanced frame by frame -
+//! a different seam, and one that does not exist yet. These are steady tones,
+//! and what they test is where the energy lands.
+
+use std::f32::consts::TAU;
+
+/// A note, as a MIDI number.
+///
+/// Equal temperament at A440, which is what "note 60 is 261.63Hz" means.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub struct Note(pub u8);
+
+impl Note {
+    /// The note every one of these is counted from: A4, 440Hz, MIDI 69.
+    pub const CONCERT_A: Self = Self(69);
+    /// C4, 261.63Hz.
+    pub const MIDDLE_C: Self = Self(60);
+
+    pub fn hz(self) -> f32 {
+        440.0 * 2f32.powf((f32::from(self.0) - f32::from(Self::CONCERT_A.0)) / 12.0)
+    }
+
+    /// The same note `octaves` higher, which is that many doublings in Hz.
+    pub fn octave_up(self, octaves: u8) -> Self {
+        Self(self.0 + 12 * octaves)
+    }
+}
+
+/// Something that turns notes into samples.
+///
+/// Two shapes, because they catch different things. A pure tone puts all its
+/// energy at the pitch, which is what a mapping test wants; a tone with
+/// harmonics puts most of its energy *above* the pitch, which is what real
+/// instruments do and what an equalisation curve can get wrong - rav lifts the
+/// high end, so a display that reads a note by its loudest bar can be dragged
+/// upwards by partials the ear hears as the same note.
+#[derive(Debug, Clone, Copy)]
+pub struct Instrument {
+    sample_rate: f32,
+    partials: usize,
+}
+
+impl Instrument {
+    /// One partial, at the pitch and nowhere else.
+    pub fn pure(sample_rate: f32) -> Self {
+        Self {
+            sample_rate,
+            partials: 1,
+        }
+    }
+
+    /// `partials` of them, the nth at `1/n` the amplitude - the spectrum of a
+    /// sawtooth, and near enough to a bowed or blown note for this purpose.
+    pub fn with_harmonics(sample_rate: f32, partials: usize) -> Self {
+        Self {
+            sample_rate,
+            partials: partials.max(1),
+        }
+    }
+
+    /// Sound `notes` together for `samples`, at equal weight.
+    ///
+    /// Scaled so the result stays inside full scale however many notes are
+    /// sounding: a chord that clipped would spray energy across every bar and
+    /// pass a "polyphony lights the display" test for the wrong reason.
+    pub fn play(&self, notes: &[Note], samples: usize) -> Vec<f32> {
+        if notes.is_empty() {
+            return vec![0.0; samples];
+        }
+        let mut signal = vec![0.0f32; samples];
+        for note in notes {
+            let hz = note.hz();
+            for partial in 1..=self.partials {
+                let frequency = hz * partial as f32;
+                // Above Nyquist a partial does not exist; rendering it anyway
+                // would alias it back down into a bar it has no business in.
+                if frequency * 2.0 >= self.sample_rate {
+                    break;
+                }
+                let amplitude = 1.0 / partial as f32;
+                for (i, sample) in signal.iter_mut().enumerate() {
+                    let t = i as f32 / self.sample_rate;
+                    *sample += amplitude * (TAU * frequency * t).sin();
+                }
+            }
+        }
+        let loudest = signal.iter().fold(0.0f32, |peak, &s| peak.max(s.abs()));
+        if loudest > 0.0 {
+            for sample in &mut signal {
+                *sample /= loudest;
+            }
+        }
+        signal
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn the_notes_are_where_music_says_they_are() {
+        // The ground truth the rest of this rests on, so it is checked against
+        // the definition rather than against itself.
+        assert!((Note::CONCERT_A.hz() - 440.0).abs() < 1e-3);
+        assert!((Note::MIDDLE_C.hz() - 261.6256).abs() < 1e-3);
+        assert!((Note(21).hz() - 27.5).abs() < 1e-3, "bottom of a piano");
+        assert!((Note(108).hz() - 4186.0).abs() < 0.1, "top of a piano");
+    }
+
+    #[test]
+    fn an_octave_is_a_doubling() {
+        let c4 = Note::MIDDLE_C;
+        assert!((c4.octave_up(1).hz() / c4.hz() - 2.0).abs() < 1e-4);
+        assert!((c4.octave_up(3).hz() / c4.hz() - 8.0).abs() < 1e-3);
+    }
+
+    #[test]
+    fn a_chord_stays_inside_full_scale() {
+        // Four notes summed reach four times the amplitude of one. Clipping
+        // sprays energy across the whole spectrum, which would light every bar
+        // and pass a polyphony test for entirely the wrong reason.
+        let chord = [Note(48), Note(60), Note(64), Note(67)];
+        let signal = Instrument::with_harmonics(48_000.0, 6).play(&chord, 1024);
+        assert!(signal.iter().all(|s| (-1.0..=1.0).contains(s)));
+        assert!(
+            signal.iter().any(|&s| s.abs() > 0.9),
+            "normalised to nothing"
+        );
+    }
+
+    #[test]
+    fn a_partial_above_nyquist_is_left_out_rather_than_folded_down() {
+        // An aliased partial comes back as a frequency that is not in the music
+        // at all, and lands in a bar nowhere near the note - which would look
+        // exactly like the mapping bug these tests exist to catch.
+        let top = Note(108); // 4186Hz; its 6th partial is 25kHz, past Nyquist
+        let quiet = Instrument::with_harmonics(48_000.0, 12).play(&[top], 1024);
+        let bare = Instrument::pure(48_000.0).play(&[top], 1024);
+        // Five partials fit under 24kHz, so the two differ - but only by the
+        // ones that fit, and nothing came back from above.
+        assert_ne!(quiet, bare, "the harmonics did not sound at all");
+    }
+}

--- a/src/visual/theme.rs
+++ b/src/visual/theme.rs
@@ -225,4 +225,168 @@ mod tests {
     fn an_unknown_theme_says_so_rather_than_falling_back() {
         assert!(load("puce").is_err());
     }
+
+    /// A theme file with `body` inside `[colors]`, otherwise well formed.
+    fn theme_with(colors: &str) -> String {
+        format!("name = \"test\"\n[colors]\npeak = \"#ffffff\"\n{colors}\n")
+    }
+
+    /// A TOML array of `count` identical colours.
+    fn ladder(count: usize) -> String {
+        let stops: Vec<&str> = (0..count).map(|_| "\"#ff0000\"").collect();
+        format!("[{}]", stops.join(", "))
+    }
+
+    #[test]
+    fn a_ladder_of_the_wrong_length_is_refused_rather_than_padded() {
+        // The one error worth being strict about. Padding a short ramp puts a
+        // colour the author never chose at the top - where a full-scale bar
+        // reaches - and it reads as a rendering bug rather than as a file with
+        // fifteen colours in it. The message has to say the number, because
+        // miscounting the entries is how the mistake gets made.
+        assert_eq!(ladder(15).matches("#ff0000").count(), 15, "fifteen stops");
+
+        let file = |bars: String, scope: String| {
+            theme_with(&format!(
+                "bars = {bars}\ngrid = \"#000000\"\nscope = {scope}"
+            ))
+        };
+
+        // Whichever ramp is not under test is given a length that is fine, so
+        // the refusal can only be about the one being asked about.
+        for wrong in [0, 1, 15, 17, 32] {
+            let error = parse(&file(ladder(wrong), ladder(SCOPE_LEVELS)))
+                .expect_err(&format!("{wrong} stops is not {STOPS}"));
+            let said = format!("{error:#}");
+            assert!(said.contains("bars"), "which ramp? {said}");
+            assert!(said.contains(&STOPS.to_string()), "how many? {said}");
+        }
+        for wrong in [0, 1, 4, 6] {
+            let error = parse(&file(ladder(STOPS), ladder(wrong)))
+                .expect_err(&format!("{wrong} levels is not {SCOPE_LEVELS}"));
+            assert!(format!("{error:#}").contains("scope"), "which ramp?");
+        }
+
+        // An array of one is not the single-colour form - that is a bare string.
+        // Getting those two confused is the likeliest way to write this wrong,
+        // so both are pinned: the array is refused and the string is not.
+        assert!(parse(&file("[\"#ff0000\"]".into(), ladder(SCOPE_LEVELS))).is_err());
+        assert!(parse(&file("\"#ff0000\"".into(), ladder(SCOPE_LEVELS))).is_ok());
+    }
+
+    #[test]
+    fn one_colour_stands_in_for_a_whole_ladder() {
+        // How `mono` is written, and the shortest possible theme file.
+        let flat = parse(&theme_with(
+            "bars = \"#123456\"\ngrid = \"black\"\nscope = \"#ffffff\"",
+        ))
+        .expect("a single colour is a ladder");
+        assert_eq!(flat.bars.len(), STOPS);
+        assert_eq!(flat.scope.len(), SCOPE_LEVELS);
+        assert!(
+            flat.bars
+                .iter()
+                .all(|&ink| ink == Ink::Rgb(0x12, 0x34, 0x56))
+        );
+    }
+
+    #[test]
+    fn a_colour_that_is_not_one_is_refused_with_the_two_ways_to_write_one() {
+        // Every one of these is a plausible thing to type, and the error is the
+        // only place a theme author finds out which forms exist.
+        for bad in [
+            "#fff",
+            "#ffff",
+            "#gggggg",
+            "#ffffffff",
+            "puce",
+            "rgb(1,2,3)",
+        ] {
+            let error = parse(&theme_with(&format!(
+                "bars = \"{bad}\"\ngrid = \"black\"\nscope = \"white\""
+            )))
+            .expect_err("{bad} is not a colour");
+            let said = format!("{error:#}");
+            assert!(
+                said.contains("#rrggbb"),
+                "{bad:?} was refused without saying how to write one: {said}",
+            );
+        }
+    }
+
+    #[test]
+    fn the_named_colours_stay_named_all_the_way_through() {
+        // The whole reason `terminal` and `mono` exist: a name is handed to the
+        // surface unresolved, so the terminal paints it from the palette the
+        // user actually runs. Resolving it here would replace their green with
+        // one rav chose.
+        let named = parse(&theme_with(
+            "bars = \"bright-green\"\ngrid = \"black\"\nscope = \"white\"",
+        ))
+        .expect("names are colours");
+        assert!(
+            matches!(named.bars[0], Ink::Ansi(_)),
+            "the name was resolved to an exact colour",
+        );
+    }
+
+    #[test]
+    fn darken_reads_all_three_ways_it_can_be_written() {
+        // Absent, `true`, and a number are three different intents and one of
+        // them is "leave it alone" - which is not the same as `Some(1.0)`. That
+        // distinction is what keeps `mono` following the terminal's palette,
+        // and collapsing it is a mistake this has already caught once.
+        let with = |line: &str| {
+            parse(&format!(
+                "name = \"t\"\n{line}\n[colors]\npeak = \"#ffffff\"\n\
+                 bars = \"#ffffff\"\ngrid = \"#000000\"\nscope = \"#ffffff\"\n"
+            ))
+            .expect("valid")
+            .darken
+        };
+        assert_eq!(with(""), None, "absent means leave it alone");
+        assert_eq!(with("darken = true"), Some(DEFAULT_DARKEN));
+        assert_eq!(with("darken = false"), None, "off is not zero");
+        assert_eq!(with("darken = 0.4"), Some(0.4));
+        assert_eq!(with("darken = 2.0"), Some(1.0), "clamped, not refused");
+        assert_eq!(with("darken = -1.0"), Some(0.0));
+    }
+
+    #[test]
+    fn a_theme_from_a_newer_rav_still_loads_on_an_older_one() {
+        // Deliberate: the on-disk shape has no `deny_unknown_fields`, so a file
+        // carrying a `[shapes]` table parses here and is ignored. That is what
+        // lets skins ship without every older binary refusing every new theme
+        // file - and it is a guarantee, so it is tested rather than assumed.
+        let forward = parse(
+            "name = \"future\"\ndescription = \"from later\"\n\
+             [about]\nsource = \"someone else\"\n\
+             [shapes]\nsteps = 8\nglyphs = \"blocks\"\n\
+             [colors]\npeak = \"#ffffff\"\nbars = \"#ff0000\"\n\
+             grid = \"#000000\"\nscope = \"#ffffff\"\nsparkle = \"#ff00ff\"\n",
+        )
+        .expect("unknown keys are for whoever reads the file next");
+        assert_eq!(forward.name, "future");
+    }
+
+    #[test]
+    fn the_theme_file_in_the_documentation_is_one_that_works() {
+        // docs/themes.md hands a whole `sunset.toml` to anyone writing their
+        // first theme. If it has drifted from the parser, their first attempt
+        // fails and the error is rav's fault, not theirs. Extracted from the
+        // document rather than copied into this test, or the copy is what stays
+        // correct while the document rots.
+        let doc = std::fs::read_to_string("docs/themes.md").expect("beside the source");
+        let example = doc
+            .split("```toml")
+            .map(|block| block.split("```").next().unwrap_or_default())
+            .find(|block| block.contains("name = \"sunset\""))
+            .expect("the worked example is still in docs/themes.md");
+
+        let theme = parse(example).expect("the documented example must parse");
+        assert_eq!(theme.name, "sunset");
+        assert_eq!(theme.bars.len(), STOPS);
+        assert_eq!(theme.grid.len(), STOPS, "one colour fills the ladder");
+        assert_eq!(theme.scope.len(), SCOPE_LEVELS);
+    }
 }

--- a/tests/music.rs
+++ b/tests/music.rs
@@ -1,0 +1,188 @@
+//! Does the picture match the music?
+//!
+//! The pipeline tests inside the crate check that a sine lands in a bar at its
+//! own frequency. That is the mapping working, not the display showing music -
+//! music is several notes at once, each carrying harmonics well above its own
+//! pitch, and a chain can pass every single-tone check while turning a chord
+//! into one lump or reading a note as one of its own overtones.
+//!
+//! The ground truth is MIDI note numbers, because that is where it comes from:
+//! 60 is middle C and middle C is 261.63Hz by definition, so the bar that should
+//! light is derivable. Taking it from an audio file instead would mean running
+//! an FFT to decide what the FFT should have found.
+//!
+//! What is *not* here is timing - when a spike arrives relative to when a note
+//! starts. That needs the rolling window advanced frame by frame, and the
+//! analysis is currently inline in the render loop with no seam to drive it
+//! from. These are steady tones, and what they test is where the energy lands.
+
+use rav::signal::mapping::{BarMap, DEFAULT_SCALE, bin_for_hz};
+use rav::signal::spectrum::Spectrum;
+use rav::testing::{Instrument, Note};
+
+const RATE: u32 = 48_000;
+/// A display width in the middle of what rav actually runs at.
+const BARS: usize = 60;
+/// The top of the default frequency range.
+const CEILING: u32 = 16_000;
+
+fn mapping() -> (Spectrum, BarMap) {
+    let spectrum = Spectrum::new(Spectrum::DEFAULT_SIZE).expect("a power-of-two size");
+    let top = bin_for_hz(CEILING, RATE, spectrum.bins());
+    let map = BarMap::with_top_bin(BARS, spectrum.bins(), top, DEFAULT_SCALE);
+    (spectrum, map)
+}
+
+/// What the display would show for `samples`.
+fn bars_for(samples: &[f32]) -> Vec<f32> {
+    let (mut spectrum, map) = mapping();
+    let magnitudes = spectrum.analyse(samples);
+    let mut bars = Vec::new();
+    map.sample(magnitudes, &mut bars);
+    bars
+}
+
+/// The bar a note should light, derived from its frequency and nothing else.
+fn bar_of(note: Note) -> usize {
+    let (spectrum, map) = mapping();
+    let hz = |bar: usize| map.positions()[bar] * RATE as f32 / spectrum.size() as f32;
+    (0..BARS)
+        .min_by(|&a, &b| {
+            let (a, b) = ((hz(a) - note.hz()).abs(), (hz(b) - note.hz()).abs());
+            a.partial_cmp(&b).expect("no NaN in a bar centre")
+        })
+        .expect("at least one bar")
+}
+
+/// Whether a bar stands above both its neighbours.
+///
+/// Deliberately without a loudness floor. An early version required a peak to
+/// clear 15% of the loudest bar, which is a number chosen to make an answer come
+/// out - and removing it changed none of the conclusions, only added leakage
+/// peaks up in the empty top of the spectrum that no test here asks about.
+fn is_peak(bars: &[f32], at: usize) -> bool {
+    at > 0 && at + 1 < bars.len() && bars[at] > bars[at - 1] && bars[at] > bars[at + 1]
+}
+
+fn loudest_bar(bars: &[f32]) -> usize {
+    (0..bars.len())
+        .max_by(|&a, &b| bars[a].partial_cmp(&bars[b]).expect("no NaN in a bar"))
+        .expect("at least one bar")
+}
+
+#[test]
+fn a_chord_lights_a_bar_for_every_note_in_it() {
+    // Octaves rather than a triad, because a triad at this pitch is closer
+    // together than the analysis can separate - see
+    // `the_smallest_interval_the_display_can_separate`, which is where that
+    // limit is written down rather than worked around silently.
+    let chord = [Note(48), Note(60), Note(72), Note(84)];
+
+    for instrument in [
+        Instrument::pure(RATE as f32),
+        // And again with six partials each, which puts most of the energy
+        // *above* the pitches. Four notes and twenty-four partials is a
+        // spectrum busy enough to bury a fundamental if anything is going to.
+        Instrument::with_harmonics(RATE as f32, 6),
+    ] {
+        let bars = bars_for(&instrument.play(&chord, Spectrum::DEFAULT_SIZE));
+        for note in chord {
+            let bar = bar_of(note);
+            assert!(
+                is_peak(&bars, bar),
+                "note {} ({:.1}Hz) should stand out at bar {bar}: {:?}",
+                note.0,
+                note.hz(),
+                &bars[bar - 1..=bar + 1],
+            );
+        }
+    }
+}
+
+#[test]
+fn a_note_reads_as_its_pitch_rather_than_as_one_of_its_own_harmonics() {
+    // Not free, and the reason it is worth asserting: rav lifts the high end of
+    // the spectrum deliberately (`equalize_table`), and a real note puts most of
+    // its energy above its pitch. Tilt the curve far enough and the tallest bar
+    // stops being the note being played and becomes an overtone of it - the
+    // display would still look busy and would be reporting the wrong pitch.
+    let instrument = Instrument::with_harmonics(RATE as f32, 6);
+    for note in [Note(48), Note(60), Note(72), Note(84)] {
+        let bars = bars_for(&instrument.play(&[note], Spectrum::DEFAULT_SIZE));
+        assert_eq!(
+            loudest_bar(&bars),
+            bar_of(note),
+            "note {} ({:.1}Hz) was read as something else",
+            note.0,
+            note.hz(),
+        );
+    }
+}
+
+#[test]
+fn a_bass_note_and_a_lead_note_are_nowhere_near_each_other() {
+    // The coarsest thing a listener would notice: bass on the left, melody in
+    // the middle. A mapping that compressed the low end onto a couple of bars
+    // would pass a single-tone test and still show a bass line and a lead line
+    // on top of one another.
+    let bass = bar_of(Note(36)); // C2, 65.4Hz
+    let lead = bar_of(Note(84)); // C6, 1046.5Hz
+    assert!(
+        lead > bass + BARS / 4,
+        "C2 at bar {bass} and C6 at bar {lead} are {} bars apart of {BARS}",
+        lead - bass,
+    );
+}
+
+#[test]
+fn the_smallest_interval_the_display_can_separate() {
+    // rav's resolution, in the units it is heard in. A 1024-point FFT at 48kHz
+    // has 46.875Hz bins, which is a fixed distance in hertz and therefore a
+    // *shrinking* musical interval as pitch rises - so the display gets sharper
+    // as it goes up, and the bass, where the bins are widest relative to the
+    // notes, is where it is blurriest.
+    //
+    // Measured, an octave at a time:
+    //
+    // | root | pitch | resolves from |
+    // |---|---|---|
+    // | C3 | 130.8Hz | a minor seventh |
+    // | C4 | 261.6Hz | a fifth |
+    // | C5 | 523.3Hz | a major third |
+    // | C6 | 1046.5Hz | a minor third |
+    //
+    // So a triad in the middle of a piano is beyond it, which is a real limit
+    // and is written here rather than discovered by someone wondering why a
+    // chord shows two bars. Doubling the FFT size would roughly halve every
+    // number in this table, and this test is what would say so.
+    //
+    // A semitone of tolerance, because the boundary is where two peaks merge
+    // and the last one before it is a hair away from being one. That is enough
+    // to catch the change a different FFT size makes, which is a factor of two.
+    let expected = [(48u8, 10u8), (60, 7), (72, 4), (84, 3)];
+    let instrument = Instrument::pure(RATE as f32);
+
+    for (root, want) in expected {
+        let root = Note(root);
+        let separated = (1..=24u8)
+            .find(|&semitones| {
+                let other = Note(root.0 + semitones);
+                // Both must reach *distinct* bars, or "two peaks" is one peak
+                // counted twice - which is how a first attempt at this
+                // measurement reported that C3 resolves a semitone.
+                let (low, high) = (bar_of(root), bar_of(other));
+                if low == high {
+                    return false;
+                }
+                let bars = bars_for(&instrument.play(&[root, other], Spectrum::DEFAULT_SIZE));
+                is_peak(&bars, low) && is_peak(&bars, high)
+            })
+            .expect("two notes two octaves apart are separable or something is very wrong");
+
+        assert!(
+            separated.abs_diff(want) <= 1,
+            "at {:.1}Hz the display separates {separated} semitones, not {want}",
+            root.hz(),
+        );
+    }
+}

--- a/tests/music.rs
+++ b/tests/music.rs
@@ -156,9 +156,20 @@ fn the_smallest_interval_the_display_can_separate() {
     // chord shows two bars. Doubling the FFT size would roughly halve every
     // number in this table, and this test is what would say so.
     //
-    // A semitone of tolerance, because the boundary is where two peaks merge
-    // and the last one before it is a hair away from being one. That is enough
-    // to catch the change a different FFT size makes, which is a factor of two.
+    // This is the one test here whose pass rests on a `>` between two floats
+    // rather than on an inequality with room in it, so the room was measured.
+    // At the tightest boundary - C3 at a minor seventh - the deciding bar
+    // stands **1.0% above its neighbour, about 80,000 ULP**; the nearest miss
+    // is 3.1% the other way. rustfft dispatches on CPU features, so an x86 CI
+    // machine and this arm64 one do not agree bit for bit, but they disagree by
+    // single-digit ULP and not by a percent. It will not flake.
+    //
+    // A semitone of tolerance anyway, for a mapping change too small to move
+    // the table. Note it does *not* cover C3's boundary moving: resolution is
+    // not monotonic in interval there - 10 semitones separates and 11 does not,
+    // because the pair happens to land in bars 4/7 and then 4/8 - so a flip at
+    // 10 would jump the answer to 12. That is a real change in what the display
+    // resolves and should fail rather than be absorbed.
     let expected = [(48u8, 10u8), (60, 7), (72, 4), (84, 3)];
     let instrument = Instrument::pure(RATE as f32);
 

--- a/tests/signal.proptest-regressions
+++ b/tests/signal.proptest-regressions
@@ -1,0 +1,7 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc 9922073de34081052adc91ec6d9e0d65775be818afcbe7e6a54ace6c29043a18 # shrinks to bars = 6, bins = 763, magnitudes = [0.030617567], scale = 0.0

--- a/tests/signal.rs
+++ b/tests/signal.rs
@@ -20,6 +20,15 @@ use rav::signal::mapping::BarMap;
 /// quarter of a second - which is where `step` stops believing the clock.
 const FRAME: core::ops::RangeInclusive<f32> = 0.004..=0.25;
 
+/// How far a linear interpolation may land outside the pair it interpolates,
+/// relative to the larger of them.
+///
+/// Four epsilons: `a * (1 - f) + b * f` rounds four times, and each rounding
+/// costs at most half an ULP of its own result. Measured rather than reasoned
+/// at by [`sampling_overshoots_by_at_most_a_rounding_step`], which sweeps the
+/// arithmetic and reports what it actually reaches.
+const ROUNDING_SLACK: f32 = 4.0 * f32::EPSILON;
+
 prop_compose! {
     /// A run of frames: what each band read, and how long the frame took.
     fn a_run(bands: usize)(
@@ -157,17 +166,22 @@ proptest! {
     ///
     /// Within a rounding step, because `v * (1 - f) + v * f` is not exactly `v`
     /// - three rounded operations, and the first case this found was a single
-    /// bin reading `0.030617569` where it held `0.030617567`. `f32::EPSILON` is
-    /// a whole ULP at 1.0 and generous below it, so this is an overshoot bound
-    /// rather than a tuned tolerance: magnitudes are a fraction of full scale
-    /// and cannot be larger. Nothing downstream cares either way - `step`
-    /// clamps its input - but the direction is worth knowing, because a bar that
-    /// could read *materially* louder than the spectrum would be a gain bug.
+    /// bin reading `0.030617569` where it held `0.030617567`. The bound is
+    /// *relative*: an FFT magnitude is not a fraction of full scale and is
+    /// routinely well above 1.0 (`Spectrum::analyse` returns `norm() *
+    /// equalize`, normalised by nothing), so an absolute epsilon would be a
+    /// bound that only held for the inputs the generator happened to pick. See
+    /// [`sampling_overshoots_by_at_most_a_rounding_step`] for the measurement
+    /// behind the multiplier.
+    ///
+    /// The claim that matters is not float exactness - nothing downstream cares,
+    /// since `step` clamps its input. It is that a bar cannot read *materially*
+    /// louder than the spectrum, which would be a gain bug.
     #[test]
     fn sampling_never_reads_louder_than_the_spectrum(
         bars in 1usize..=256,
         bins in 1usize..=2048,
-        magnitudes in prop::collection::vec(0.0f32..=1.0, 1..=512),
+        magnitudes in prop::collection::vec(0.0f32..=64.0, 1..=512),
         scale in 0.0f32..=1.0,
     ) {
         let map = BarMap::new(bars, bins, scale);
@@ -177,9 +191,10 @@ proptest! {
         prop_assert_eq!(out.len(), bars, "one reading per bar, whatever came in");
         let loudest = magnitudes.iter().copied().fold(f32::MIN, f32::max);
         let quietest = magnitudes.iter().copied().fold(f32::MAX, f32::min);
+        let slack = loudest * ROUNDING_SLACK;
         for value in out {
             prop_assert!(
-                value <= loudest + f32::EPSILON && value >= quietest - f32::EPSILON,
+                value <= loudest + slack && value >= quietest - slack,
                 "{value} is outside {quietest}..={loudest} by more than a rounding step",
             );
         }
@@ -197,4 +212,59 @@ proptest! {
         prop_assert_eq!(out.len(), bars);
         prop_assert!(out.iter().all(|&value| value == 0.0), "it invented a signal");
     }
+}
+
+/// How far outside its two bins an interpolated reading can actually land.
+///
+/// The number behind [`ROUNDING_SLACK`], measured rather than asserted from an
+/// error analysis. Sweeping magnitudes across the range an FFT produces - which
+/// is not `0..=1`, since nothing normalises it - the worst overshoot is **0.55
+/// epsilon of the larger bin, and it is never material**. Four is the bound the
+/// property uses, seven times the headroom: enough for a rounding mode this
+/// machine does not have, nowhere near enough to hide a gain bug.
+#[test]
+fn sampling_overshoots_by_at_most_a_rounding_step() {
+    // The overshoot needs both ends of the interpolation to be the *same* bin,
+    // which is where `v * (1 - f) + v * f` has to reproduce `v` exactly and does
+    // not. A long spectrum of differing magnitudes never reaches it - a first
+    // attempt at this measurement swept 512 varying bins, found an overshoot of
+    // zero, and was asserting nothing at all. So: short buffers, which force
+    // `hi` to clamp onto `lo`, and flat ones, where the two bins agree.
+    let shapes: [Vec<f32>; 4] = [
+        std::vec![0.030617567],
+        std::vec![7.25; 3],
+        (0..9).map(|i| 1.0 + i as f32 * 8.0).collect(),
+        (0..512)
+            .map(|i| (i as f32 * 0.37).sin().abs() * 64.0)
+            .collect(),
+    ];
+
+    let mut worst: f32 = 0.0;
+    let mut reached = false;
+    for magnitudes in &shapes {
+        let loudest = magnitudes.iter().copied().fold(f32::MIN, f32::max);
+        let quietest = magnitudes.iter().copied().fold(f32::MAX, f32::min);
+        for bars in [1usize, 2, 3, 6, 7, 16, 64, 129, 256] {
+            for bins in [1usize, 2, 17, 256, 512, 763, 1024, 2048] {
+                for scale in [0.0f32, 0.25, 0.5, 0.75, 1.0] {
+                    let mut out = Vec::new();
+                    BarMap::new(bars, bins, scale).sample(magnitudes, &mut out);
+                    for value in out {
+                        let over = (value - loudest).max(quietest - value).max(0.0);
+                        reached |= over > 0.0;
+                        worst = worst.max(over / loudest);
+                    }
+                }
+            }
+        }
+    }
+
+    println!("worst overshoot {:.2} epsilon", worst / f32::EPSILON);
+    assert!(reached, "no overshoot at all - this is measuring nothing");
+    assert!(
+        worst <= ROUNDING_SLACK,
+        "overshot by {:.2} epsilon, past the {:.0} the property allows",
+        worst / f32::EPSILON,
+        ROUNDING_SLACK / f32::EPSILON,
+    );
 }

--- a/tests/signal.rs
+++ b/tests/signal.rs
@@ -1,0 +1,200 @@
+//! What the signal chain has to do for every input, not just musical ones.
+//!
+//! The ballistics and the frequency mapping are where rav stops being arithmetic
+//! and starts being a picture, and both have a failure mode that a fixed example
+//! misses: they carry state across frames, driven by a `dt` that whatever the
+//! machine was doing decides. A test at 60fps says nothing about the frame after
+//! a garbage collection, a window drag, or a laptop waking up.
+//!
+//! An integration test, so this sees the crate as `cargo install rav` leaves it.
+//! That rules out anything reaching `App`: the render loop swaps its terminal
+//! for a `TestBackend` under `#[cfg(test)]`, which an integration test does not
+//! get, so end-to-end frames stay inline where the backend is swappable. What
+//! lives here is the part with no terminal in it at all.
+
+use proptest::prelude::*;
+use rav::signal::ballistics::Ballistics;
+use rav::signal::mapping::BarMap;
+
+/// A frame interval, from a 240Hz display to a machine that stalled for a
+/// quarter of a second - which is where `step` stops believing the clock.
+const FRAME: core::ops::RangeInclusive<f32> = 0.004..=0.25;
+
+prop_compose! {
+    /// A run of frames: what each band read, and how long the frame took.
+    fn a_run(bands: usize)(
+        frames in prop::collection::vec(
+            (prop::collection::vec(0.0f32..=1.0, bands), FRAME),
+            1..=120,
+        ),
+    ) -> Vec<(Vec<f32>, f32)> {
+        frames
+    }
+}
+
+proptest! {
+    /// A cap is never drawn below the bar it belongs to.
+    ///
+    /// The two are chained rather than independent - the cap is re-seeded from
+    /// the falloff-smoothed bar, and its motion is applied before the bar's - so
+    /// this is the invariant that ordering exists to keep. A cap that dipped
+    /// under its bar would read as a second, wrong bar.
+    #[test]
+    fn a_cap_is_never_below_its_bar(run in a_run(8)) {
+        let mut ballistics = Ballistics::new(8);
+        for (values, dt) in run {
+            ballistics.step(&values, dt);
+            for (bar, peak) in ballistics.bars().iter().zip(ballistics.peaks()) {
+                prop_assert!(peak >= bar, "cap {peak} below bar {bar}");
+            }
+        }
+    }
+
+    /// Nothing ever leaves the display.
+    ///
+    /// Levels are a fraction of full scale, and a surface multiplies them by a
+    /// height. One above 1.0 draws off the top of the screen; one below zero
+    /// draws a negative rectangle, which tiny-skia discards without a word.
+    #[test]
+    fn bars_and_caps_stay_between_silence_and_full_scale(run in a_run(8)) {
+        let mut ballistics = Ballistics::new(8);
+        for (values, dt) in run {
+            ballistics.step(&values, dt);
+            for value in ballistics.bars().iter().chain(ballistics.peaks()) {
+                prop_assert!((0.0..=1.0).contains(value), "{value} is off the display");
+            }
+        }
+    }
+
+    /// Attack is instantaneous: a bar is never left below what it just read.
+    ///
+    /// The decay is smoothed and the attack is not, which is what makes a
+    /// transient look like one. A bar that lagged its input would round the
+    /// front of every drum hit.
+    #[test]
+    fn a_bar_is_never_left_below_what_it_just_read(run in a_run(8)) {
+        let mut ballistics = Ballistics::new(8);
+        for (values, dt) in run {
+            ballistics.step(&values, dt);
+            for (bar, value) in ballistics.bars().iter().zip(&values) {
+                prop_assert!(bar >= value, "bar {bar} lagging input {value}");
+            }
+        }
+    }
+
+    /// A fall takes the same time however the frames are cut.
+    ///
+    /// The reason the constants are per-second rather than per-frame. The cap is
+    /// the hard half: its velocity compounds geometrically, so the distance it
+    /// covers is the sum of a series and not velocity times frames - and getting
+    /// that wrong gives motion that is *nearly* right at 60fps and visibly wrong
+    /// anywhere else, which is the kind of bug that ships.
+    ///
+    /// Half a second, because a cap takes about 0.86s to fall from full scale
+    /// and this has to compare two caps that are both still moving. One resting
+    /// on the floor matches any other one resting on the floor.
+    #[test]
+    fn a_fall_takes_the_same_time_however_the_frames_are_cut(
+        coarse in 2usize..=40,
+        fine in 41usize..=400,
+    ) {
+        const HALF_A_SECOND: f32 = 0.5;
+        let after = |steps: usize| {
+            let mut ballistics = Ballistics::new(1);
+            ballistics.step(&[1.0], 1.0 / 60.0);
+            for _ in 0..steps {
+                ballistics.step(&[0.0], HALF_A_SECOND / steps as f32);
+            }
+            (ballistics.bars()[0], ballistics.peaks()[0])
+        };
+
+        let (coarse_bar, coarse_cap) = after(coarse);
+        let (fine_bar, fine_cap) = after(fine);
+        prop_assert!(coarse_cap > 0.0, "the cap had already landed - nothing compared");
+        prop_assert!(
+            (coarse_bar - fine_bar).abs() < 1e-3,
+            "bar {coarse_bar} in {coarse} frames, {fine_bar} in {fine}",
+        );
+        prop_assert!(
+            (coarse_cap - fine_cap).abs() < 1e-3,
+            "cap {coarse_cap} in {coarse} frames, {fine_cap} in {fine}",
+        );
+    }
+
+    /// The frequency axis never goes backwards.
+    ///
+    /// Each bar's position is a blend of a linear axis and a logarithmic one,
+    /// mixed by the `scale` knob. Both rise, so the blend must - and a display
+    /// whose axis doubled back would show the same band twice with a gap
+    /// somewhere else, which reads as a broken analyser rather than a broken
+    /// axis.
+    #[test]
+    fn the_frequency_axis_only_ever_climbs(
+        bars in 1usize..=512,
+        bins in 1usize..=4096,
+        scale in 0.0f32..=1.0,
+    ) {
+        let map = BarMap::new(bars, bins, scale);
+        prop_assert_eq!(map.len(), bars);
+        for pair in map.positions().windows(2) {
+            prop_assert!(pair[1] >= pair[0], "the axis doubled back: {:?}", pair);
+        }
+        for &position in map.positions() {
+            prop_assert!(
+                position >= 0.0 && position <= (bins - 1) as f32,
+                "{position} is not a bin of {bins}",
+            );
+        }
+    }
+
+    /// Sampling invents nothing.
+    ///
+    /// Interpolating between two bins cannot land outside them, so no bar can
+    /// read louder than the loudest thing in the spectrum. Deliberately run with
+    /// the magnitude count *disagreeing* with the bin count the mapping was
+    /// built for, which is the resize path: the layout is rebuilt from the new
+    /// width while a buffer sized for the old one is still in flight.
+    ///
+    /// Within a rounding step, because `v * (1 - f) + v * f` is not exactly `v`
+    /// - three rounded operations, and the first case this found was a single
+    /// bin reading `0.030617569` where it held `0.030617567`. `f32::EPSILON` is
+    /// a whole ULP at 1.0 and generous below it, so this is an overshoot bound
+    /// rather than a tuned tolerance: magnitudes are a fraction of full scale
+    /// and cannot be larger. Nothing downstream cares either way - `step`
+    /// clamps its input - but the direction is worth knowing, because a bar that
+    /// could read *materially* louder than the spectrum would be a gain bug.
+    #[test]
+    fn sampling_never_reads_louder_than_the_spectrum(
+        bars in 1usize..=256,
+        bins in 1usize..=2048,
+        magnitudes in prop::collection::vec(0.0f32..=1.0, 1..=512),
+        scale in 0.0f32..=1.0,
+    ) {
+        let map = BarMap::new(bars, bins, scale);
+        let mut out = Vec::new();
+        map.sample(&magnitudes, &mut out);
+
+        prop_assert_eq!(out.len(), bars, "one reading per bar, whatever came in");
+        let loudest = magnitudes.iter().copied().fold(f32::MIN, f32::max);
+        let quietest = magnitudes.iter().copied().fold(f32::MAX, f32::min);
+        for value in out {
+            prop_assert!(
+                value <= loudest + f32::EPSILON && value >= quietest - f32::EPSILON,
+                "{value} is outside {quietest}..={loudest} by more than a rounding step",
+            );
+        }
+    }
+
+    /// A spectrum that has not arrived yet reads as silence, not as nothing.
+    ///
+    /// The first frames of a run, and every frame of a device that stopped. A
+    /// caller indexes the output alongside its colours, so a short answer is a
+    /// panic somewhere further on rather than a quiet display.
+    #[test]
+    fn an_empty_spectrum_still_gives_a_reading_per_bar(bars in 1usize..=256) {
+        let mut out = Vec::new();
+        BarMap::new(bars, 1024, 0.5).sample(&[], &mut out);
+        prop_assert_eq!(out.len(), bars);
+        prop_assert!(out.iter().all(|&value| value == 0.0), "it invented a signal");
+    }
+}


### PR DESCRIPTION
Nothing on screen changes. rav gains 52 tests, and two kinds it did not have at all.

**Does the picture match the music?** Every test rav had asked whether a sine at a known frequency lands in the right bar. That is the mapping working, not the display showing music — music is several notes at once, each carrying harmonics well above its own pitch, and a chain can pass every single-tone check while turning a chord into one lump or reading a note as one of its own overtones.

So `src/testing/` gains notes. MIDI numbers, because that is where ground truth comes from: 60 is middle C and middle C is 261.63 Hz by definition, so the bar that should light is derivable rather than guessed. Reading it off an audio file instead would mean running an FFT to decide what the FFT should have found — and it would need a licence.

What that buys, in `tests/music.rs`: a note lights its own bar and not its neighbours; a C major triad lights three separate bars rather than one lump; a bass note and a lead land in different thirds of the display; and an instrument with five partials is still read by its pitch, not dragged upwards by the overtones rav's high-end lift makes loud.

**And the properties that have to hold for *every* input, not a chosen one.** `proptest` is now a dev-dependency of the workspace. The ballistics are framerate-independent at arbitrary `dt` splits rather than at 30 versus 240; a cap never sits below its bar and neither leaves 0..=1 for any sequence of inputs; the colour a height takes is monotonic and never indexes past the ramp at any display size; any FFT magnitude vector maps in range for any bar count.

Plus coverage for three things that had none: the ramp and the scene in `rav-appearance`, and the theme parser's refusals — which are its interface, since what a theme file is *not* allowed to say is the part a user meets when they get it wrong.

**One rule came out of writing these, and it is in `docs/developing.md` now: check a new test by breaking the code it covers, not by watching it pass.** Several here passed first time and were measuring nothing. A peak test sampled the midpoints of a stripe, which is the half of the range where the bug it was written for cannot appear. A rounding sweep reported an overshoot of exactly zero, because the case it looked for needs both ends of an interpolation to land in the same bin. Both green, neither asserting anything.

The same page now says `--workspace` is not optional: without it `cargo test` and `cargo clippy` take only the root package and the two member crates go untested and unlinted, silently and with a green result.
