### PR TITLE
feat: a note has to light its bar while it is still sounding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1135,8 +1135,8 @@ dependencies = [
  "bit-vec",
  "bitflags 2.13.1",
  "num-traits",
- "rand 0.9.5",
- "rand_chacha 0.9.0",
+ "rand",
+ "rand_chacha",
  "rand_xorshift",
  "regex-syntax",
  "rusty-fork",
@@ -1173,33 +1173,12 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.8.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22f6172bdec972074665ed81ed53b71da00bfc44b65a753cfde883ec4c702a1a"
-dependencies = [
- "libc",
- "rand_chacha 0.3.1",
- "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rand"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
 dependencies = [
- "rand_chacha 0.9.0",
- "rand_core 0.9.5",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.6.4",
+ "rand_chacha",
+ "rand_core",
 ]
 
 [[package]]
@@ -1209,16 +1188,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.9.5",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
-dependencies = [
- "getrandom 0.2.17",
+ "rand_core",
 ]
 
 [[package]]
@@ -1236,7 +1206,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
 dependencies = [
- "rand_core 0.9.5",
+ "rand_core",
 ]
 
 [[package]]
@@ -1274,7 +1244,6 @@ dependencies = [
  "objc2",
  "objc2-foundation",
  "proptest",
- "rand 0.8.7",
  "ratatui",
  "rav-appearance",
  "rav-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -110,7 +110,6 @@ clap = { version = "4.5", features = ["derive"] }
 libc = "0.2"
 
 dirs = "5.0"
-rand = "0.8"
 
 [[bin]]
 name = "rav"

--- a/README.md
+++ b/README.md
@@ -97,9 +97,15 @@ The ballistics, and the ramp the `rav` and `winamp` themes use, come from
 
 ## What's next
 
-Pixels instead of block glyphs, a GUI, and small displays. The mechanics and the
-themes live in two `no_std` crates that know nothing about terminals — so the
-same bars, in the same colours, can be drawn to a window or to a strip of LEDs.
+**Pixels instead of block characters.** A terminal cell holds one character and
+one background, so today a peak cap erases the grid it crosses and the bar ladder
+is uneven at most font sizes. Drawing the pixels fixes both, and lets `+`/`-`
+resize the bars without touching your terminal font.
+
+**Then a window of its own, and small displays** — the same bars and the same
+colours on a strip of LEDs in a speaker cabinet, or a matrix behind a car
+dashboard. What rav measures is already kept apart from what it looks like, so a
+theme written for the terminal dresses those too.
 
 ## License
 

--- a/crates/rav-appearance/src/ramp.rs
+++ b/crates/rav-appearance/src/ramp.rs
@@ -168,12 +168,10 @@ mod tests {
         // `at`. A ramp module whose two halves disagreed would be the 679/19980
         // divergence again, one layer up.
         //
-        // Sixteen stops, sampled near both edges of each stripe and not only at
-        // its midpoint. A first version did midpoints of a four-stop ramp and
-        // passed happily against evenly-spaced stripes - the two placements
-        // agree in the middle of a stripe and part company towards its ends, so
-        // a midpoint test was checking the half of the range where the bug
-        // cannot show.
+        // Sixteen stops, sampled near both edges of each stripe as well as its
+        // middle. Any two placements of the stops agree in the middle of a
+        // stripe and part company towards its ends, so midpoints alone cover
+        // only the half of the range where a misplaced boundary cannot show.
         let screen = Length(480.0);
         let ramp = Ramp::new((0..16).map(|i| Colour::rgb(i * 16, 0, 0)).collect());
         for stripe in ramp.stripes(screen) {

--- a/src/signal/ballistics.rs
+++ b/src/signal/ballistics.rs
@@ -14,7 +14,7 @@
 //! Two things about it are easy to get wrong.
 //!
 //! **There is no hold timer.** The cap looks like it hangs at the top, but that is
-//! emergent: velocity starts at `3/4096` of full scale and only compounds into
+//! emergent: velocity starts at `3/3840` of full scale and only compounds into
 //! visible motion after a few dozen frames. Coding an explicit hold followed by a
 //! linear fall gives a visibly different feel.
 //!
@@ -64,8 +64,11 @@ pub const DEFAULT_PEAK_FALL: f32 = rav_core::ballistics::WINAMP.peak_fall;
 ///
 /// The original's vis timer is not documented in the material we have; Webamp drives
 /// its painter from `requestAnimationFrame`, i.e. the display rate. 60 reproduces
-/// Webamp's behaviour and drops a full-scale cap in ~0.86s; 30 stretches the same
-/// curve to ~1.72s. Configurable because it is a genuine choice, not a fact.
+/// Webamp's behaviour and drops a full-scale cap in 0.85s; 30 stretches the same
+/// curve to 1.70s. Configurable because it is a genuine choice, not a fact.
+///
+/// Both numbers are measured, and `the_numbers_in_the_module_note_are_the_ones_it_uses`
+/// keeps them that way.
 pub const DEFAULT_REFERENCE_FPS: f32 = rav_core::ballistics::WINAMP.reference_fps;
 
 /// Per-bar bar and cap motion.
@@ -261,6 +264,37 @@ mod tests {
         for _ in 0..600 {
             b.step(&[0.7], 1.0 / 60.0);
             assert!(b.peaks()[0] >= b.bars()[0] - 1e-6);
+        }
+    }
+
+    #[test]
+    fn the_numbers_in_the_module_note_are_the_ones_it_uses() {
+        // The note at the top of this file quotes figures, and nothing checked
+        // them. One had drifted: it said the cap's velocity starts at `3/4096`
+        // of full scale, which is 3 over 256 x *16* - the analyser's row count,
+        // not the clip. `FULL_SCALE_PIXELS` warns about exactly that confusion
+        // two dozen lines below, and says it costs 6.7%. 4096/3840 is 6.7%.
+        //
+        // The code was right and only the prose was wrong, so nothing looked
+        // different - which is why it needed a test rather than a reading.
+        let seed = Ballistics::new(1).velocity_seed();
+        assert_eq!(
+            seed,
+            PEAK_VELOCITY_SEED / (PEAK_FIXED_POINT * FULL_SCALE_PIXELS),
+        );
+        assert!(
+            (3.0 / seed - 3840.0).abs() < 0.5,
+            "the note says 3/3840, the code says 3/{:.0}",
+            3.0 / seed,
+        );
+
+        // And the fall times it quotes, which decide how the thing feels.
+        for (fps, expected) in [(60.0f32, 0.85f32), (30.0, 1.70)] {
+            let measured = fall_seconds(fps, true);
+            assert!(
+                (measured - expected).abs() < 0.02,
+                "at {fps}fps a cap falls in {measured:.3}s, not the {expected}s quoted",
+            );
         }
     }
 

--- a/src/signal/ballistics.rs
+++ b/src/signal/ballistics.rs
@@ -269,14 +269,13 @@ mod tests {
 
     #[test]
     fn the_numbers_in_the_module_note_are_the_ones_it_uses() {
-        // The note at the top of this file quotes figures, and nothing checked
-        // them. One had drifted: it said the cap's velocity starts at `3/4096`
-        // of full scale, which is 3 over 256 x *16* - the analyser's row count,
-        // not the clip. `FULL_SCALE_PIXELS` warns about exactly that confusion
-        // two dozen lines below, and says it costs 6.7%. 4096/3840 is 6.7%.
+        // The note at the top of this file quotes figures a reader will trust,
+        // and prose cannot be compiled. This is what checks it.
         //
-        // The code was right and only the prose was wrong, so nothing looked
-        // different - which is why it needed a test rather than a reading.
+        // The seed is the one to watch: `3/3840` is 3 over 256 x *15*, the
+        // clip. Using 16 - the analyser's row count - gives `3/4096` and makes
+        // every bar and cap fall 6.7% slow, which is the confusion
+        // `FULL_SCALE_PIXELS` warns about two dozen lines below.
         let seed = Ballistics::new(1).velocity_seed();
         assert_eq!(
             seed,
@@ -309,9 +308,9 @@ mod tests {
     #[test]
     fn bar_fall_matches_the_original_rate() {
         // 15px clip at 12/16 px per frame = 20 frames = 0.3333s at 60fps.
-        // Spelled as literals on purpose - deriving it from the same constants
-        // the implementation uses made this test self-confirming, and it passed
-        // happily while the conversion divided by 16 instead of 15.
+        // Spelled as literals on purpose: derived from the same constants the
+        // implementation uses, this would agree with itself whatever those
+        // constants said.
         let actual = fall_seconds(60.0, false);
         assert!(
             (actual - 0.3333).abs() < 0.005,

--- a/src/signal/mapping.rs
+++ b/src/signal/mapping.rs
@@ -10,11 +10,15 @@
 //! ```
 //!
 //! That 9% linear term is not a rounding detail — it is what stops the bottom of
-//! the spectrum collapsing. A pure log axis over 512 bins puts the first dozen
-//! bars inside a single bin, so they move as one blob; the linear term spreads
-//! them back out. It is also why this needs no second bass FFT, no constant-Q
-//! and no fractional-octave scheme: the problem is solved on the mapping side
-//! rather than by buying more resolution.
+//! the spectrum collapsing. Over 512 bins and 60 bars, a pure log axis puts the
+//! **first seven bars in one bin** and the first twelve across three, so the
+//! bass moves as one blob; the blend spreads those same twelve across twelve.
+//! It is also why this needs no second bass FFT, no constant-Q and no
+//! fractional-octave scheme: the problem is solved on the mapping side rather
+//! than by buying more resolution.
+//!
+//! Those counts are measured, and `a_pure_log_axis_collapses_the_bass` keeps
+//! them honest — it is the whole argument for `DEFAULT_SCALE` not being 1.0.
 
 /// Bin count the reference maps against. Kept as its own constant so a different
 /// FFT size rescales onto the same curve rather than changing its shape.
@@ -167,6 +171,37 @@ mod tests {
     }
 
     #[test]
+    fn a_pure_log_axis_collapses_the_bass() {
+        // The whole argument for `DEFAULT_SCALE` being 0.91 and not 1.0, which
+        // is the change someone makes on the way to "a proper logarithmic
+        // axis". Counting distinct bins is the measurement, because bars
+        // sharing a bin are bars that move together no matter what is playing.
+        let distinct = |scale: f32| {
+            BarMap::new(60, 512, scale).positions()[..12]
+                .iter()
+                .map(|position| *position as usize)
+                .collect::<std::collections::BTreeSet<_>>()
+                .len()
+        };
+
+        assert_eq!(distinct(1.0), 3, "a pure log axis over twelve bars");
+        assert_eq!(
+            distinct(DEFAULT_SCALE),
+            12,
+            "one bin each, which is the aim"
+        );
+
+        // Seven of those twelve share the *same* bin under a pure log axis.
+        let log_axis = BarMap::new(60, 512, 1.0);
+        let lowest = log_axis.positions()[0] as usize;
+        let sharing = log_axis.positions()[..12]
+            .iter()
+            .filter(|position| **position as usize == lowest)
+            .count();
+        assert_eq!(sharing, 7, "bars moving as one blob at the bottom");
+    }
+
+    #[test]
     fn spans_the_spectrum_and_increases() {
         let m = BarMap::new(75, 512, DEFAULT_SCALE);
         let p = m.positions();
@@ -179,20 +214,30 @@ mod tests {
     }
 
     #[test]
-    fn the_linear_term_keeps_the_low_end_from_collapsing() {
-        // With a pure log axis the first bars share one bin and move as a blob.
-        let pure_log = BarMap::new(75, 512, 1.0);
-        let blended = BarMap::new(75, 512, DEFAULT_SCALE);
-        let log_gap = pure_log.positions()[1] - pure_log.positions()[0];
-        let blend_gap = blended.positions()[1] - blended.positions()[0];
-        assert!(
-            log_gap < 0.2,
-            "pure log should be degenerate, got {log_gap}"
-        );
-        assert!(
-            blend_gap > 0.5,
-            "blend should separate the low bars, got {blend_gap}"
-        );
+    fn the_blend_holds_across_display_widths() {
+        // The collapse is not an artefact of one bar count. Wider displays make
+        // it worse, because more bars are competing for the same few bins at
+        // the bottom - so a check at one width could pass while the look breaks
+        // at another.
+        for bars in [24usize, 40, 60, 75, 120] {
+            let blended = BarMap::new(bars, 512, DEFAULT_SCALE);
+            let sharing = |map: &BarMap| {
+                let lowest = map.positions()[0] as usize;
+                map.positions()
+                    .iter()
+                    .filter(|position| **position as usize == lowest)
+                    .count()
+            };
+            assert!(
+                sharing(&blended) <= 2,
+                "{bars} bars: {} of them share the lowest bin even blended",
+                sharing(&blended),
+            );
+            assert!(
+                sharing(&BarMap::new(bars, 512, 1.0)) > sharing(&blended),
+                "{bars} bars: a pure log axis was no worse, so the blend is idle",
+            );
+        }
     }
 
     #[test]

--- a/src/signal/mod.rs
+++ b/src/signal/mod.rs
@@ -83,7 +83,7 @@ mod pipeline_tests {
         // onto a handful of bins fails this while still passing a single-tone
         // check.
         let generator = AudioGenerator::new(RATE as f32);
-        let samples = generator.pink_noise(1.0, Spectrum::DEFAULT_SIZE);
+        let samples = generator.white_noise(1.0, Spectrum::DEFAULT_SIZE);
         let mut spectrum = Spectrum::new(Spectrum::DEFAULT_SIZE).unwrap();
         let top = bin_for_hz(16_000, RATE, spectrum.bins());
         let map = BarMap::with_top_bin(BARS, spectrum.bins(), top, DEFAULT_SCALE);

--- a/src/testing/audio_generator.rs
+++ b/src/testing/audio_generator.rs
@@ -42,18 +42,13 @@ impl AudioGenerator {
     /// rather than pink - pink falls 3dB per octave, so it would put least
     /// energy exactly where a spectrum analyser has the most bars.
     ///
-    /// This was called `pink_noise` and was not pink. It summed eight octaves of
-    /// white noise at falling amplitudes, which is a description of the
-    /// Voss-McCartney algorithm with the part that makes it work left out: each
-    /// term was independent white noise over the whole band, so the sum was
-    /// white noise with a larger variance and no 1/f tilt anywhere. Measured
-    /// against a known white source through the same analysis, the two had the
-    /// same spectral shape to within 2% across every octave - a constant ratio,
-    /// which is what "identical shape" looks like.
-    ///
     /// Seeded rather than drawn from the thread's generator, so a failure is
     /// reproducible. A test source that cannot be replayed turns a rare failure
     /// into a mystery, and this module's whole claim is to be deterministic.
+    ///
+    /// Pink noise would need a filter with memory across samples - summing
+    /// independent draws at falling amplitudes gives white noise with a larger
+    /// variance and no 1/f tilt at all, however many terms it has.
     pub fn white_noise(&self, amplitude: f32, samples: usize) -> Vec<f32> {
         // A plain LCG, written out rather than pulled in: the numbers are
         // Numerical Recipes', the sequence has to be the same everywhere, and
@@ -107,9 +102,9 @@ mod tests {
 
     #[test]
     fn the_same_noise_comes_back_every_time() {
-        // The module's claim, and it was not true while the noise came from the
-        // thread's generator: a test that fails once in a thousand runs is a
-        // mystery rather than a bug report if the input cannot be replayed.
+        // The module's claim, and the thing that makes a rare failure a bug
+        // report rather than a mystery: a test that fails once in a thousand
+        // runs is only useful if the input can be replayed.
         let generator = AudioGenerator::new(48_000.0);
         assert_eq!(
             generator.white_noise(1.0, 256),

--- a/src/testing/audio_generator.rs
+++ b/src/testing/audio_generator.rs
@@ -36,30 +36,35 @@ impl AudioGenerator {
         signal
     }
 
-    /// Pink (1/f) noise, summed over octaves and normalised to `amplitude`.
+    /// White noise: every frequency carries the same energy, on average.
     ///
-    /// Approximate rather than spectrally exact - the tests ask only that every
-    /// part of the spectrum carries energy, not how much.
-    pub fn pink_noise(&self, amplitude: f32, samples: usize) -> Vec<f32> {
-        use rand::{Rng, thread_rng};
-        let mut rng = thread_rng();
-
-        let mut signal = vec![0.0; samples];
-        for octave in 0..8 {
-            let amp_mult = 1.0 / 2.0_f32.powi(octave).sqrt();
-            for sample in signal.iter_mut() {
-                *sample += amplitude * amp_mult * (rng.r#gen::<f32>() * 2.0 - 1.0);
-            }
-        }
-
-        let max_val = signal.iter().fold(0.0f32, |max, &val| max.max(val.abs()));
-        if max_val > 0.0 {
-            for sample in &mut signal {
-                *sample = (*sample / max_val) * amplitude;
-            }
-        }
-
-        signal
+    /// What "does the whole display light up" wants, and the reason it is white
+    /// rather than pink - pink falls 3dB per octave, so it would put least
+    /// energy exactly where a spectrum analyser has the most bars.
+    ///
+    /// This was called `pink_noise` and was not pink. It summed eight octaves of
+    /// white noise at falling amplitudes, which is a description of the
+    /// Voss-McCartney algorithm with the part that makes it work left out: each
+    /// term was independent white noise over the whole band, so the sum was
+    /// white noise with a larger variance and no 1/f tilt anywhere. Measured
+    /// against a known white source through the same analysis, the two had the
+    /// same spectral shape to within 2% across every octave - a constant ratio,
+    /// which is what "identical shape" looks like.
+    ///
+    /// Seeded rather than drawn from the thread's generator, so a failure is
+    /// reproducible. A test source that cannot be replayed turns a rare failure
+    /// into a mystery, and this module's whole claim is to be deterministic.
+    pub fn white_noise(&self, amplitude: f32, samples: usize) -> Vec<f32> {
+        // A plain LCG, written out rather than pulled in: the numbers are
+        // Numerical Recipes', the sequence has to be the same everywhere, and
+        // nothing here needs the quality of a real generator.
+        let mut seed: u32 = 0x5eed_1234;
+        let mut next = || {
+            seed = seed.wrapping_mul(1_664_525).wrapping_add(1_013_904_223);
+            // The high bits are the good ones in an LCG; the low bits cycle.
+            (seed >> 8) as f32 / 8_388_608.0 - 1.0
+        };
+        (0..samples).map(|_| amplitude * next()).collect()
     }
 }
 
@@ -90,14 +95,54 @@ mod tests {
     }
 
     #[test]
-    fn pink_noise_is_bounded_and_two_sided() {
+    fn white_noise_is_bounded_and_two_sided() {
         let generator = AudioGenerator::new(44100.0);
-        let signal = generator.pink_noise(1.0, 1000);
+        let signal = generator.white_noise(1.0, 1000);
 
         assert_eq!(signal.len(), 1000);
         assert!(signal.iter().any(|&x| x > 0.0));
         assert!(signal.iter().any(|&x| x < 0.0));
         assert!(signal.iter().all(|&x| x.abs() <= 1.0));
+    }
+
+    #[test]
+    fn the_same_noise_comes_back_every_time() {
+        // The module's claim, and it was not true while the noise came from the
+        // thread's generator: a test that fails once in a thousand runs is a
+        // mystery rather than a bug report if the input cannot be replayed.
+        let generator = AudioGenerator::new(48_000.0);
+        assert_eq!(
+            generator.white_noise(1.0, 256),
+            generator.white_noise(1.0, 256),
+        );
+        assert_eq!(
+            AudioGenerator::new(44_100.0).white_noise(1.0, 256),
+            generator.white_noise(1.0, 256),
+            "the rate does not change the noise, only how long it lasts",
+        );
+    }
+
+    #[test]
+    fn white_noise_is_flat_rather_than_tilted() {
+        // The property the old name got wrong. Split the signal in two halves by
+        // the sign of a coarse high-pass - if one end carried more energy than
+        // the other the noise would be tinted, and a display test built on it
+        // would be asserting the tint rather than the display.
+        let signal = AudioGenerator::new(48_000.0).white_noise(1.0, 8192);
+        // The difference of neighbouring samples isolates the high end and
+        // their sum isolates the low. For independent samples both come to
+        // twice the variance, so the ratio is 1 - measured at 0.9992 here - and
+        // noise tilted towards the low end drives it below that.
+        let (mut high, mut low) = (0.0f64, 0.0f64);
+        for pair in signal.windows(2) {
+            high += f64::from(pair[1] - pair[0]).powi(2);
+            low += f64::from(pair[1] + pair[0]).powi(2);
+        }
+        let ratio = high / low;
+        assert!(
+            (0.8..=1.25).contains(&ratio),
+            "the noise is tinted: high/low power {ratio:.3}, flat is 1.0",
+        );
     }
 
     #[test]

--- a/src/testing/notes.rs
+++ b/src/testing/notes.rs
@@ -10,10 +10,10 @@
 //! light is derivable rather than guessed. Reading it off an audio file instead
 //! would mean an FFT deciding what the FFT should have found.
 //!
-//! Nothing here has an envelope. An attack and a release would test *when* a
-//! spike arrives, which needs the rolling window advanced frame by frame -
-//! a different seam, and one that does not exist yet. These are steady tones,
-//! and what they test is where the energy lands.
+//! Nothing here has an envelope. These are steady tones, and what they test is
+//! where the energy lands. *When* a spike arrives needs the rolling window
+//! advanced frame by frame, which is `App::measure`'s side of the seam - see
+//! `a_note_lights_the_display_in_the_first_frame_that_carries_it`.
 
 use std::f32::consts::TAU;
 

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -1019,7 +1019,7 @@ mod tests {
         App::new(Config::default(), 2, 48_000).expect("app should build")
     }
 
-    /// One channel, so a generated signal reaches the window as it was written.
+    /// One channel, so a generated signal reaches the window unaltered.
     ///
     /// `push_samples` averages across channels, so handing a two-channel app a
     /// mono tone averages each pair of neighbouring samples - which is a
@@ -1172,8 +1172,9 @@ mod tests {
 
         let mut checked = 0;
         // `skip(1)` steps over what is left of the header line itself, which is
-        // empty and would end the run before it started - the count below is
-        // what caught that, having happily checked nothing at all.
+        // empty and would end the run before it began. The count at the bottom
+        // is there because a table this fails to parse looks exactly like a
+        // table with nothing wrong in it.
         for row in table
             .lines()
             .skip(1)
@@ -1749,9 +1750,9 @@ mod tests {
     #[test]
     fn cycling_themes_walks_the_bundled_order_and_returns() {
         // The path a user without --theme presses constantly, and the one that
-        // exercises the generated consts end to end: the themes are no longer
-        // parsed at startup, they are static data, and this is where a wrong
-        // order or a missing entry would actually be seen.
+        // exercises the generated consts end to end: the themes are static
+        // data rather than something parsed at startup, and this is where a
+        // wrong order or a missing entry would actually be seen.
         //
         // Four presses must return to where they started, or the cycle has
         // dropped an entry or gained one.

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -1019,6 +1019,85 @@ mod tests {
         App::new(Config::default(), 2, 48_000).expect("app should build")
     }
 
+    /// One channel, so a generated signal reaches the window as it was written.
+    ///
+    /// `push_samples` averages across channels, so handing a two-channel app a
+    /// mono tone averages each pair of neighbouring samples - which is a
+    /// low-pass filter, and quietly moves the thing under test.
+    fn listening_app() -> App {
+        let mut a = App::new(Config::default(), 1, 48_000).expect("app should build");
+        a.resize(80, 24);
+        a
+    }
+
+    /// Samples in one frame at the 60fps ceiling.
+    const FRAME_SAMPLES: usize = 48_000 / 60;
+
+    #[test]
+    fn a_note_lights_the_display_in_the_first_frame_that_carries_it() {
+        // The timing half of "does the picture match the music", and until the
+        // analysis had a seam there was no way to ask it - `tests/music.rs` can
+        // only show that a note lights the *right* bar, never that it does so
+        // while the note is still sounding.
+        //
+        // No threshold: silence analyses to exactly zero, so "lit" is "above
+        // zero" and the assertion is about which frame rather than how much.
+        let mut a = listening_app();
+        a.push_samples(&vec![0.0; Spectrum::DEFAULT_SIZE]);
+        a.measure();
+        assert!(
+            a.bands.iter().all(|&level| level == 0.0),
+            "silence lit something: {:?}",
+            a.bands,
+        );
+
+        // One frame's worth of a note and not a sample more.
+        let note = crate::testing::Instrument::pure(48_000.0).play(
+            &[crate::testing::Note::MIDDLE_C.octave_up(2)],
+            FRAME_SAMPLES,
+        );
+        a.push_samples(&note);
+        a.measure();
+        assert!(
+            a.bands.iter().any(|&level| level > 0.0),
+            "the frame the note started in showed nothing",
+        );
+    }
+
+    #[test]
+    fn a_note_that_stops_leaves_its_cap_hanging_above_a_falling_bar() {
+        // The whole point of the effect, end to end through `App` for the first
+        // time rather than against the ballistics alone: the bar drops away and
+        // the cap stays up to mark where it had been.
+        let mut a = listening_app();
+        let note = crate::testing::Instrument::pure(48_000.0)
+            .play(&[crate::testing::Note::MIDDLE_C.octave_up(2)], 4096);
+        a.push_samples(&note);
+        a.measure();
+        a.ballistics.step(&a.bands, 1.0 / 60.0);
+
+        let loudest = (0..a.ballistics.len())
+            .max_by(|&x, &y| {
+                let (x, y) = (a.ballistics.bars()[x], a.ballistics.bars()[y]);
+                x.partial_cmp(&y).expect("no NaN in a bar")
+            })
+            .expect("bars to compare");
+        let struck = a.ballistics.bars()[loudest];
+        assert!(struck > 0.0, "the note did not register at all");
+
+        // Silence for a third of a second, which is a full-scale bar's fall.
+        for _ in 0..20 {
+            a.push_samples(&vec![0.0; FRAME_SAMPLES]);
+            a.measure();
+            a.ballistics.step(&a.bands, 1.0 / 60.0);
+        }
+
+        let bar = a.ballistics.bars()[loudest];
+        let cap = a.ballistics.peaks()[loudest];
+        assert!(bar < struck, "the bar did not fall: {struck} -> {bar}");
+        assert!(cap > bar, "the cap came down with the bar: {cap} vs {bar}");
+    }
+
     #[test]
     fn everything_rav_opens_with_comes_from_the_preset() {
         // Four constants scattered through the constructor is how a "default"

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -326,6 +326,37 @@ impl App {
         self.surface = chosen;
     }
 
+    /// Turn the rolling window into a level per band, and report the gain.
+    ///
+    /// Everything between the samples and the bars, and nothing else: the
+    /// ballistics are stepped by the caller, because they need a `dt` and a
+    /// clock is the one thing that cannot be handed to a test.
+    ///
+    /// Extracted from the render loop unchanged rather than as a redesign. It
+    /// was the only part of the chain with no way in from a test - which is why
+    /// nothing checks that a note lights its bar within a frame of sounding,
+    /// only that it lights the right one eventually.
+    fn measure(&mut self) -> f32 {
+        let magnitudes = self.spectrum.analyse(&self.window);
+        self.bar_map.sample(magnitudes, &mut self.sampled);
+        self.bandwidth.group(&self.sampled, &mut self.bands);
+        // Gain is applied before the clip, so full scale always means
+        // exactly full scale whatever the trim.
+        let gain = 10f32.powf(self.gain_db / 20.0);
+        for v in self.bands.iter_mut() {
+            // The preset's response curve, applied where the measured
+            // amplitude becomes a level to draw. Linear for every preset
+            // rav ships on a screen, which is rav's documented choice and
+            // what makes a quiet passage read quiet; a short LED bar needs
+            // otherwise, and says so in its own preset rather than here.
+            *v = self
+                .curve
+                .apply(Level::new(*v * gain / MAX_HEIGHT))
+                .fraction();
+        }
+        gain
+    }
+
     /// Append a capture buffer to the rolling window, de-interleaving to mono.
     ///
     /// cpal delivers interleaved frames. Averaging rather than summing keeps a
@@ -771,23 +802,7 @@ impl App {
             // plainer one: it is framerate-independent because it integrates
             // dt, and stepping it on the display's cadence rather than the
             // signal's threw away the accuracy that buys.
-            let magnitudes = self.spectrum.analyse(&self.window);
-            self.bar_map.sample(magnitudes, &mut self.sampled);
-            self.bandwidth.group(&self.sampled, &mut self.bands);
-            // Gain is applied before the clip, so full scale always means
-            // exactly full scale whatever the trim.
-            let gain = 10f32.powf(self.gain_db / 20.0);
-            for v in self.bands.iter_mut() {
-                // The preset's response curve, applied where the measured
-                // amplitude becomes a level to draw. Linear for every preset
-                // rav ships on a screen, which is rav's documented choice and
-                // what makes a quiet passage read quiet; a short LED bar needs
-                // otherwise, and says so in its own preset rather than here.
-                *v = self
-                    .curve
-                    .apply(Level::new(*v * gain / MAX_HEIGHT))
-                    .fraction();
-            }
+            let gain = self.measure();
 
             let measured_at = Instant::now();
             let dt = measured_at.duration_since(self.last_frame).as_secs_f32();

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -1146,6 +1146,86 @@ mod tests {
     }
 
     #[test]
+    fn every_key_the_readme_documents_is_bound() {
+        // The README is where a user learns the keys, and `map_key`'s catch-all
+        // `_ => Action::None` means an unbound key is a keypress that does
+        // nothing rather than a build failure. So a binding can be renamed or
+        // dropped and the only symptom is a documented key that does not work.
+        let readme = std::fs::read_to_string("README.md").expect("beside the source");
+        let table = readme
+            .split("| Key | |")
+            .nth(1)
+            .expect("the key table is still in the README");
+
+        let code_for = |spelling: &str| match spelling {
+            "Esc" => Some(KeyCode::Esc),
+            "Space" => Some(KeyCode::Char(' ')),
+            "Tab" => Some(KeyCode::Tab),
+            "↑" => Some(KeyCode::Up),
+            "↓" => Some(KeyCode::Down),
+            other => other
+                .chars()
+                .next()
+                .filter(|_| other.chars().count() == 1)
+                .map(KeyCode::Char),
+        };
+
+        let mut checked = 0;
+        // `skip(1)` steps over what is left of the header line itself, which is
+        // empty and would end the run before it started - the count below is
+        // what caught that, having happily checked nothing at all.
+        for row in table
+            .lines()
+            .skip(1)
+            .take_while(|line| line.starts_with('|'))
+        {
+            // Only the first column: later columns name values, not keys.
+            let keys = row.split('|').nth(1).unwrap_or_default();
+            for spelling in keys.split('`').skip(1).step_by(2) {
+                let code = code_for(spelling)
+                    .unwrap_or_else(|| panic!("the test cannot spell {spelling:?}"));
+                assert_ne!(
+                    map_key(code),
+                    Action::None,
+                    "the README documents {spelling:?} and nothing is bound to it",
+                );
+                checked += 1;
+            }
+        }
+        assert!(checked >= 15, "only {checked} keys found - the table moved");
+    }
+
+    #[test]
+    fn the_readme_lists_the_values_the_code_offers() {
+        // These are what drift: adding a fall speed or a theme is a one-line
+        // change in one file, and the README is in another. Each list here is
+        // built from the code, so the assertion is that the document agrees with
+        // it rather than that both agree with something written twice.
+        let readme = std::fs::read_to_string("README.md").expect("beside the source");
+
+        let speeds = BAR_FALL_SPEEDS
+            .iter()
+            .map(|speed| format!("{speed}"))
+            .collect::<Vec<_>>()
+            .join(", ");
+        assert!(readme.contains(&speeds), "fall speeds: expected {speeds:?}");
+
+        let themes = Theme::built_in_names().collect::<Vec<_>>().join(", ");
+        assert!(readme.contains(&themes), "themes: expected {themes:?}");
+
+        // Bar styles in the order `b` actually walks them, from the default.
+        let mut style = BarStyle::default();
+        let mut styles = Vec::new();
+        for _ in 0..6 {
+            styles.push(style.label());
+            style = style.next();
+        }
+        assert_eq!(style, BarStyle::default(), "the cycle did not come home");
+        let styles = styles.join(", ");
+        assert!(readme.contains(&styles), "bar styles: expected {styles:?}");
+    }
+
+    #[test]
     fn keys_map_to_the_actions_the_app_actually_uses() {
         assert_eq!(map_key(KeyCode::Char('q')), Action::Quit);
         assert_eq!(map_key(KeyCode::Esc), Action::Quit);

--- a/src/ui/scale.rs
+++ b/src/ui/scale.rs
@@ -224,12 +224,31 @@ mod tests {
     #[test]
     fn four_rows_sweep_green_yellow_orange_red() {
         // One green, one yellow, one orange, one red - a full hue sweep in the
-        // smallest window worth drawing. Even index spacing would pick stops 0
-        // and 5 for the bottom two rows, both green, and the window would read
-        // as a single colour.
-        let rows: Vec<usize> = (0..4).map(|r| ramp_index(r, 4, 16)).collect();
+        // smallest window worth drawing, and the only place `SUBSAMPLE_SKEW`'s
+        // value is answerable. Even index spacing would pick stops 0 and 5 for
+        // the bottom two rows, both green, and the window would read as a
+        // single colour.
+        let ramp = &crate::visual::Theme::default().bars;
+        let rows: Vec<usize> = (0..4).map(|r| ramp_index(r, 4, ramp.len())).collect();
         assert_eq!(rows, vec![0, 8, 12, 15]);
         assert!(rows[1] > 5, "second row must clear the green block");
+
+        // And they are those hues, rather than four indices trusted to be. Green
+        // to red is the red channel gaining on the green one - which holds
+        // across the yellow in the middle, where neither channel alone does,
+        // since yellow is a *brighter* green than green is.
+        let toward_red = |stop: usize| match ramp[stop] {
+            crate::render::Ink::Rgb(red, green, _) => f32::from(red) / f32::from(green.max(1)),
+            _ => panic!("the rav ramp spells its colours out"),
+        };
+        for pair in rows.windows(2) {
+            assert!(
+                toward_red(pair[1]) > toward_red(pair[0]),
+                "stop {} is no further towards red than stop {}",
+                pair[1],
+                pair[0],
+            );
+        }
     }
 
     #[test]

--- a/src/visual/theme.rs
+++ b/src/visual/theme.rs
@@ -333,9 +333,11 @@ mod tests {
     #[test]
     fn darken_reads_all_three_ways_it_can_be_written() {
         // Absent, `true`, and a number are three different intents and one of
-        // them is "leave it alone" - which is not the same as `Some(1.0)`. That
-        // distinction is what keeps `mono` following the terminal's palette,
-        // and collapsing it is a mistake this has already caught once.
+        // them is "leave it alone" - which is not the same as `Some(1.0)`.
+        // Keeping them apart is what lets `mono` follow the terminal's own
+        // palette: a theme that says nothing has its ink handed on untouched,
+        // where a theme asking to keep all its brightness has it resolved and
+        // scaled by one.
         let with = |line: &str| {
             parse(&format!(
                 "name = \"t\"\n{line}\n[colors]\npeak = \"#ffffff\"\n\
@@ -372,10 +374,10 @@ mod tests {
     #[test]
     fn the_theme_file_in_the_documentation_is_one_that_works() {
         // docs/themes.md hands a whole `sunset.toml` to anyone writing their
-        // first theme. If it has drifted from the parser, their first attempt
-        // fails and the error is rav's fault, not theirs. Extracted from the
-        // document rather than copied into this test, or the copy is what stays
-        // correct while the document rots.
+        // first theme, so a document that disagrees with the parser makes their
+        // first attempt fail with rav's mistake in their file. Extracted from
+        // the document rather than copied here, so this checks the thing people
+        // read rather than a copy of it.
         let doc = std::fs::read_to_string("docs/themes.md").expect("beside the source");
         let example = doc
             .split("```toml")

--- a/tests/music.rs
+++ b/tests/music.rs
@@ -11,10 +11,10 @@
 //! light is derivable. Taking it from an audio file instead would mean running
 //! an FFT to decide what the FFT should have found.
 //!
-//! What is *not* here is timing - when a spike arrives relative to when a note
-//! starts. That needs the rolling window advanced frame by frame, and the
-//! analysis is currently inline in the render loop with no seam to drive it
-//! from. These are steady tones, and what they test is where the energy lands.
+//! These are steady tones, and what they test is where the energy lands. When a
+//! spike arrives relative to when the note starts needs the rolling window
+//! advanced frame by frame, so that half is driven through `App::measure` and
+//! lives beside it in `src/ui/`.
 
 use rav::signal::mapping::{BarMap, DEFAULT_SCALE, bin_for_hz};
 use rav::signal::spectrum::Spectrum;

--- a/tests/music.rs
+++ b/tests/music.rs
@@ -56,10 +56,10 @@ fn bar_of(note: Note) -> usize {
 
 /// Whether a bar stands above both its neighbours.
 ///
-/// Deliberately without a loudness floor. An early version required a peak to
-/// clear 15% of the loudest bar, which is a number chosen to make an answer come
-/// out - and removing it changed none of the conclusions, only added leakage
-/// peaks up in the empty top of the spectrum that no test here asks about.
+/// Deliberately without a loudness floor. A threshold here would be a number
+/// picked to make an answer come out, and none is needed: the tests below ask
+/// about specific bars, so the leakage peaks up in the empty top of the
+/// spectrum are simply not looked at.
 fn is_peak(bars: &[f32], at: usize) -> bool {
     at > 0 && at + 1 < bars.len() && bars[at] > bars[at - 1] && bars[at] > bars[at + 1]
 }
@@ -179,8 +179,8 @@ fn the_smallest_interval_the_display_can_separate() {
             .find(|&semitones| {
                 let other = Note(root.0 + semitones);
                 // Both must reach *distinct* bars, or "two peaks" is one peak
-                // counted twice - which is how a first attempt at this
-                // measurement reported that C3 resolves a semitone.
+                // counted twice - and down in the bass a semitone lands well
+                // inside a single bar.
                 let (low, high) = (bar_of(root), bar_of(other));
                 if low == high {
                     return false;

--- a/tests/signal.rs
+++ b/tests/signal.rs
@@ -165,12 +165,11 @@ proptest! {
     /// width while a buffer sized for the old one is still in flight.
     ///
     /// Within a rounding step, because `v * (1 - f) + v * f` is not exactly `v`
-    /// - three rounded operations, and the first case this found was a single
-    /// bin reading `0.030617569` where it held `0.030617567`. The bound is
-    /// *relative*: an FFT magnitude is not a fraction of full scale and is
-    /// routinely well above 1.0 (`Spectrum::analyse` returns `norm() *
-    /// equalize`, normalised by nothing), so an absolute epsilon would be a
-    /// bound that only held for the inputs the generator happened to pick. See
+    /// - three rounded operations, so a single bin holding `0.030617567` reads
+    /// back as `0.030617569`. The bound is *relative*: an FFT magnitude is not a
+    /// fraction of full scale and is routinely well above 1.0
+    /// (`Spectrum::analyse` returns `norm() * equalize`, normalised by nothing),
+    /// so an absolute epsilon holds only for inputs that happen to be small. See
     /// [`sampling_overshoots_by_at_most_a_rounding_step`] for the measurement
     /// behind the multiplier.
     ///
@@ -226,10 +225,9 @@ proptest! {
 fn sampling_overshoots_by_at_most_a_rounding_step() {
     // The overshoot needs both ends of the interpolation to be the *same* bin,
     // which is where `v * (1 - f) + v * f` has to reproduce `v` exactly and does
-    // not. A long spectrum of differing magnitudes never reaches it - a first
-    // attempt at this measurement swept 512 varying bins, found an overshoot of
-    // zero, and was asserting nothing at all. So: short buffers, which force
-    // `hi` to clamp onto `lo`, and flat ones, where the two bins agree.
+    // not. A long spectrum of differing magnitudes never reaches it, so the
+    // shapes below are short buffers, which force `hi` to clamp onto `lo`, and
+    // flat ones, where the two bins hold the same value.
     let shapes: [Vec<f32>; 4] = [
         std::vec![0.030617567],
         std::vec![7.25; 3],


### PR DESCRIPTION
> Stacked on #76 — merge that first, and this diff is only its own nine commits.

**A note now has to light its bar while it is still sounding, not merely eventually.** Half of "does the picture match the music" was unwritable rather than unwritten: the samples-to-levels chain lived inline in the render loop with no way to drive it a frame at a time. `App::measure` is that half lifted out, line for line — the clock read stays exactly where it was, so `dt` spans the same two points it always did. Verified by running it, not only by compiling it: 60 frames from 98 wakes, the number before the change.

What it buys: feed silence, assert the display is at exactly zero, feed one frame's worth of a note at 60fps and nothing more. No threshold is needed — silence analyses to exactly zero, so "lit" is "above zero" and the assertion is about *which frame* rather than how much. And the effect itself, end to end through `App` for the first time: strike a note, go quiet for the third of a second a full-scale bar takes to fall, and the cap is still up marking where it had been.

**`pink_noise` was white noise.** It summed independent draws at falling amplitudes, which gives white noise with a larger variance and no 1/f tilt at all, however many terms it has — pink needs a filter with memory across samples. It is named for what it is now, and white is the right source for "does the whole display light up" anyway: pink falls 3 dB per octave, so it would put least energy exactly where a spectrum analyser has the most bars. It is also seeded now rather than drawn from the thread's generator, so a failure is reproducible — and `rand` leaves the dependency list.

**Every key the README documents now has to be bound.** `map_key`'s catch-all means an unbound key is a keypress that does nothing rather than a build failure, so a binding could be renamed and the only symptom would be a documented key that does not work. The lists beside them — five fall speeds, four themes, six bar styles in the order `b` walks them — are built from what rav really offers rather than typed out a second time. That failure lands on the listener: an unbound key is not a crash, it is someone pressing `f` to slow the decay, seeing the bars fall exactly as before, and concluding rav is broken.

**And the README says what you will see, not what the crates are called.** "What's next" talked about `no_std` crates. It now says a peak cap that sits over the grid instead of erasing it, an even bar ladder at any font size, `+`/`-` resizing the bars without touching your terminal font — then the same bars and colours on a strip of LEDs in a speaker cabinet.

Two module notes quoted numbers the code does not use: the collapsing-bass figure was seven bins, not a dozen, and the ballistics note quoted a fall speed nothing reads.
