### PR TITLE
fix(ci): attach the Linux binary to the release it belongs to

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -277,11 +277,24 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
           RELEASES: ${{ steps.release-plz.outputs.releases }}
         run: |
+          # What was released, before looking for `rav` among it. An empty list
+          # here means the output is not the shape this expects any more, and
+          # that has to be loud: the whole reason three releases shipped without
+          # a binary is that the one step which knew kept failing where nobody
+          # read it. "Cannot find the tag" must never be indistinguishable from
+          # "there was no tag to find".
+          RELEASED=$(echo "$RELEASES" | jq -r '.[].package_name | select(. != null)' | paste -sd' ' -)
+          if [ -z "$RELEASED" ]; then
+            echo "released nothing this run, or the output changed shape:"
+            echo "$RELEASES"
+            exit 1
+          fi
+
           TAG=$(echo "$RELEASES" | jq -r '.[] | select(.package_name == "rav") | .tag')
-          # A run that released only the libraries has no binary to attach, and
-          # that is not a failure.
+          # Only the libraries moved. There is no binary to attach to a release
+          # that was never created, and that is an ordinary outcome.
           if [ -z "$TAG" ] || [ "$TAG" = "null" ]; then
-            echo "no rav release in this run - nothing to attach"
+            echo "released $RELEASED - no rav among them, so nothing to attach"
             exit 0
           fi
           chmod +x dist/rav

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -264,14 +264,26 @@ jobs:
       # The tag comes from release-plz's own output. It creates the tag through
       # the GitHub API, so the tag exists on the remote while this checkout has
       # none of it - git describe finds nothing here.
+      #
+      # Chosen by name rather than by position. release-plz lists what it
+      # released in dependency order, so `rav-core` comes first - and `rav` is
+      # the only one of the three that has a GitHub release to attach anything
+      # to, the two libraries carrying `git_release_enable = false`. Taking the
+      # first entry uploaded to a release that does not exist, which is why
+      # beta.6, beta.7 and beta.8 all shipped with no binary on them.
       - name: Attach it to the release
         if: steps.release-plz.outputs.releases_created == 'true'
         env:
           GITHUB_TOKEN: ${{ github.token }}
           RELEASES: ${{ steps.release-plz.outputs.releases }}
         run: |
-          TAG=$(echo "$RELEASES" | jq -r '.[0].tag')
-          test -n "$TAG" && test "$TAG" != "null"
+          TAG=$(echo "$RELEASES" | jq -r '.[] | select(.package_name == "rav") | .tag')
+          # A run that released only the libraries has no binary to attach, and
+          # that is not a failure.
+          if [ -z "$TAG" ] || [ "$TAG" = "null" ]; then
+            echo "no rav release in this run - nothing to attach"
+            exit 0
+          fi
           chmod +x dist/rav
           mv dist/rav dist/rav-linux-x86_64
           gh release upload "$TAG" dist/rav-linux-x86_64 --clobber


### PR DESCRIPTION
**Three releases have gone out with nothing on them to download.** beta.6, beta.7 and beta.8 each have zero assets — someone landing on the releases page to fetch a Linux build gets source and nothing else.

The step that uploads the binary picked its tag with `.[0].tag`. release-plz lists what it released in dependency order, so the first entry is `rav-core` — which carries `git_release_enable = false` and therefore has no GitHub release at all:

```
RELEASES  [ rav-core-v1.0.0-beta.8, rav-appearance-v1.0.0-beta.8, rav-v1.0.0-beta.8 ]
             ^ .[0], no release exists for it

gh release upload rav-core-v1.0.0-beta.8 …
→ release not found
→ ##[error]Process completed with exit code 1
```

So the release job has been failing at its last step ever since the workspace was split into three crates, and the red run said "Release: failure" while everything a user gets had in fact published.

**The publish itself was never affected.** All three crates reached crates.io at each of those versions and all three tags exist. What was missing is only the attached binary.

It now selects the `rav` entry by name. A run that releases only the libraries has no binary to attach, so it says so and exits rather than failing — that case would otherwise turn a perfectly good library release red.

beta.8's binary has been uploaded by hand, so the release that just shipped is not left bare while this waits.
