### PR TITLE
feat: rav says what it is listening to, and plays something when it cannot hear

### DIFF
--- a/src/audio/mod.rs
+++ b/src/audio/mod.rs
@@ -183,6 +183,17 @@ impl AudioCapture {
         self.config.channels
     }
 
+    /// What the display is being fed from, for saying so on screen.
+    ///
+    /// The name the device reports, not the one that was asked for: `-d` takes
+    /// a partial name, and rav falls back to the default input when it finds no
+    /// loopback, so the two differ exactly when it matters.
+    pub fn device_name(&self) -> String {
+        self.device
+            .name()
+            .unwrap_or_else(|_| "an unnamed device".to_string())
+    }
+
     /// Every input device with its name, enumerated **once**.
     ///
     /// Worth its own function because enumeration is not cheap: cpal's ALSA

--- a/src/audio/mod.rs
+++ b/src/audio/mod.rs
@@ -1,3 +1,4 @@
+pub mod synthetic;
 #[cfg(target_os = "macos")]
 pub mod tap;
 

--- a/src/audio/synthetic.rs
+++ b/src/audio/synthetic.rs
@@ -1,0 +1,199 @@
+//! A signal rav can draw when there is nothing to capture.
+//!
+//! What `--test-audio` plays. A machine with no loopback, no recording
+//! permission, or no sound card at all still shows a working display, which is
+//! the difference between "rav is broken" and "rav cannot hear anything here" -
+//! and on Linux, where routing system output into a capture is genuinely
+//! awkward, it is the first thing worth running.
+//!
+//! A sweep rather than a tone: a single frequency lights one bar and proves
+//! almost nothing, while a sweep walks the whole display, so every band, the
+//! bar fall and the peak caps are all visible in one pass.
+
+use super::AudioData;
+use flume::Receiver;
+use std::time::{Duration, Instant};
+use tracing::info;
+
+/// Where the sweep starts and ends.
+///
+/// From the lowest note a small speaker reproduces to the top of the default
+/// frequency range, so the peak arrives at the left edge and leaves at the
+/// right rather than starting or ending out of view.
+const LOWEST: f32 = 40.0;
+const HIGHEST: f32 = 16_000.0;
+
+/// How long one pass takes.
+///
+/// Slow enough to watch a bar rise, hold and fall behind the peak - which is the
+/// motion worth looking at - and short enough that the display is not still
+/// filling up when someone decides whether rav works.
+const SWEEP: Duration = Duration::from_secs(12);
+
+/// Loud, but not against the ceiling: a signal that clipped every bar to full
+/// scale would hide exactly the ballistics this exists to show.
+const AMPLITUDE: f32 = 0.5;
+
+/// Blocks a second, matching what a capture device delivers.
+///
+/// The render loop wakes on audio arriving, so this is what sets the frame rate.
+/// A hundred a second leaves room for the 60fps cap to be the thing that limits
+/// it, as it is with a real device.
+const BLOCKS_PER_SECOND: u32 = 100;
+
+/// The frequency `turn` of the way through a pass, where 1.0 is a whole one.
+///
+/// Logarithmic, so the peak crosses the display at a steady pace: the bars are
+/// spaced by octave, not by hertz. A function rather than an expression inside
+/// the loop so a test can ask the same question the generator answers - a test
+/// that recomputes the curve for itself agrees with itself whatever this does.
+fn sweep_hz(turn: f32) -> f32 {
+    LOWEST * (HIGHEST / LOWEST).powf(turn.fract())
+}
+
+/// Start the test signal, and hand back the channel it feeds.
+///
+/// One mono channel. The thread ends when the receiver is dropped, so nothing
+/// needs to stop it.
+pub fn start(sample_rate: u32) -> Receiver<AudioData> {
+    let (tx, rx) = flume::bounded(super::QUEUE_BLOCKS);
+    let rate = sample_rate.max(1);
+    let per_block = (rate / BLOCKS_PER_SECOND).max(1) as usize;
+    let block_time = Duration::from_secs_f64(f64::from(per_block as u32) / f64::from(rate));
+
+    info!(
+        "Playing the built-in test signal: {LOWEST:.0}Hz to {HIGHEST:.0}Hz every {}s",
+        SWEEP.as_secs()
+    );
+
+    std::thread::spawn(move || {
+        // Phase is integrated rather than computed from the frequency and the
+        // time, because a sweep changes frequency every sample: `sin(2*pi*f*t)`
+        // with a moving `f` jumps the phase each time it moves, which is a click
+        // on every sample and broadband noise across the whole display.
+        let mut phase = 0.0f32;
+        let mut elapsed = 0.0f32;
+        let dt = 1.0 / rate as f32;
+        let mut due = Instant::now();
+
+        loop {
+            let mut block = Vec::with_capacity(per_block);
+            for _ in 0..per_block {
+                let hz = sweep_hz(elapsed / SWEEP.as_secs_f32());
+                phase = (phase + std::f32::consts::TAU * hz * dt) % std::f32::consts::TAU;
+                block.push(AMPLITUDE * phase.sin());
+                elapsed += dt;
+            }
+
+            if tx.send(AudioData { samples: block }).is_err() {
+                // The app has gone. Nothing to clean up: the channel is the only
+                // thing this thread holds.
+                return;
+            }
+
+            // A deadline rather than a sleep of one block, so the signal keeps
+            // real time instead of drifting slower by however long the work
+            // above took, every block, for as long as rav runs.
+            due += block_time;
+            if let Some(nap) = due.checked_duration_since(Instant::now()) {
+                std::thread::sleep(nap);
+            } else {
+                // Behind schedule: give up the missed time rather than sending a
+                // burst, which would arrive as a jump in the display.
+                due = Instant::now();
+            }
+        }
+    });
+
+    rx
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn the_sweep_covers_the_range_it_advertises() {
+        // The frequency at the start, at the end and in the middle of one pass,
+        // asked of the generator itself, not recomputed here. A sweep that only
+        // reached a third of the way up would still look busy and would leave
+        // most of the display dark.
+        assert!((sweep_hz(0.0) - LOWEST).abs() < 1.0);
+        assert!((sweep_hz(0.999) - HIGHEST).abs() < HIGHEST * 0.01);
+        // Halfway through is the geometric mean, not the arithmetic one - which
+        // is what puts the peak in the middle of a display spaced by octave.
+        assert!((sweep_hz(0.5) - (LOWEST * HIGHEST).sqrt()).abs() < 1.0);
+    }
+
+    #[test]
+    fn it_delivers_blocks_at_something_like_a_capture_rate() {
+        let rx = start(48_000);
+        let first = rx
+            .recv_timeout(Duration::from_secs(2))
+            .expect("no block arrived");
+        assert_eq!(first.samples.len(), 480, "48kHz in 100 blocks is 480 each");
+
+        // Not silence, and not clipped: a display fed by this has to show
+        // something, and has to show the ballistics rather than a solid wall.
+        let peak = first.samples.iter().fold(0.0f32, |m, s| m.max(s.abs()));
+        assert!(peak > 0.0, "the test signal is silent");
+        assert!(
+            peak <= AMPLITUDE + 1e-6,
+            "louder than it asked to be: {peak}"
+        );
+    }
+
+    #[test]
+    fn what_it_plays_reaches_the_display() {
+        // The whole claim of `--test-audio`: someone with no loopback and no
+        // permission sees bars move. Blocks that are the right size and the
+        // right loudness still prove nothing if the analysis makes nothing of
+        // them, so this runs the real chain over the real output.
+        use crate::signal::mapping::{BarMap, DEFAULT_SCALE};
+        use crate::signal::spectrum::Spectrum;
+
+        let rx = start(48_000);
+        let mut window = Vec::new();
+        while window.len() < Spectrum::DEFAULT_SIZE {
+            let block = rx
+                .recv_timeout(Duration::from_secs(2))
+                .expect("the signal stopped");
+            window.extend_from_slice(&block.samples);
+        }
+        window.truncate(Spectrum::DEFAULT_SIZE);
+
+        let mut spectrum = Spectrum::new(Spectrum::DEFAULT_SIZE).expect("a power-of-two size");
+        let mut bars = Vec::new();
+        BarMap::new(60, spectrum.bins(), DEFAULT_SCALE)
+            .sample(spectrum.analyse(&window), &mut bars);
+
+        let lit = bars.iter().filter(|b| **b > 0.0).count();
+        assert!(lit > 0, "the test signal draws nothing: {bars:?}");
+
+        // And it starts at the bottom, which is where a sweep should begin - a
+        // signal that lit the top first would mean the sweep runs backwards.
+        let loudest = bars
+            .iter()
+            .enumerate()
+            .max_by(|a, b| a.1.total_cmp(b.1))
+            .map(|(i, _)| i)
+            .expect("no bars at all");
+        assert!(
+            loudest < bars.len() / 2,
+            "the sweep starts in the upper half: bar {loudest} of {}",
+            bars.len(),
+        );
+    }
+
+    #[test]
+    fn the_thread_stops_when_nothing_is_listening() {
+        // Otherwise every run of the tests leaves a thread generating audio into
+        // a channel nobody reads, for as long as the process lives.
+        let rx = start(48_000);
+        rx.recv_timeout(Duration::from_secs(2)).expect("no block");
+        drop(rx);
+        // Nothing to assert but the absence of a hang: the send fails and the
+        // thread returns. If it did not, this test would still pass - which is
+        // why the `is_err` return above is the thing being read, not timing.
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -134,36 +134,57 @@ async fn rav_main() -> Result<()> {
         return Ok(());
     }
 
-    // Initialize audio capture
-    let mut audio_capture = AudioCapture::new(
-        args.device.as_deref(),
-        config.audio.sample_rate,
-        config.audio.buffer_size,
-    )
-    .await?;
+    // `--test-audio` opens no device at all, which is the whole of its use: a
+    // machine with no loopback, no recording permission or no sound card still
+    // shows a working display.
+    let mut audio_capture = if args.test_audio {
+        None
+    } else {
+        Some(
+            AudioCapture::new(
+                args.device.as_deref(),
+                config.audio.sample_rate,
+                config.audio.buffer_size,
+            )
+            .await?,
+        )
+    };
 
-    // Start audio capture
-    let audio_receiver = audio_capture.start().await?;
-    info!("🎵 Audio capture started");
+    let (audio_receiver, channels, sample_rate, source) = match &mut audio_capture {
+        Some(capture) => {
+            let receiver = capture.start().await?;
+            info!("🎵 Audio capture started");
+            // Both are only final after start(), which may renegotiate. The
+            // channel count matters: cpal delivers interleaved frames, and
+            // ignoring it silently mixes L and R into the time domain.
+            info!(
+                "Capturing at {}Hz, {} channel(s)",
+                capture.sample_rate(),
+                capture.channels()
+            );
+            (
+                receiver,
+                capture.channels(),
+                capture.sample_rate(),
+                capture.device_name(),
+            )
+        }
+        None => {
+            let rate = config.audio.sample_rate;
+            (
+                rav::audio::synthetic::start(rate),
+                1,
+                rate,
+                "the built-in test signal".to_string(),
+            )
+        }
+    };
 
-    // Both are only final after start(), which may renegotiate. The channel
-    // count matters: cpal delivers interleaved frames, and ignoring it silently
-    // mixes L and R into the time domain.
-    info!(
-        "Capturing at {}Hz, {} channel(s)",
-        audio_capture.sample_rate(),
-        audio_capture.channels()
-    );
-
-    let mut app = App::new(
-        config,
-        audio_capture.channels(),
-        audio_capture.sample_rate(),
-    )?;
+    let mut app = App::new(config, channels, sample_rate)?;
     // The device for now; the tap below replaces it if it starts. Said here and
     // corrected there rather than announced once in the middle, because the
     // answer is not settled until the tap has had its turn.
-    app.listening_to(audio_capture.device_name());
+    app.listening_to(source);
 
     // A named theme that cannot be read is an error rather than a silent fall
     // back to the default: the display would look right and be the wrong theme.
@@ -176,22 +197,28 @@ async fn rav_main() -> Result<()> {
     // the system volume, so playback level does not drive the display, and it
     // needs no virtual device installed. Falls back to the capture device when
     // unavailable - macOS below 14.2, or the recording permission refused.
+    //
+    // Skipped entirely under `--test-audio`: taking the system's own output
+    // would be capturing a device, which is the one thing that flag exists to
+    // avoid.
     #[cfg(target_os = "macos")]
-    match rav::audio::tap::Tap::start() {
-        Ok(tap) => {
-            info!(
-                "Using CoreAudio process tap: {}Hz, {} channel(s)",
-                tap.sample_rate(),
-                tap.channels()
-            );
-            // The cpal stream is already running, and its channel is unbounded.
-            // Leaving it feeding a receiver the app will never drain again grows
-            // the queue by ~350 KB/s until the process is killed.
-            audio_capture.stop();
-            app.use_tap(tap);
-        }
-        Err(e) => {
-            info!("Process tap unavailable ({e}); using the capture device instead");
+    if let Some(capture) = &mut audio_capture {
+        match rav::audio::tap::Tap::start() {
+            Ok(tap) => {
+                info!(
+                    "Using CoreAudio process tap: {}Hz, {} channel(s)",
+                    tap.sample_rate(),
+                    tap.channels()
+                );
+                // Nothing drains the cpal stream once the tap takes over. Its
+                // queue is bounded and drops its oldest block, so this frees a
+                // capture device and a callback rather than memory.
+                capture.stop();
+                app.use_tap(tap);
+            }
+            Err(e) => {
+                info!("Process tap unavailable ({e}); using the capture device instead");
+            }
         }
     }
 
@@ -206,9 +233,12 @@ async fn rav_main() -> Result<()> {
         }
     };
 
-    // Explicitly stop audio capture before exit
-    info!("Stopping audio capture...");
-    audio_capture.stop();
+    // Explicitly stop audio capture before exit. The test signal needs no such
+    // thing: its thread ends when the channel it feeds is dropped.
+    if let Some(capture) = &mut audio_capture {
+        info!("Stopping audio capture...");
+        capture.stop();
+    }
 
     // Small delay to allow cleanup
     tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;

--- a/src/main.rs
+++ b/src/main.rs
@@ -160,6 +160,10 @@ async fn rav_main() -> Result<()> {
         audio_capture.channels(),
         audio_capture.sample_rate(),
     )?;
+    // The device for now; the tap below replaces it if it starts. Said here and
+    // corrected there rather than announced once in the middle, because the
+    // answer is not settled until the tap has had its turn.
+    app.listening_to(audio_capture.device_name());
 
     // A named theme that cannot be read is an error rather than a silent fall
     // back to the default: the display would look right and be the wrong theme.

--- a/src/ui/help.rs
+++ b/src/ui/help.rs
@@ -193,6 +193,46 @@ mod tests {
     }
 
     #[test]
+    fn a_row_with_no_key_still_reads_as_a_line() {
+        // What rav is listening to is reported, not offered, so it carries no
+        // key - and the key column is shared, so an empty one has to leave the
+        // description where every other row's sits rather than sliding left.
+        let rows = vec![
+            HelpRow {
+                key: "q",
+                description: "quit",
+                value: None,
+            },
+            HelpRow {
+                key: "",
+                description: "listening to",
+                value: Some("MacBook Pro Microphone".into()),
+            },
+        ];
+        let area = Rect::new(0, 0, 60, 12);
+        let mut buf = Buffer::empty(area);
+        Help {
+            rows: &rows,
+            title: "rav",
+        }
+        .render(area, &mut buf);
+        let out = text_of(&buf);
+
+        assert!(out.contains("listening to"), "missing the row:\n{out}");
+        assert!(
+            out.contains("MacBook Pro Microphone"),
+            "the source is the whole point of the row:\n{out}",
+        );
+
+        let column = |needle: &str| out.lines().find_map(|l| l.find(needle));
+        assert_eq!(
+            column("listening to"),
+            column("quit"),
+            "the keyless row is not aligned with the rest:\n{out}",
+        );
+    }
+
+    #[test]
     fn the_panel_is_centred_and_framed() {
         let buf = render(60, 12);
         let out = text_of(&buf);

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -208,6 +208,14 @@ pub struct App {
     /// Briefly shown after a settings key, so a change is visible without a
     /// permanent status bar cluttering the display.
     status: Option<(String, Instant)>,
+    /// What rav is listening to, for the help overlay to name.
+    ///
+    /// "Why are the bars showing the wrong thing" has one answer and it is this,
+    /// and until now it was only in `rav.log`. A microphone hears the room, so a
+    /// display fed by one moves convincingly while showing nothing of what is
+    /// playing - which looks like rav working rather than rav on the wrong
+    /// source.
+    source: Option<String>,
     /// When present, audio comes from here rather than the cpal channel.
     #[cfg(target_os = "macos")]
     tap: Option<crate::audio::tap::Tap>,
@@ -280,6 +288,7 @@ impl App {
             bar_style: BarStyle::default(),
             show_help: false,
             status: None,
+            source: None,
             #[cfg(target_os = "macos")]
             tap: None,
             #[cfg(target_os = "macos")]
@@ -513,7 +522,7 @@ impl App {
             Bandwidth::Wide => "wide",
             Bandwidth::Thin => "thin",
         };
-        vec![
+        let mut rows = vec![
             HelpRow {
                 key: "space",
                 description: "switch visualisation",
@@ -574,7 +583,27 @@ impl App {
                 description: "quit",
                 value: None,
             },
-        ]
+        ];
+        // Last, and with no key, because it is the one line here that reports
+        // rather than offers - and it is what the rest of the panel is worth
+        // nothing without.
+        if let Some(source) = &self.source {
+            rows.push(HelpRow {
+                key: "",
+                description: "listening to",
+                value: Some(source.clone()),
+            });
+        }
+        rows
+    }
+
+    /// Name the source the display is being fed from.
+    ///
+    /// Set once the source is settled, never guessed: on macOS the tap is tried
+    /// *after* the capture device is opened, so anything announced earlier can
+    /// be contradicted a moment later.
+    pub fn listening_to(&mut self, source: impl Into<String>) {
+        self.source = Some(source.into());
     }
 
     /// Feed the rolling window from a process tap instead of a cpal stream.
@@ -584,6 +613,7 @@ impl App {
         self.sample_rate = tap.sample_rate();
         self.sized_for = (0, 0); // the mapping depends on the sample rate
         self.tap = Some(tap);
+        self.listening_to("system audio");
     }
 
     pub async fn run(&mut self, audio_receiver: Receiver<AudioData>) -> Result<()> {
@@ -1248,6 +1278,34 @@ mod tests {
 
         a.apply(Action::ToggleHelp);
         assert!(!a.show_help);
+    }
+
+    #[test]
+    fn the_overlay_says_what_rav_is_listening_to() {
+        // "Why are the bars showing the wrong thing" has one answer and this is
+        // where it is now. A microphone hears the room, so a display fed by one
+        // moves convincingly while showing nothing of what is playing - which
+        // reads as rav working, not as rav on the wrong source.
+        let mut a = app();
+        assert!(
+            a.help_rows()
+                .iter()
+                .all(|r| r.description != "listening to"),
+            "a source nobody has named is not worth a row",
+        );
+
+        a.listening_to("MacBook Pro Microphone");
+        let source = a
+            .help_rows()
+            .into_iter()
+            .find(|r| r.description == "listening to")
+            .and_then(|r| r.value);
+        assert_eq!(source, Some("MacBook Pro Microphone".to_string()));
+
+        // And it is the panel's last word, after everything you can press.
+        let rows = a.help_rows();
+        assert_eq!(rows.last().unwrap().description, "listening to");
+        assert_eq!(rows.last().unwrap().key, "", "it is not a key you press");
     }
 
     #[test]


### PR DESCRIPTION
> Stacked on #72 — merge that first, and this diff is only its own two commits.

Two answers to "why are the bars showing the wrong thing", which until now rav knew and kept to itself.

**`h` says what rav is listening to.** Every other setting was already in that panel; the one that decides whether the display means anything was not. It reads `system audio`, or the device by name:

```
  up/down   gain (0 resets)                    +0 dB
  h         this help
  q         quit
            listening to        MacBook Pro Microphone
```

A microphone hears the room, so a display fed by one moves convincingly while showing none of what is playing — which reads as rav working, not as rav on the wrong source. `docs/troubleshooting.md` exists largely to walk someone through a log file to find this out.

It is named after the source is settled rather than during startup, and that ordering is the whole of the care here: macOS opens the capture device first and tries the process tap *afterwards*. Anything announced in between gets contradicted about forty milliseconds later — a warning that system audio will not be shown, on a run that is showing it. The help panel renders long after the question is closed.

**`--test-audio` plays something.** The flag has been in `--help` for a long time promising a test generator instead of real audio input. It was parsed and never read: `rav --test-audio` opened the capture device and the process tap exactly as without it.

It now sweeps a sine from 40 Hz to 16 kHz every twelve seconds. A sweep rather than a tone, because a single frequency lights one bar and proves almost nothing, while a sweep walks the display — every band, the bar fall, and the caps hanging behind the peak, all in one pass. Slow enough to watch the motion, loud enough to see it, quiet enough that nothing clips flat.

The point is that it opens **no device at all**. A machine with no loopback, no recording permission or no sound card still shows a working display, which is the difference between "rav is broken" and "rav cannot hear anything here". On Linux, where routing system output into a capture is genuinely awkward, it is the first thing worth running — and it is what a demo needs (#69).

Measured: the display runs 60 frames from 105 wakes, the same cadence a real device gives, and the log shows no device and no tap opened. A run without the flag is unchanged.

One detail worth keeping: the phase is integrated rather than computed from frequency times time. A sweep moves its frequency every sample, and `sin(2πft)` with a moving `f` jumps the phase each time it moves — a click per sample, which reads as noise across the whole display instead of a peak.
