### PR TITLE
feat: rav can draw its bars as pixels

### DIFF
--- a/src/surface/frame.rs
+++ b/src/surface/frame.rs
@@ -1,0 +1,279 @@
+//! Turning what the analyser measured into a frame of pixels.
+//!
+//! The join between the numbers and the picture, and the only place that knows
+//! both. Above it the analyser deals in levels; below it the terminal deals in
+//! bytes; here a theme becomes ramps and a set of levels becomes bars standing
+//! in columns.
+//!
+//! Owned rather than borrowed, because a [`Scene`] holds references to its
+//! bands and styles and something has to be holding them. That something lives
+//! for a frame.
+
+use crate::render::{Band, Canvas, CapStyle, Draw, Ramp, Scene, Style};
+use crate::visual::{Palette, Theme};
+use rav_core::geometry::{BarLayout, Screen};
+use rav_core::units::{Length, Level};
+
+/// How the picture should look, before any of it is resolved to colours.
+///
+/// A theme names colours and the user switches things on and off; neither is a
+/// ramp until a palette has had its say, and only this layer has one. Keeping
+/// them together is what the settings actually are - "the look" - rather than
+/// four arguments that happen to travel side by side.
+pub struct Look<'a> {
+    pub theme: &'a Theme,
+    /// The terminal's own colours, for a theme that named rather than spelled.
+    pub palette: &'a Palette,
+    /// The unlit part of each column, which `g` switches.
+    pub backdrop: bool,
+    /// How thick a peak cap is, or `None` when `p` has switched them off.
+    pub caps: Option<Length>,
+}
+
+/// Everything a frame needs, held for as long as it takes to draw.
+pub struct Frame {
+    bands: Vec<Band>,
+    bars: Ramp,
+    grid: Option<Ramp>,
+    cap: Option<CapStyle>,
+    layout: BarLayout,
+    screen: Screen,
+}
+
+impl Frame {
+    /// Compose a frame from levels and the look they wear.
+    ///
+    /// `levels` and `peaks` are what the ballistics currently hold: a fraction
+    /// of full scale per band.
+    pub fn new(
+        levels: &[f32],
+        peaks: &[f32],
+        look: &Look<'_>,
+        layout: BarLayout,
+        screen: Screen,
+    ) -> Self {
+        let bands = levels
+            .iter()
+            .zip(peaks.iter().chain(std::iter::repeat(&0.0)))
+            .map(|(&level, &peak)| Band::new(Level::new(level), Level::new(peak)))
+            .collect();
+        Self {
+            bands,
+            bars: look.theme.bar_ramp(look.palette),
+            grid: look.backdrop.then(|| look.theme.grid_ramp(look.palette)),
+            cap: look.caps.map(|thickness| CapStyle {
+                colour: look.theme.cap_colour(look.palette),
+                thickness,
+            }),
+            layout,
+            screen,
+        }
+    }
+
+    /// Draw it, and hand back the pixels.
+    ///
+    /// RGBA, `width * height * 4` bytes, ready for the terminal to read - see
+    /// [`super::pixels`], which never encodes them.
+    pub fn pixels(&self) -> Option<Vec<u8>> {
+        let mut canvas = Canvas::for_screen(&self.screen)?;
+        canvas.clear();
+        let styles = [Style {
+            bars: &self.bars,
+            grid: self.grid.as_ref(),
+            cap: self.cap,
+        }];
+        Scene {
+            bands: &self.bands,
+            layout: self.layout,
+            screen: self.screen,
+            styles: &styles,
+        }
+        .draw(&mut canvas);
+        Some(canvas.to_rgba())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rav_core::geometry::Column;
+
+    const WIDE: f32 = 240.0;
+    const TALL: f32 = 120.0;
+
+    fn screen() -> Screen {
+        Screen::new(Length(WIDE), Length(TALL))
+    }
+
+    fn layout() -> BarLayout {
+        BarLayout::new(Length(20.0), Length(4.0))
+    }
+
+    /// The pixel at `(x, y)`, as `(r, g, b, a)`.
+    fn at(pixels: &[u8], x: u32, y: u32) -> (u8, u8, u8, u8) {
+        let i = ((y * WIDE as u32 + x) * 4) as usize;
+        (pixels[i], pixels[i + 1], pixels[i + 2], pixels[i + 3])
+    }
+
+    /// The default look, for the cases that are not about how it looks.
+    ///
+    /// Leaks its theme and palette rather than threading two more bindings
+    /// through every caller; a handful of allocations for the whole test run.
+    fn plain() -> Look<'static> {
+        Look {
+            theme: Box::leak(Box::new(Theme::default())),
+            palette: Box::leak(Box::new(Palette::default())),
+            backdrop: true,
+            caps: None,
+        }
+    }
+
+    fn frame(levels: &[f32], peaks: &[f32], backdrop: bool) -> Vec<u8> {
+        capped(levels, peaks, backdrop, Some(Length(2.0)))
+    }
+
+    fn capped(levels: &[f32], peaks: &[f32], backdrop: bool, caps: Option<Length>) -> Vec<u8> {
+        let theme = Theme::default();
+        let palette = Palette::default();
+        let look = Look {
+            theme: &theme,
+            palette: &palette,
+            backdrop,
+            caps,
+        };
+        Frame::new(levels, peaks, &look, layout(), screen())
+            .pixels()
+            .expect("a screen with area")
+    }
+
+    #[test]
+    fn a_frame_is_the_size_the_screen_asked_for() {
+        let pixels = frame(&[0.5], &[0.5], true);
+        assert_eq!(pixels.len(), (WIDE * TALL * 4.0) as usize);
+    }
+
+    #[test]
+    fn a_full_bar_wears_the_top_of_the_ramp_and_a_silent_one_the_bottom() {
+        // The rule the whole look rests on: colour follows height, not the
+        // band's own level. A bar reaching the ceiling is red up there and green
+        // down at the floor - the same green a bar that never leaves the floor
+        // shows.
+        let pixels = frame(&[1.0], &[1.0], false);
+        let inside = layout().column(0).left().get() as u32 + 5;
+
+        let floor = at(&pixels, inside, TALL as u32 - 2);
+        let ceiling = at(&pixels, inside, 4);
+        assert!(
+            floor.1 > floor.0,
+            "the foot of the bar is not green: {floor:?}"
+        );
+        assert!(ceiling.0 > ceiling.1, "the top is not red: {ceiling:?}");
+    }
+
+    #[test]
+    fn the_backdrop_shows_the_colour_a_bar_would_reach() {
+        // What `g` turns on: the unlit part of a column previewing where the bar
+        // is going. Above a half-height bar the column is still painted, and in
+        // the same hue family the bar would be if it got there.
+        let lit = frame(&[0.5], &[0.5], true);
+        let bare = frame(&[0.5], &[0.5], false);
+        let inside = layout().column(0).left().get() as u32 + 5;
+
+        let above_the_bar = TALL as u32 / 4;
+        assert_ne!(
+            at(&lit, inside, above_the_bar).3,
+            0,
+            "the backdrop left the column empty",
+        );
+        assert_eq!(
+            at(&bare, inside, above_the_bar).3,
+            0,
+            "the column was painted with the backdrop switched off",
+        );
+    }
+
+    #[test]
+    fn a_silent_band_shows_its_cap_resting_on_the_floor_and_nothing_else() {
+        // Every frame of a quiet passage. With caps off a silent band is empty;
+        // with them on the only thing drawn is the cap, held inside the screen
+        // at the bottom rather than half off it.
+        let inside = layout().column(0).left().get() as u32 + 5;
+
+        let bare = capped(&[0.0], &[0.0], false, None);
+        for y in [1u32, TALL as u32 / 2, TALL as u32 - 2] {
+            assert_eq!(at(&bare, inside, y).3, 0, "something drawn at y={y}");
+        }
+
+        let with_cap = capped(&[0.0], &[0.0], false, Some(Length(2.0)));
+        assert_eq!(at(&with_cap, inside, 1).3, 0, "something up at the ceiling");
+        assert_eq!(
+            at(&with_cap, inside, TALL as u32 / 2).3,
+            0,
+            "a bar where there is no signal",
+        );
+        assert_ne!(
+            at(&with_cap, inside, TALL as u32 - 1).3,
+            0,
+            "the cap fell off the bottom of the screen",
+        );
+    }
+
+    #[test]
+    fn the_gap_between_columns_stays_empty() {
+        // Bars that merged into a solid block would read as one loud band across
+        // the whole spectrum.
+        let pixels = frame(&[1.0, 1.0], &[1.0, 1.0], true);
+        let first = layout().column(0);
+        let second = layout().column(1);
+        let between = (first.right().get() + second.left().get()) as u32 / 2;
+        assert_eq!(
+            at(&pixels, between, TALL as u32 / 2).3,
+            0,
+            "the columns ran together",
+        );
+    }
+
+    #[test]
+    fn a_cap_is_drawn_where_the_bar_is_not() {
+        // The defect a terminal cell cannot fix: there, a cap and the backdrop
+        // compete for one cell and the cap wins by erasing it. Here they are two
+        // rectangles, so the cap marks the peak *above* a lower bar without
+        // taking anything away from it.
+        let pixels = frame(&[0.3], &[0.8], true);
+        let inside = layout().column(0).left().get() as u32 + 5;
+
+        // The cap rides at 0.8 of the height, measured down from the ceiling.
+        let cap_row = (TALL * (1.0 - 0.8)) as u32;
+        let cap = at(&pixels, inside, cap_row);
+        let bar = at(&pixels, inside, TALL as u32 - 4);
+        assert_ne!(cap.3, 0, "no cap at the peak");
+        assert_ne!(bar.3, 0, "the bar went missing under its own cap");
+        assert_ne!(cap, bar, "the cap is indistinguishable from the bar");
+    }
+
+    #[test]
+    fn a_screen_with_no_area_gives_no_frame() {
+        // A terminal mid-resize, every time one is dragged.
+        let nothing = Screen::new(Length::NONE, Length::NONE);
+        let none = Frame::new(&[0.5], &[0.5], &plain(), layout(), nothing);
+        assert!(none.pixels().is_none());
+    }
+
+    #[test]
+    fn fewer_peaks_than_bands_is_not_a_panic() {
+        // The two arrive from the same place today, but a resize lands between
+        // them often enough that a mismatch must be a quiet frame rather than a
+        // crash mid-render.
+        let short = Frame::new(&[0.5, 0.5, 0.5], &[0.5], &plain(), layout(), screen());
+        assert!(short.pixels().is_some());
+    }
+
+    /// Where a column sits, for the assertions above.
+    #[test]
+    fn the_columns_are_where_the_tests_think_they_are() {
+        let first: Column = layout().column(0);
+        assert_eq!(first.left(), Length::NONE);
+        assert_eq!(first.right(), Length(20.0));
+        assert_eq!(layout().column(1).left(), Length(24.0));
+    }
+}

--- a/src/surface/kitty.rs
+++ b/src/surface/kitty.rs
@@ -1,0 +1,248 @@
+//! The kitty graphics protocol, as the three things rav says in it.
+//!
+//! An enum rather than a builder, so the combinations that mean nothing cannot
+//! be written down: there is no way to ask for a delete with a width, or to
+//! transmit a frame and forget its size. Every field the terminal needs for a
+//! given command is a field of that variant.
+//!
+//! # Pixels do not go through base64
+//!
+//! A command is an APC string - `ESC _ G` … `ESC \` - and everything after the
+//! `;` is base64 by the protocol's rules, because the payload shares a channel
+//! with the escape that ends it. That would be a 33% tax on every frame, which
+//! at 2400x1440 is 13.8MB becoming 18.4MB, sixty times a second, through a pty.
+//!
+//! So the frame is not the payload. It is written to a file and the *path* is
+//! the payload: about thirty bytes encoded, while the pixels reach the terminal
+//! as a plain write to shared memory. That is the whole reason rav uses `t=t`
+//! rather than the direct transport, and it is why [`Payload`] exists as its own
+//! type - the encoding is a property of the channel, not of a frame, and having
+//! a name makes it obvious that no frame is passing through it.
+
+use std::fmt::Write as _;
+use std::path::Path;
+
+/// The image id every frame is sent under.
+///
+/// One, reused. A fresh id per frame leaves the terminal holding every frame it
+/// has ever been sent.
+const IMAGE_ID: u32 = 1;
+
+/// Something small enough to travel inside an escape sequence.
+///
+/// Base64 because the protocol says so - the payload shares a channel with the
+/// escape that terminates it, so raw bytes could end the command early. **No
+/// frame is ever one of these**; see the module note.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Payload(String);
+
+impl Payload {
+    /// A path to a staged frame.
+    ///
+    /// Encoded rather than written out, because a path may hold a `,` or a `;`
+    /// and the terminal would read those as more of the command.
+    pub fn path(path: &Path) -> Self {
+        Self(encode(path.to_string_lossy().as_bytes()))
+    }
+
+    /// Raw bytes - only ever a handful, for the query below.
+    pub fn bytes(raw: &[u8]) -> Self {
+        Self(encode(raw))
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+/// One thing rav says to the terminal.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Command<'a> {
+    /// Draw a frame that has been staged where the terminal can read it.
+    ///
+    /// `bytes` is how much to read: a direct payload carries its own length and
+    /// a file does not, so without it the terminal reads nothing, draws
+    /// nothing, and reports success.
+    Draw {
+        frame: &'a Path,
+        bytes: usize,
+        width: u32,
+        height: u32,
+    },
+    /// Ask whether images are supported at all. Draws nothing either way.
+    Ask,
+    /// Take every image off the screen.
+    ///
+    /// Every one, not one by one: a panic hook has no idea which ids are live,
+    /// and a frame left behind is painted over the shell the user returns to.
+    Erase,
+}
+
+impl Command<'_> {
+    /// The escape sequence, ready to write.
+    pub fn escape(&self) -> String {
+        let mut out = String::from("\x1b_G");
+        match self {
+            Self::Draw {
+                frame,
+                bytes,
+                width,
+                height,
+            } => {
+                // `q=2` silences the acknowledgement. Sixty a second would
+                // arrive on the descriptor rav reads keypresses from.
+                //
+                // `z=0` is the default and is written anyway: below zero the
+                // frame sits under every cell's background, and a terminal
+                // running any theme gives every cell one - so a negative z is a
+                // blank screen with every frame transmitted successfully.
+                //
+                // `C=1` leaves the cursor alone. Without it the terminal parks
+                // it past the frame's bottom-right, so the next frame is placed
+                // from there and the picture walks off the screen.
+                let _ = write!(
+                    out,
+                    "a=T,q=2,i={IMAGE_ID},f=32,s={width},v={height},z=0,C=1,S={bytes},t=t;{}",
+                    Payload::path(frame).as_str(),
+                );
+            }
+            Self::Ask => {
+                // One opaque pixel, transmitted directly and only queried, so
+                // there is nothing to stage and nothing appears.
+                let _ = write!(
+                    out,
+                    "i={IMAGE_ID},s=1,v=1,a=q,t=d,f=24;{}",
+                    Payload::bytes(&[0, 0, 0]).as_str(),
+                );
+            }
+            Self::Erase => out.push_str("a=d,d=A"),
+        }
+        out.push_str("\x1b\\");
+        out
+    }
+}
+
+fn encode(bytes: &[u8]) -> String {
+    const ALPHABET: &[u8; 64] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+    let mut out = String::with_capacity(bytes.len().div_ceil(3) * 4);
+    for group in bytes.chunks(3) {
+        let b = [
+            group[0],
+            group.get(1).copied().unwrap_or(0),
+            group.get(2).copied().unwrap_or(0),
+        ];
+        let n = (u32::from(b[0]) << 16) | (u32::from(b[1]) << 8) | u32::from(b[2]);
+        for i in 0..4 {
+            if i <= group.len() {
+                out.push(ALPHABET[(n >> (18 - i * 6)) as usize & 0x3f] as char);
+            } else {
+                out.push('=');
+            }
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn base64_matches_the_standard_alphabet_and_padding() {
+        // The terminal decodes this. A wrong table hands it a path that does not
+        // exist, and it draws nothing without saying so.
+        assert_eq!(encode(b""), "");
+        assert_eq!(encode(b"f"), "Zg==");
+        assert_eq!(encode(b"fo"), "Zm8=");
+        assert_eq!(encode(b"foo"), "Zm9v");
+        assert_eq!(encode(b"foobar"), "Zm9vYmFy");
+        assert_eq!(encode(&[0xff, 0xef, 0xfe]), "/+/+", "the last two symbols");
+    }
+
+    #[test]
+    fn drawing_says_everything_the_terminal_needs() {
+        let escape = Command::Draw {
+            frame: Path::new("/dev/shm/rav-1-0.rgba"),
+            bytes: 40_000,
+            width: 100,
+            height: 100,
+        }
+        .escape();
+
+        // Byte for byte the sequence measured at 60fps in WezTerm, so drifting
+        // from the only form known to draw is a failure here rather than a
+        // blank screen there.
+        assert_eq!(
+            escape,
+            format!(
+                "\x1b_Ga=T,q=2,i=1,f=32,s=100,v=100,z=0,C=1,S=40000,t=t;{}\x1b\\",
+                encode(b"/dev/shm/rav-1-0.rgba"),
+            ),
+        );
+    }
+
+    #[test]
+    fn a_path_travels_encoded_rather_than_raw() {
+        // A `,` or a `;` in a path would otherwise be read as more of the
+        // command, and the frame would be misread or dropped.
+        let escape = Command::Draw {
+            frame: Path::new("/tmp/a,b;c/rav-0.rgba"),
+            bytes: 4,
+            width: 1,
+            height: 1,
+        }
+        .escape();
+        assert!(!escape.contains("/tmp/a,b;c"), "the path went out raw");
+        assert!(escape.contains(&encode(b"/tmp/a,b;c/rav-0.rgba")));
+    }
+
+    #[test]
+    fn asking_draws_nothing_and_erasing_takes_everything() {
+        let ask = Command::Ask.escape();
+        assert!(ask.contains("a=q"), "a query, so nothing appears");
+        assert!(!ask.contains("a=T"), "this would put a pixel on the screen");
+        assert!(ask.contains("t=d"), "three bytes need no file");
+
+        assert_eq!(Command::Erase.escape(), "\x1b_Ga=d,d=A\x1b\\");
+    }
+
+    #[test]
+    fn every_command_is_a_complete_apc_string() {
+        // An unterminated escape leaves the terminal consuming whatever follows
+        // - including the next frame - as though it were part of this one.
+        for command in [
+            Command::Draw {
+                frame: Path::new("/tmp/f"),
+                bytes: 1,
+                width: 1,
+                height: 1,
+            },
+            Command::Ask,
+            Command::Erase,
+        ] {
+            let escape = command.escape();
+            assert!(escape.starts_with("\x1b_G"), "{command:?} is not an APC");
+            assert!(escape.ends_with("\x1b\\"), "{command:?} is unterminated");
+        }
+    }
+
+    #[test]
+    fn a_frame_is_never_a_payload() {
+        // The point of the file transport, and the thing a refactor would undo
+        // first. A megabyte through `Payload` is a megabyte and a third through
+        // the pty, sixty times a second.
+        let frame = vec![0u8; 4096];
+        let escape = Command::Draw {
+            frame: Path::new("/dev/shm/f"),
+            bytes: frame.len(),
+            width: 32,
+            height: 32,
+        }
+        .escape();
+        assert!(
+            escape.len() < 120,
+            "the command grew with the frame: {} bytes",
+            escape.len(),
+        );
+    }
+}

--- a/src/surface/mod.rs
+++ b/src/surface/mod.rs
@@ -6,6 +6,7 @@
 //! class in this area, so it ships first with its only possible symptom being a
 //! wrong label.
 
+pub mod kitty;
 pub mod pixels;
 
 use crate::render::Capabilities;
@@ -197,10 +198,7 @@ fn probe_via<W: Write, R: Read + AsRawFd>(out: &mut W, input: &mut R) -> bool {
     // silence and there is nothing to wait for. Terminals answer queries in the
     // order they arrive, so a `CSI c` reply with no graphics reply ahead of it
     // is a definite no, available immediately.
-    let pixel = "AAAA"; // three zero bytes, base64
-    if write!(out, "\x1b_Gi=31,s=1,v=1,a=q,t=d,f=24;{pixel}\x1b\\\x1b[c").is_err()
-        || out.flush().is_err()
-    {
+    if write!(out, "{}\x1b[c", kitty::Command::Ask.escape()).is_err() || out.flush().is_err() {
         return false;
     }
 

--- a/src/surface/mod.rs
+++ b/src/surface/mod.rs
@@ -145,12 +145,16 @@ pub fn choose(asked: Choice, multiplexed: bool, answers: impl FnOnce() -> bool) 
         Choice::Auto if multiplexed => glyphs("tmux or screen is in the way"),
         // Not a guard, because calling `answers` consumes it and a match guard
         // only gets a borrow.
+        // Pixels are asked for, never assumed. A terminal that says it can draw
+        // images is told so and left on block characters, because "it looked
+        // fine on the one terminal that was tried" is not something a default
+        // can rest on - and a default that turns out wrong is a broken display
+        // for everybody rather than for whoever opted in.
+        //
+        // The line to change when that is no longer true is the one below.
         Choice::Auto => {
             if answers() {
-                Chosen {
-                    surface: Surface::Kitty,
-                    because: "your terminal can draw images",
-                }
+                glyphs("your terminal can draw images - try --surface kitty")
             } else {
                 glyphs("your terminal cannot draw images")
             }
@@ -329,11 +333,28 @@ mod tests {
     }
 
     #[test]
-    fn auto_follows_the_terminals_answer() {
-        assert_eq!(choose(Choice::Auto, false, || true).surface, Surface::Kitty);
+    fn nobody_gets_pixels_without_asking_for_them() {
+        // Both ways round, auto draws block characters. A terminal that can do
+        // better is told how, rather than being switched over on its behalf:
+        // the pixel surface has been seen working on one terminal, and a
+        // default that turns out wrong breaks the display for everyone instead
+        // of for whoever chose it.
+        let capable = choose(Choice::Auto, false, || true);
+        assert_eq!(capable.surface, Surface::Glyphs);
+        assert!(
+            capable.because.contains("--surface kitty"),
+            "a capable terminal was not told how to use it: {}",
+            capable.because,
+        );
         assert_eq!(
             choose(Choice::Auto, false, || false).surface,
             Surface::Glyphs
+        );
+
+        // Asking is still honoured, or there would be no way in at all.
+        assert_eq!(
+            choose(Choice::Kitty, false, || false).surface,
+            Surface::Kitty
         );
     }
 

--- a/src/surface/mod.rs
+++ b/src/surface/mod.rs
@@ -6,6 +6,8 @@
 //! class in this area, so it ships first with its only possible symptom being a
 //! wrong label.
 
+pub mod pixels;
+
 use crate::render::Capabilities;
 use rav_core::units::Cells;
 use std::io::{Read, Write};

--- a/src/surface/mod.rs
+++ b/src/surface/mod.rs
@@ -8,6 +8,7 @@
 
 pub mod frame;
 pub mod kitty;
+pub mod overlay;
 pub mod pixels;
 
 use crate::render::Capabilities;

--- a/src/surface/mod.rs
+++ b/src/surface/mod.rs
@@ -6,6 +6,7 @@
 //! class in this area, so it ships first with its only possible symptom being a
 //! wrong label.
 
+pub mod frame;
 pub mod kitty;
 pub mod pixels;
 

--- a/src/surface/mod.rs
+++ b/src/surface/mod.rs
@@ -126,10 +126,10 @@ pub fn choose(asked: Choice, multiplexed: bool, answers: impl FnOnce() -> bool) 
         because,
     };
     match asked {
-        Choice::Window => Chosen {
-            surface: Surface::Window,
-            because: "asked for",
-        },
+        // A window of rav's own is not built. Saying so beats reporting a
+        // surface nothing draws on and leaving the user to wonder why the
+        // picture looks exactly as it did before.
+        Choice::Window => glyphs("a window of rav's own is not built yet"),
         // An explicit request is honoured even where auto would decline, so a
         // terminal that does not answer the query but does draw images is still
         // reachable. It is the user's terminal and they can see the result.
@@ -143,8 +143,6 @@ pub fn choose(asked: Choice, multiplexed: bool, answers: impl FnOnce() -> bool) 
         // failure is a garbled screen rather than a missing picture - so auto
         // never picks pixels there, however the terminal answers.
         Choice::Auto if multiplexed => glyphs("tmux or screen is in the way"),
-        // Not a guard, because calling `answers` consumes it and a match guard
-        // only gets a borrow.
         // Pixels are asked for, never assumed. A terminal that says it can draw
         // images is told so and left on block characters, because "it looked
         // fine on the one terminal that was tried" is not something a default
@@ -152,6 +150,9 @@ pub fn choose(asked: Choice, multiplexed: bool, answers: impl FnOnce() -> bool) 
         // for everybody rather than for whoever opted in.
         //
         // The line to change when that is no longer true is the one below.
+        //
+        // Not a match guard, because calling `answers` consumes it and a guard
+        // only gets a borrow.
         Choice::Auto => {
             if answers() {
                 glyphs("your terminal can draw images - try --surface kitty")
@@ -356,6 +357,15 @@ mod tests {
             choose(Choice::Kitty, false, || false).surface,
             Surface::Kitty
         );
+    }
+
+    #[test]
+    fn asking_for_a_window_says_there_is_not_one_yet() {
+        // Reporting a surface nothing draws on leaves the user looking at a
+        // picture identical to the one before, wondering what the flag did.
+        let asked = choose(Choice::Window, false, || false);
+        assert_eq!(asked.surface, Surface::Glyphs);
+        assert!(asked.because.contains("not built"), "{}", asked.because);
     }
 
     #[test]

--- a/src/surface/overlay.rs
+++ b/src/surface/overlay.rs
@@ -1,0 +1,210 @@
+//! Writing the status line and the help panel over a picture made of pixels.
+//!
+//! A written cell blanks the image beneath it - any cell, at any z, even a
+//! space at the default background. So a pixel surface cannot hand its frame to
+//! ratatui and let it paint: `Terminal::draw` writes every cell in the buffer,
+//! and the picture would be erased the instant it was drawn.
+//!
+//! What it can do is let the same widgets render into a buffer of their own and
+//! then emit **only the cells they actually touched**. The overlay looks
+//! identical either way, because it is the same widget; the rest of the grid is
+//! never written, so the frame under it survives.
+
+use ratatui::buffer::Buffer;
+use ratatui::layout::Rect;
+use ratatui::style::Color;
+use ratatui::widgets::Widget;
+use std::fmt::Write as _;
+
+/// Render `widget` over `area` and return the escape sequence for the cells it
+/// used - nothing at all when it drew nothing.
+pub fn of(widget: impl Widget, area: Rect) -> String {
+    let mut buffer = Buffer::empty(area);
+    widget.render(area, &mut buffer);
+    written(&buffer)
+}
+
+/// The escapes for every cell a widget left something in.
+///
+/// "Something" is a symbol other than a space, or any background at all. A
+/// space with a background is how a panel is filled, and skipping it would
+/// leave the picture showing through the help text.
+fn written(buffer: &Buffer) -> String {
+    let mut out = String::new();
+    let area = buffer.area;
+    for y in area.top()..area.bottom() {
+        // Cells are addressed one at a time rather than in runs. A run would be
+        // fewer bytes, but the overlay is a few hundred cells against a frame
+        // of several million pixels - and a wrong run is a smear across the
+        // picture, which is a poor trade for bytes nobody is short of.
+        for x in area.left()..area.right() {
+            let cell = &buffer[(x, y)];
+            if cell.symbol() == " " && cell.bg == Color::Reset {
+                continue;
+            }
+            // Rows and columns are 1-based in `CUP`, and the cursor has to be
+            // put back afterwards or the next frame is placed from here.
+            let _ = write!(out, "\x1b[{};{}H", y + 1, x + 1);
+            out.push_str(&colours(cell.fg, cell.bg));
+            out.push_str(cell.symbol());
+            out.push_str("\x1b[0m");
+        }
+    }
+    out
+}
+
+/// The SGR sequence that sets a cell's colours.
+fn colours(fg: Color, bg: Color) -> String {
+    let mut out = String::from("\x1b[");
+    out.push_str(&code(fg, true));
+    out.push(';');
+    out.push_str(&code(bg, false));
+    out.push('m');
+    out
+}
+
+/// One colour as its SGR parameters.
+///
+/// Truecolour where the theme gave an exact colour, and the palette slot where
+/// it named one - which is what keeps `terminal` and `mono` following whatever
+/// the reader actually runs, exactly as the glyph surface does.
+fn code(colour: Color, foreground: bool) -> String {
+    let base = if foreground { 30 } else { 40 };
+    let bright = if foreground { 90 } else { 100 };
+    match colour {
+        Color::Reset => format!("{}", base + 9),
+        Color::Rgb(r, g, b) => format!("{};2;{r};{g};{b}", base + 8),
+        Color::Indexed(i) => format!("{};5;{i}", base + 8),
+        Color::Black => format!("{base}"),
+        Color::Red => format!("{}", base + 1),
+        Color::Green => format!("{}", base + 2),
+        Color::Yellow => format!("{}", base + 3),
+        Color::Blue => format!("{}", base + 4),
+        Color::Magenta => format!("{}", base + 5),
+        Color::Cyan => format!("{}", base + 6),
+        Color::Gray => format!("{}", base + 7),
+        Color::DarkGray => format!("{bright}"),
+        Color::LightRed => format!("{}", bright + 1),
+        Color::LightGreen => format!("{}", bright + 2),
+        Color::LightYellow => format!("{}", bright + 3),
+        Color::LightBlue => format!("{}", bright + 4),
+        Color::LightMagenta => format!("{}", bright + 5),
+        Color::LightCyan => format!("{}", bright + 6),
+        Color::White => format!("{}", bright + 7),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A widget that paints exactly the cells it is told to.
+    struct Spots(Vec<(u16, u16, &'static str, Color)>);
+
+    impl Widget for Spots {
+        fn render(self, _area: Rect, buffer: &mut Buffer) {
+            for (x, y, symbol, bg) in self.0 {
+                buffer[(x, y)].set_symbol(symbol).set_bg(bg);
+            }
+        }
+    }
+
+    fn area() -> Rect {
+        Rect::new(0, 0, 20, 5)
+    }
+
+    #[test]
+    fn a_widget_that_draws_nothing_writes_nothing() {
+        // Every frame with no status note and the help closed, which is almost
+        // all of them. One stray space would blank the picture.
+        let quiet = of(Spots(Vec::new()), area());
+        assert!(quiet.is_empty(), "wrote {quiet:?} over the frame");
+    }
+
+    #[test]
+    fn only_the_cells_a_widget_touched_are_written() {
+        // The whole reason this exists: a written cell blanks the image beneath
+        // it, so the overlay must cost exactly its own cells and no more.
+        let escape = of(
+            Spots(vec![(3, 1, "x", Color::Reset), (4, 1, "y", Color::Reset)]),
+            area(),
+        );
+        assert_eq!(escape.matches('H').count(), 2, "moved more than twice");
+        assert!(escape.contains("\x1b[2;4H"), "x is not at row 2, column 4");
+        assert!(escape.contains("\x1b[2;5H"), "y is not at row 2, column 5");
+    }
+
+    #[test]
+    fn a_space_with_a_background_is_a_cell_the_widget_meant() {
+        // How a panel is filled. Skipping it would leave the bars showing
+        // through the help text, which is the one place legibility beats the
+        // picture.
+        let filled = of(Spots(vec![(1, 1, " ", Color::Rgb(16, 20, 26))]), area());
+        assert!(!filled.is_empty(), "the panel's own background was dropped");
+        assert!(filled.contains("48;2;16;20;26"), "not that background");
+    }
+
+    #[test]
+    fn a_named_colour_goes_out_as_a_palette_slot() {
+        // What keeps `terminal` and `mono` following the reader's own colours:
+        // the name reaches the terminal as a slot, not as an colour rav picked.
+        let named = of(Spots(vec![(0, 0, "g", Color::Green)]), area());
+        assert!(
+            named.contains("42"),
+            "green is not the palette's green: {named}"
+        );
+        assert!(
+            !named.contains("48;2;"),
+            "it was resolved to an exact colour"
+        );
+    }
+
+    #[test]
+    fn the_real_help_panel_costs_its_own_cells_and_no_more() {
+        // The widget this exists for, rather than a stand-in. The panel is a
+        // few hundred cells in the middle of a large grid; everything outside it
+        // has to go unwritten or the picture is gone.
+        use crate::ui::help::{Help, HelpRow};
+
+        let rows = [
+            HelpRow {
+                key: "q",
+                description: "quit",
+                value: None,
+            },
+            HelpRow {
+                key: "t",
+                description: "theme",
+                value: Some("rav".into()),
+            },
+        ];
+        let grid = Rect::new(0, 0, 120, 40);
+        let escape = of(
+            Help {
+                rows: &rows,
+                title: "rav",
+            },
+            grid,
+        );
+
+        let touched = escape.matches("\x1b[").count() / 3; // move, colours, reset
+        let whole_grid = usize::from(grid.width) * usize::from(grid.height);
+        assert!(touched > 0, "the panel drew nothing");
+        assert!(
+            touched < whole_grid / 4,
+            "{touched} of {whole_grid} cells written - the frame is gone",
+        );
+        assert!(
+            escape.contains("48;2;16;20;26"),
+            "the panel lost its own background, so the bars show through it",
+        );
+    }
+
+    #[test]
+    fn every_cell_puts_the_style_back() {
+        // Left set, the next thing written to this terminal wears the overlay's
+        // colours - including the shell, after rav exits.
+        let escape = of(Spots(vec![(0, 0, "a", Color::Red)]), area());
+        assert!(escape.ends_with("\x1b[0m"), "the style was left on");
+    }
+}

--- a/src/surface/pixels.rs
+++ b/src/surface/pixels.rs
@@ -22,11 +22,9 @@
 //! **One image id, reused.** A new id per frame leaves the terminal holding
 //! every frame ever sent.
 
+use super::kitty::Command;
 use std::io::{self, Write};
 use std::path::{Path, PathBuf};
-
-/// The id every frame is sent under.
-const IMAGE_ID: u32 = 1;
 
 /// How long a frame may go unread before its staging file is reclaimed, in
 /// frames. The terminal unlinks what it reads, so this normally finds nothing;
@@ -88,8 +86,16 @@ impl Pixels {
         // read half a frame or find the file already gone - and it would happen
         // under exactly the lag this transport exists to tolerate.
         let path = dir.join(format!("rav-{}-{}.rgba", std::process::id(), self.sent));
+        // The frame goes to the file exactly as it is. Nothing encodes it: the
+        // command below carries the path, not the pixels.
         std::fs::write(&path, frame)?;
-        out.write_all(&transmission(&path, frame.len(), width, height))?;
+        let command = Command::Draw {
+            frame: &path,
+            bytes: frame.len(),
+            width,
+            height,
+        };
+        out.write_all(command.escape().as_bytes())?;
 
         if let Some(stale) = self.sent.checked_sub(LAG_TOLERATED) {
             let _ = std::fs::remove_file(dir.join(format!(
@@ -115,111 +121,57 @@ impl Pixels {
     }
 }
 
-/// The escape sequence that places a staged frame.
-fn transmission(path: &Path, bytes: usize, width: u32, height: u32) -> Vec<u8> {
-    let encoded = base64(path.to_string_lossy().as_bytes());
-    // `z=0` is the default and is written anyway. Below zero puts the frame
-    // under every cell's background, and a terminal running any theme gives
-    // every cell one - so a negative z is a blank screen that still reports
-    // every frame transmitted successfully.
-    format!(
-        "\x1b_Ga=T,q=2,i={IMAGE_ID},f=32,s={width},v={height},z=0,C=1,S={bytes},t=t;{encoded}\x1b\\"
-    )
-    .into_bytes()
-}
-
 /// Take every image off the screen.
 ///
 /// Belongs in a panic hook as much as in a clean exit: `panic = "abort"` still
 /// runs one, and without this a panic leaves pixels painted over the shell the
 /// user comes back to.
 pub fn clear(out: &mut impl Write) -> io::Result<()> {
-    out.write_all(b"\x1b_Ga=d,d=A\x1b\\")?;
+    out.write_all(Command::Erase.escape().as_bytes())?;
     out.flush()
-}
-
-fn base64(bytes: &[u8]) -> String {
-    const ALPHABET: &[u8; 64] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
-    let mut out = String::with_capacity(bytes.len().div_ceil(3) * 4);
-    for group in bytes.chunks(3) {
-        let b = [
-            group[0],
-            group.get(1).copied().unwrap_or(0),
-            group.get(2).copied().unwrap_or(0),
-        ];
-        let n = (u32::from(b[0]) << 16) | (u32::from(b[1]) << 8) | u32::from(b[2]);
-        for i in 0..4 {
-            if i <= group.len() {
-                out.push(ALPHABET[(n >> (18 - i * 6)) as usize & 0x3f] as char);
-            } else {
-                out.push('=');
-            }
-        }
-    }
-    out
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    fn sequence(path: &str, bytes: usize, width: u32, height: u32) -> String {
-        String::from_utf8(transmission(Path::new(path), bytes, width, height)).unwrap()
-    }
-
     #[test]
-    fn base64_matches_the_standard_alphabet_and_padding() {
-        // The terminal decodes this; a wrong table sends it a path that does not
-        // exist and it draws nothing, silently.
-        assert_eq!(base64(b""), "");
-        assert_eq!(base64(b"f"), "Zg==");
-        assert_eq!(base64(b"fo"), "Zm8=");
-        assert_eq!(base64(b"foo"), "Zm9v");
-        assert_eq!(base64(b"foobar"), "Zm9vYmFy");
-        assert_eq!(base64(&[0xff, 0xef, 0xfe]), "/+/+", "the last two symbols");
-    }
+    fn a_staged_frame_reaches_the_file_byte_for_byte() {
+        // The reason `t=t` is the transport at all: what the terminal reads is
+        // the frame itself, not an encoding of it. Anything that put the pixels
+        // through the escape sequence would cost a third again in bytes and a
+        // pass over the whole frame, sixty times a second.
+        let dir = std::env::temp_dir().join(format!("rav-raw-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let frame: Vec<u8> = (0..=255u8).cycle().take(4096).collect();
 
-    #[test]
-    fn a_transmission_carries_everything_the_terminal_needs() {
-        let escape = sequence("/dev/shm/rav-1-0.rgba", 40_000, 100, 100);
+        let mut pixels = Pixels::new();
+        let mut small = Vec::new();
+        pixels.send(&mut small, &frame, 32, 32, &dir).unwrap();
 
-        assert!(escape.starts_with("\x1b_G"), "not an APC string");
-        assert!(escape.ends_with("\x1b\\"), "unterminated");
-        assert!(escape.contains("S=40000"), "no size: it would draw nothing");
-        assert!(escape.contains("C=1"), "the picture would walk off-screen");
-        assert!(escape.contains("q=2"), "replies would flood the key reader");
-        assert!(escape.contains("s=100,v=100"), "wrong extent");
-        assert!(escape.contains("f=32"), "RGBA");
-        assert!(escape.contains("t=t"), "a file the terminal unlinks");
-        assert!(escape.contains(&format!("i={IMAGE_ID}")), "one id, reused");
-
-        // Byte for byte the sequence measured at 60fps in WezTerm, so any
-        // difference here is a difference from the only form known to draw.
+        let staged = std::fs::read_dir(&dir).unwrap().next().unwrap().unwrap();
         assert_eq!(
-            escape,
-            format!(
-                "\x1b_Ga=T,q=2,i=1,f=32,s=100,v=100,z=0,C=1,S=40000,t=t;{}\x1b\\",
-                base64(b"/dev/shm/rav-1-0.rgba"),
-            ),
+            std::fs::read(staged.path()).unwrap(),
+            frame,
+            "not the frame"
         );
-    }
 
-    #[test]
-    fn the_path_travels_encoded_rather_than_raw() {
-        // A raw path with a `;` or a `,` in it would be read as more of the
-        // header, and the frame would be dropped or misread.
-        let escape = sequence("/tmp/a,b;c/rav-0.rgba", 4, 1, 1);
-        assert!(!escape.contains("/tmp/a,b;c"), "the path went out raw");
-        assert!(escape.contains(&base64(b"/tmp/a,b;c/rav-0.rgba")));
-    }
+        // A hundredfold larger frame, and the same command but for the digits of
+        // the byte count. Anything else means the pixels are being carried
+        // rather than pointed at.
+        let big = vec![0u8; frame.len() * 100];
+        let mut large = Vec::new();
+        pixels.send(&mut large, &big, 320, 320, &dir).unwrap();
+        assert!(
+            large.len().abs_diff(small.len()) <= 4,
+            "{} bytes for a 4KB frame, {} for a 400KB one",
+            small.len(),
+            large.len(),
+        );
+        assert!(large.len() * 1000 < big.len(), "the command carried it");
 
-    #[test]
-    fn clearing_removes_every_image_rather_than_one() {
-        // `d=A` is all of them. A panic hook has no idea which ids are live, and
-        // leaving one behind paints it over the user's shell.
-        let mut out = Vec::new();
-        clear(&mut out).unwrap();
-        assert_eq!(out, b"\x1b_Ga=d,d=A\x1b\\");
+        pixels.tidy(&dir);
+        std::fs::remove_dir_all(&dir).ok();
     }
 
     #[test]

--- a/src/surface/pixels.rs
+++ b/src/surface/pixels.rs
@@ -1,0 +1,274 @@
+//! Sending a frame to the terminal as pixels.
+//!
+//! The escape sequences only, and the staging the file transport needs. Nothing
+//! here decides what a frame contains or when to send one - it is the last mile,
+//! and it is separate because every part of it is a rule the terminal imposes
+//! rather than a choice rav makes.
+//!
+//! # The rules, each measured rather than read
+//!
+//! **`C=1`, and the caller homes the cursor.** An image lands wherever the
+//! cursor is, and the terminal parks the cursor past the image's bottom-right
+//! unless told otherwise - so each frame is placed from where the last one ended
+//! and the picture walks off the screen.
+//!
+//! **`q=2`.** Every transmission is acknowledged by default. At 60fps that is
+//! sixty replies a second arriving on the same descriptor rav reads keys from.
+//!
+//! **`S=` is not optional** for the file transport. Direct transmission carries
+//! its length in the payload; a file does not, so without it the terminal reads
+//! nothing, draws nothing, and reports success.
+//!
+//! **One image id, reused.** A new id per frame leaves the terminal holding
+//! every frame ever sent.
+
+use std::io::{self, Write};
+use std::path::{Path, PathBuf};
+
+/// The id every frame is sent under.
+const IMAGE_ID: u32 = 1;
+
+/// How long a frame may go unread before its staging file is reclaimed, in
+/// frames. The terminal unlinks what it reads, so this normally finds nothing;
+/// it matters when a frame was skipped, because in `/dev/shm` an abandoned
+/// frame is resident memory rather than a file on a disk. Eight frames is 133ms
+/// of tolerated lag at 60fps.
+const LAG_TOLERATED: u64 = 8;
+
+/// Where frames are staged for the terminal to read.
+///
+/// `/dev/shm` where it exists, which is tmpfs on Linux - so the handoff is
+/// memory to memory and never reaches a disk. Falling back to the temp
+/// directory elsewhere, which macOS backs with the page cache and which is
+/// among the paths terminals will accept a frame from.
+pub fn staging() -> &'static Path {
+    static DIR: std::sync::OnceLock<PathBuf> = std::sync::OnceLock::new();
+    DIR.get_or_init(|| {
+        let shm = Path::new("/dev/shm");
+        // Existing is not the same as writable: a container can mount it
+        // read-only, and a frame that fails to write is worse than one written
+        // somewhere slower.
+        if shm.is_dir() {
+            let probe = shm.join(format!("rav-probe-{}", std::process::id()));
+            if std::fs::write(&probe, b"x").is_ok() {
+                let _ = std::fs::remove_file(&probe);
+                return shm.to_path_buf();
+            }
+        }
+        std::env::temp_dir()
+    })
+    .as_path()
+}
+
+/// Sends frames, and cleans up after the ones the terminal did not read.
+#[derive(Debug, Default)]
+pub struct Pixels {
+    sent: u64,
+}
+
+impl Pixels {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Stage `frame` and tell the terminal to draw it at the cursor.
+    ///
+    /// `frame` is RGBA, `width * height * 4` bytes. The caller homes the cursor
+    /// first; see the module note on `C=1`.
+    pub fn send(
+        &mut self,
+        out: &mut impl Write,
+        frame: &[u8],
+        width: u32,
+        height: u32,
+        dir: &Path,
+    ) -> io::Result<()> {
+        // A name per frame, never reused. Reusing one would truncate and rewrite
+        // a path a still-pending escape sequence names, so the terminal would
+        // read half a frame or find the file already gone - and it would happen
+        // under exactly the lag this transport exists to tolerate.
+        let path = dir.join(format!("rav-{}-{}.rgba", std::process::id(), self.sent));
+        std::fs::write(&path, frame)?;
+        out.write_all(&transmission(&path, frame.len(), width, height))?;
+
+        if let Some(stale) = self.sent.checked_sub(LAG_TOLERATED) {
+            let _ = std::fs::remove_file(dir.join(format!(
+                "rav-{}-{}.rgba",
+                std::process::id(),
+                stale
+            )));
+        }
+        self.sent += 1;
+        out.flush()
+    }
+
+    /// Remove every frame this has staged and not yet reclaimed.
+    ///
+    /// For shutting down. In `/dev/shm` a leftover frame is resident memory
+    /// that outlives the process.
+    pub fn tidy(&self, dir: &Path) {
+        let first = self.sent.saturating_sub(LAG_TOLERATED);
+        for tick in first..self.sent {
+            let _ =
+                std::fs::remove_file(dir.join(format!("rav-{}-{}.rgba", std::process::id(), tick)));
+        }
+    }
+}
+
+/// The escape sequence that places a staged frame.
+fn transmission(path: &Path, bytes: usize, width: u32, height: u32) -> Vec<u8> {
+    let encoded = base64(path.to_string_lossy().as_bytes());
+    // `z=0` is the default and is written anyway. Below zero puts the frame
+    // under every cell's background, and a terminal running any theme gives
+    // every cell one - so a negative z is a blank screen that still reports
+    // every frame transmitted successfully.
+    format!(
+        "\x1b_Ga=T,q=2,i={IMAGE_ID},f=32,s={width},v={height},z=0,C=1,S={bytes},t=t;{encoded}\x1b\\"
+    )
+    .into_bytes()
+}
+
+/// Take every image off the screen.
+///
+/// Belongs in a panic hook as much as in a clean exit: `panic = "abort"` still
+/// runs one, and without this a panic leaves pixels painted over the shell the
+/// user comes back to.
+pub fn clear(out: &mut impl Write) -> io::Result<()> {
+    out.write_all(b"\x1b_Ga=d,d=A\x1b\\")?;
+    out.flush()
+}
+
+fn base64(bytes: &[u8]) -> String {
+    const ALPHABET: &[u8; 64] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+    let mut out = String::with_capacity(bytes.len().div_ceil(3) * 4);
+    for group in bytes.chunks(3) {
+        let b = [
+            group[0],
+            group.get(1).copied().unwrap_or(0),
+            group.get(2).copied().unwrap_or(0),
+        ];
+        let n = (u32::from(b[0]) << 16) | (u32::from(b[1]) << 8) | u32::from(b[2]);
+        for i in 0..4 {
+            if i <= group.len() {
+                out.push(ALPHABET[(n >> (18 - i * 6)) as usize & 0x3f] as char);
+            } else {
+                out.push('=');
+            }
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sequence(path: &str, bytes: usize, width: u32, height: u32) -> String {
+        String::from_utf8(transmission(Path::new(path), bytes, width, height)).unwrap()
+    }
+
+    #[test]
+    fn base64_matches_the_standard_alphabet_and_padding() {
+        // The terminal decodes this; a wrong table sends it a path that does not
+        // exist and it draws nothing, silently.
+        assert_eq!(base64(b""), "");
+        assert_eq!(base64(b"f"), "Zg==");
+        assert_eq!(base64(b"fo"), "Zm8=");
+        assert_eq!(base64(b"foo"), "Zm9v");
+        assert_eq!(base64(b"foobar"), "Zm9vYmFy");
+        assert_eq!(base64(&[0xff, 0xef, 0xfe]), "/+/+", "the last two symbols");
+    }
+
+    #[test]
+    fn a_transmission_carries_everything_the_terminal_needs() {
+        let escape = sequence("/dev/shm/rav-1-0.rgba", 40_000, 100, 100);
+
+        assert!(escape.starts_with("\x1b_G"), "not an APC string");
+        assert!(escape.ends_with("\x1b\\"), "unterminated");
+        assert!(escape.contains("S=40000"), "no size: it would draw nothing");
+        assert!(escape.contains("C=1"), "the picture would walk off-screen");
+        assert!(escape.contains("q=2"), "replies would flood the key reader");
+        assert!(escape.contains("s=100,v=100"), "wrong extent");
+        assert!(escape.contains("f=32"), "RGBA");
+        assert!(escape.contains("t=t"), "a file the terminal unlinks");
+        assert!(escape.contains(&format!("i={IMAGE_ID}")), "one id, reused");
+
+        // Byte for byte the sequence measured at 60fps in WezTerm, so any
+        // difference here is a difference from the only form known to draw.
+        assert_eq!(
+            escape,
+            format!(
+                "\x1b_Ga=T,q=2,i=1,f=32,s=100,v=100,z=0,C=1,S=40000,t=t;{}\x1b\\",
+                base64(b"/dev/shm/rav-1-0.rgba"),
+            ),
+        );
+    }
+
+    #[test]
+    fn the_path_travels_encoded_rather_than_raw() {
+        // A raw path with a `;` or a `,` in it would be read as more of the
+        // header, and the frame would be dropped or misread.
+        let escape = sequence("/tmp/a,b;c/rav-0.rgba", 4, 1, 1);
+        assert!(!escape.contains("/tmp/a,b;c"), "the path went out raw");
+        assert!(escape.contains(&base64(b"/tmp/a,b;c/rav-0.rgba")));
+    }
+
+    #[test]
+    fn clearing_removes_every_image_rather_than_one() {
+        // `d=A` is all of them. A panic hook has no idea which ids are live, and
+        // leaving one behind paints it over the user's shell.
+        let mut out = Vec::new();
+        clear(&mut out).unwrap();
+        assert_eq!(out, b"\x1b_Ga=d,d=A\x1b\\");
+    }
+
+    #[test]
+    fn every_frame_is_staged_under_a_name_of_its_own() {
+        // Reusing a name rewrites a file a pending escape sequence still points
+        // at, so the terminal reads half a frame - under exactly the lag this
+        // transport exists to tolerate.
+        let dir = std::env::temp_dir().join(format!("rav-test-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+
+        let mut pixels = Pixels::new();
+        let mut out = Vec::new();
+        for _ in 0..3 {
+            pixels.send(&mut out, &[0u8; 16], 2, 2, &dir).unwrap();
+        }
+        let staged: std::collections::BTreeSet<String> = std::fs::read_dir(&dir)
+            .unwrap()
+            .map(|entry| entry.unwrap().file_name().to_string_lossy().into_owned())
+            .collect();
+        assert_eq!(staged.len(), 3, "frames shared a name: {staged:?}");
+
+        pixels.tidy(&dir);
+        assert_eq!(
+            std::fs::read_dir(&dir).unwrap().count(),
+            0,
+            "left frames behind"
+        );
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn a_frame_older_than_the_tolerated_lag_is_reclaimed() {
+        // In /dev/shm an abandoned frame is resident memory, so a terminal that
+        // skips frames must not cost a megabyte a second.
+        let dir = std::env::temp_dir().join(format!("rav-lag-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+
+        let mut pixels = Pixels::new();
+        let mut out = Vec::new();
+        for _ in 0..(LAG_TOLERATED + 5) {
+            pixels.send(&mut out, &[0u8; 16], 2, 2, &dir).unwrap();
+        }
+        assert_eq!(
+            std::fs::read_dir(&dir).unwrap().count(),
+            LAG_TOLERATED as usize,
+            "the staging directory is growing without bound",
+        );
+
+        pixels.tidy(&dir);
+        std::fs::remove_dir_all(&dir).ok();
+    }
+}

--- a/src/surface/pixels.rs
+++ b/src/surface/pixels.rs
@@ -107,16 +107,22 @@ impl Pixels {
         self.sent += 1;
         out.flush()
     }
+}
 
-    /// Remove every frame this has staged and not yet reclaimed.
-    ///
-    /// For shutting down. In `/dev/shm` a leftover frame is resident memory
-    /// that outlives the process.
-    pub fn tidy(&self, dir: &Path) {
-        let first = self.sent.saturating_sub(LAG_TOLERATED);
-        for tick in first..self.sent {
-            let _ =
-                std::fs::remove_file(dir.join(format!("rav-{}-{}.rgba", std::process::id(), tick)));
+/// Remove every frame this process staged.
+///
+/// By name rather than by count, so it needs nothing but the directory - which
+/// is what lets it run from the panic path, where there is no [`Pixels`] to
+/// ask. In `/dev/shm` a leftover frame is resident memory that outlives the
+/// process, and at a full screen each one is megabytes.
+pub fn tidy(dir: &Path) {
+    let mine = format!("rav-{}-", std::process::id());
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        if entry.file_name().to_string_lossy().starts_with(&mine) {
+            let _ = std::fs::remove_file(entry.path());
         }
     }
 }
@@ -170,7 +176,7 @@ mod tests {
         );
         assert!(large.len() * 1000 < big.len(), "the command carried it");
 
-        pixels.tidy(&dir);
+        tidy(&dir);
         std::fs::remove_dir_all(&dir).ok();
     }
 
@@ -193,7 +199,7 @@ mod tests {
             .collect();
         assert_eq!(staged.len(), 3, "frames shared a name: {staged:?}");
 
-        pixels.tidy(&dir);
+        tidy(&dir);
         assert_eq!(
             std::fs::read_dir(&dir).unwrap().count(),
             0,
@@ -220,7 +226,7 @@ mod tests {
             "the staging directory is growing without bound",
         );
 
-        pixels.tidy(&dir);
+        tidy(&dir);
         std::fs::remove_dir_all(&dir).ok();
     }
 }

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -397,7 +397,25 @@ impl App {
                 status,
                 help,
             ),
-            _ => Ok(false),
+            // This will not change while the terminal is the terminal it is, so
+            // the overlay stops promising pixels and the loop stops asking. A
+            // help panel reading "pixels" over a picture made of block
+            // characters is worse than no label at all.
+            _ => {
+                let fallback = Chosen {
+                    surface: crate::surface::Surface::Glyphs,
+                    because: "your terminal will not say how big it is in pixels",
+                };
+                if self.surface != fallback {
+                    info!(
+                        "Drawing with {} ({})",
+                        fallback.surface.label(),
+                        fallback.because
+                    );
+                }
+                self.surface = fallback;
+                Ok(false)
+            }
         }
     }
 

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -206,6 +206,8 @@ pub struct App {
     /// What the overlay wrote over the last pixel frame, so the cells can be
     /// taken back when it changes.
     painted_cells: String,
+    /// Whether there is a picture on the screen to take down.
+    painting: bool,
 
     /// Which surface rav would draw on, and why.
     ///
@@ -298,6 +300,7 @@ impl App {
             sized_for: (0, 0),
             painter: crate::surface::pixels::Pixels::new(),
             painted_cells: String::new(),
+            painting: false,
             surface: Chosen::UNASKED,
             visualisation: Visualisation::default(),
             scope_style: ScopeStyle::default(),
@@ -417,6 +420,13 @@ impl App {
         use rav_core::geometry::Screen;
         use rav_core::units::{CellSize, Cells, Length};
 
+        // Only the analyser is drawn as pixels. The oscilloscope is still block
+        // characters, so `space` has to hand the screen back rather than leave
+        // the bars sitting there looking like a key that does nothing.
+        if self.visualisation != Visualisation::Analyzer {
+            return self.stop_painting(out).map(|()| false);
+        }
+
         let screen = Screen::new(
             Length(f32::from(size.width)),
             Length(f32::from(size.height)),
@@ -492,7 +502,24 @@ impl App {
         )?;
         out.write_all(cells.as_bytes())?;
         out.flush()?;
+        self.painting = true;
         Ok(true)
+    }
+
+    /// Take the picture down, for whenever the glyph renderer takes over.
+    ///
+    /// An image left up shows through wherever the grid leaves a cell empty,
+    /// which is most of a quiet display. Doing nothing when there was no
+    /// picture, so this costs a frame's worth of nothing on every terminal that
+    /// never had one.
+    fn stop_painting(&mut self, out: &mut impl Write) -> Result<()> {
+        if self.painting {
+            crate::surface::pixels::clear(out)?;
+            self.painter.tidy(crate::surface::pixels::staging());
+            self.painted_cells.clear();
+            self.painting = false;
+        }
+        Ok(())
     }
 
     /// Append a capture buffer to the rolling window, de-interleaving to mono.
@@ -1733,6 +1760,37 @@ mod tests {
             !String::from_utf8_lossy(&steady).contains("\x1b[2J"),
             "it cleared a screen nothing had changed on",
         );
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn switching_to_the_oscilloscope_hands_the_screen_back() {
+        // Only the analyser is drawn as pixels. Without this, `space` would look
+        // like a key that does nothing: the bars would sit there while the scope
+        // was supposedly showing, and the image would show through wherever the
+        // glyph grid left a cell empty.
+        let mut a = app();
+        a.resize(80, 24);
+        let dir = scratch("scope");
+
+        let mut bars = Vec::new();
+        assert!(a.painted(&mut bars, window(), &dir, None, None).unwrap());
+
+        a.apply(Action::CycleVisualisation);
+        let mut scope = Vec::new();
+        assert!(
+            !a.painted(&mut scope, window(), &dir, None, None).unwrap(),
+            "it drew the analyser while the scope was showing",
+        );
+        assert!(
+            String::from_utf8_lossy(&scope).contains("a=d,d=A"),
+            "the picture was left up under the scope",
+        );
+
+        // And back again, without taking the screen down twice.
+        a.apply(Action::CycleVisualisation);
+        let mut again = Vec::new();
+        assert!(a.painted(&mut again, window(), &dir, None, None).unwrap());
         std::fs::remove_dir_all(&dir).ok();
     }
 

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -203,6 +203,9 @@ pub struct App {
 
     /// Sends frames to the terminal when the surface is pixels.
     painter: crate::surface::pixels::Pixels,
+    /// What the overlay wrote over the last pixel frame, so the cells can be
+    /// taken back when it changes.
+    painted_cells: String,
 
     /// Which surface rav would draw on, and why.
     ///
@@ -294,6 +297,7 @@ impl App {
             layout: BarLayout::default(),
             sized_for: (0, 0),
             painter: crate::surface::pixels::Pixels::new(),
+            painted_cells: String::new(),
             surface: Chosen::UNASKED,
             visualisation: Visualisation::default(),
             scope_style: ScopeStyle::default(),
@@ -447,6 +451,37 @@ impl App {
             return Ok(false);
         };
 
+        let grid = ratatui::layout::Rect::new(0, 0, size.columns, size.rows);
+        let mut cells = String::new();
+        if let Some(text) = status {
+            cells.push_str(&overlay::of(
+                Status {
+                    text,
+                    foreground: Color::Rgb(222, 222, 222),
+                    background: to_color(self.theme.grid[0]),
+                },
+                grid,
+            ));
+        }
+        if let Some(rows) = help {
+            cells.push_str(&overlay::of(Help { rows, title: "rav" }, grid));
+        }
+
+        // A cell the overlay wrote is a cell, and cells stay until something
+        // takes them away - a new image will not, since a written cell wins over
+        // the picture beneath it. So closing the help panel would leave it on
+        // screen for good. Erasing puts the cells back to empty, which is not
+        // the same as writing spaces over them: an empty cell lets the picture
+        // through and a space does not.
+        //
+        // Only when the overlay changes, which is a keypress rather than a
+        // frame. The image is sent immediately afterwards, so the clear is never
+        // a frame the user sees.
+        if cells != self.painted_cells {
+            write!(out, "\x1b[2J")?;
+            self.painted_cells = cells.clone();
+        }
+
         write!(out, "\x1b[H")?;
         self.painter.send(
             out,
@@ -455,22 +490,7 @@ impl App {
             u32::from(size.height),
             staging,
         )?;
-
-        let grid = ratatui::layout::Rect::new(0, 0, size.columns, size.rows);
-        if let Some(text) = status {
-            let panel = overlay::of(
-                Status {
-                    text,
-                    foreground: Color::Rgb(222, 222, 222),
-                    background: to_color(self.theme.grid[0]),
-                },
-                grid,
-            );
-            out.write_all(panel.as_bytes())?;
-        }
-        if let Some(rows) = help {
-            out.write_all(overlay::of(Help { rows, title: "rav" }, grid).as_bytes())?;
-        }
+        out.write_all(cells.as_bytes())?;
         out.flush()?;
         Ok(true)
     }
@@ -1671,6 +1691,48 @@ mod tests {
         let sent = String::from_utf8_lossy(&out);
         assert!(sent.contains("a=T"), "no frame");
         assert!(!sent.contains("\x1b[0m"), "a cell was written: {sent:?}");
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn closing_the_help_panel_takes_its_text_off_the_picture() {
+        // A cell the overlay wrote is a cell, and cells outlive the frame under
+        // them - a new image does not remove one, because a written cell wins
+        // over the picture. Without erasing, closing the panel would leave it
+        // sitting there for the rest of the session.
+        let mut a = app();
+        a.resize(80, 24);
+        let dir = scratch("closing");
+        let rows = a.help_rows();
+
+        let mut opened = Vec::new();
+        a.painted(&mut opened, window(), &dir, None, Some(&rows))
+            .unwrap();
+        assert!(
+            String::from_utf8_lossy(&opened).contains("\x1b[0m"),
+            "the panel was never drawn",
+        );
+
+        let mut closed = Vec::new();
+        a.painted(&mut closed, window(), &dir, None, None).unwrap();
+        let sent = String::from_utf8_lossy(&closed);
+        assert!(
+            sent.contains("\x1b[2J"),
+            "the panel was left on the picture"
+        );
+        assert!(
+            sent.find("\x1b[2J") < sent.find("a=T"),
+            "the frame was sent before the screen was cleared, so it was wiped",
+        );
+
+        // And a frame with the overlay unchanged does not clear again, or every
+        // frame would be a full repaint.
+        let mut steady = Vec::new();
+        a.painted(&mut steady, window(), &dir, None, None).unwrap();
+        assert!(
+            !String::from_utf8_lossy(&steady).contains("\x1b[2J"),
+            "it cleared a screen nothing had changed on",
+        );
         std::fs::remove_dir_all(&dir).ok();
     }
 

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -1033,7 +1033,8 @@ impl App {
             if self.surface.surface == crate::surface::Surface::Kitty
                 && self.paint(status.as_deref(), help_rows.as_deref())?
             {
-                frames += 1;
+                // The frame is already counted above; this path draws it a
+                // different way rather than drawing an extra one.
                 continue;
             }
 
@@ -1100,6 +1101,11 @@ impl App {
             })?;
         }
 
+        // Reclaim any frame the terminal never got round to reading. It unlinks
+        // what it does read, so this is usually nothing - but in `/dev/shm` an
+        // abandoned frame is resident memory that outlives the process, and at
+        // a full screen that is megabytes each.
+        let _ = self.stop_painting(&mut Vec::new());
         info!("👋 Analyser shut down");
         Ok(())
     }
@@ -1791,6 +1797,34 @@ mod tests {
         a.apply(Action::CycleVisualisation);
         let mut again = Vec::new();
         assert!(a.painted(&mut again, window(), &dir, None, None).unwrap());
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn handing_the_screen_back_reclaims_the_frames_the_terminal_skipped() {
+        // The terminal unlinks what it reads, so this is usually nothing. What
+        // it is not nothing for is a terminal that fell behind: in `/dev/shm` an
+        // abandoned frame is resident memory, megabytes each at a full screen,
+        // and it outlives the process that staged it.
+        let mut a = app();
+        a.resize(80, 24);
+        let dir = scratch("reclaim");
+
+        let mut out = Vec::new();
+        for _ in 0..3 {
+            a.painted(&mut out, window(), &dir, None, None).unwrap();
+        }
+        assert!(
+            std::fs::read_dir(&dir).unwrap().count() > 0,
+            "nothing was staged, so this proves nothing",
+        );
+
+        a.painter.tidy(&dir);
+        assert_eq!(
+            std::fs::read_dir(&dir).unwrap().count(),
+            0,
+            "frames were left in the staging directory",
+        );
         std::fs::remove_dir_all(&dir).ok();
     }
 

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -38,6 +38,7 @@ use ratatui::backend::TestBackend;
 use ratatui::{Terminal, style::Color};
 use scope::{Scope, ScopeStyle};
 use status::Status;
+use std::io::Write;
 #[cfg(not(test))]
 use std::io::{self, Stdout};
 use std::time::{Duration, Instant};
@@ -200,11 +201,14 @@ pub struct App {
     /// Size the cached mapping and colours were built for.
     sized_for: (u16, u16),
 
+    /// Sends frames to the terminal when the surface is pixels.
+    painter: crate::surface::pixels::Pixels,
+
     /// Which surface rav would draw on, and why.
     ///
-    /// Reported, not obeyed - the glyph renderer draws every frame whatever this
-    /// says. It is here so the choice is visible in the help overlay for a beta
-    /// before anything depends on it being right.
+    /// `--surface kitty` draws pixels; anything else draws block characters.
+    /// A terminal that will not report its size in pixels falls back to them
+    /// too, so this is what rav *would* use as much as what it does.
     surface: Chosen,
 
     visualisation: Visualisation,
@@ -289,6 +293,7 @@ impl App {
             palette: Palette::default(),
             layout: BarLayout::default(),
             sized_for: (0, 0),
+            painter: crate::surface::pixels::Pixels::new(),
             surface: Chosen::UNASKED,
             visualisation: Visualisation::default(),
             scope_style: ScopeStyle::default(),
@@ -364,6 +369,110 @@ impl App {
                 .fraction();
         }
         gain
+    }
+
+    /// Draw the frame as pixels, and say whether it managed to.
+    ///
+    /// Asking the terminal how big it is in pixels is the one part a test
+    /// cannot do, so it is the only part here. Everything that decides what
+    /// goes out is [`Self::painted`].
+    ///
+    /// A terminal that reports no pixel size is one that does not know, and
+    /// working a cell size out from a font is how #63 began - so that is a
+    /// `false`, and the glyph renderer draws the frame instead.
+    #[cfg(not(test))]
+    fn paint(&mut self, status: Option<&str>, help: Option<&[HelpRow<'_>]>) -> Result<bool> {
+        match crossterm::terminal::window_size() {
+            Ok(size) if size.width > 0 && size.height > 0 => self.painted(
+                &mut io::stdout(),
+                size,
+                crate::surface::pixels::staging(),
+                status,
+                help,
+            ),
+            _ => Ok(false),
+        }
+    }
+
+    /// Everything a pixel frame is, given a size to draw it at.
+    ///
+    /// The order is the whole of it: home the cursor, place the image where the
+    /// cursor now is, then write the overlay's own cells. An image lands
+    /// wherever the cursor happens to be, and the overlay goes on afterwards
+    /// because a written cell blanks the picture beneath it.
+    fn painted(
+        &mut self,
+        out: &mut impl Write,
+        size: crossterm::terminal::WindowSize,
+        staging: &std::path::Path,
+        status: Option<&str>,
+        help: Option<&[HelpRow<'_>]>,
+    ) -> Result<bool> {
+        use crate::surface::frame::{Frame, Look};
+        use crate::surface::overlay;
+        use rav_core::geometry::Screen;
+        use rav_core::units::{CellSize, Cells, Length};
+
+        let screen = Screen::new(
+            Length(f32::from(size.width)),
+            Length(f32::from(size.height)),
+        );
+
+        // The bar width is in cells, because cells are what `+` and `-` move.
+        // One cell is however many pixels this terminal says it is.
+        let cell = CellSize {
+            width: size.width / size.columns.max(1),
+            height: size.height / size.rows.max(1),
+        };
+        let layout = rav_core::geometry::BarLayout::new(
+            cell.across(Cells(self.layout.bar_width)),
+            cell.across(Cells(self.layout.spacing)),
+        );
+        let look = Look {
+            theme: &self.theme,
+            palette: &self.palette,
+            backdrop: self.show_grid,
+            // One row of the sixteen the original panel had, which is the
+            // proportion its caps were drawn at.
+            caps: (self.peaks != Peaks::Off).then(|| screen.height() / 16.0),
+        };
+        let Some(pixels) = Frame::new(
+            self.ballistics.bars(),
+            self.ballistics.peaks(),
+            &look,
+            layout,
+            screen,
+        )
+        .pixels() else {
+            return Ok(false);
+        };
+
+        write!(out, "\x1b[H")?;
+        self.painter.send(
+            out,
+            &pixels,
+            u32::from(size.width),
+            u32::from(size.height),
+            staging,
+        )?;
+
+        let grid = ratatui::layout::Rect::new(0, 0, size.columns, size.rows);
+        if let Some(text) = status {
+            let panel = overlay::of(
+                Status {
+                    text,
+                    foreground: Color::Rgb(222, 222, 222),
+                    background: to_color(self.theme.grid[0]),
+                },
+                grid,
+            );
+            out.write_all(panel.as_bytes())?;
+        }
+        if let Some(rows) = help {
+            out.write_all(overlay::of(Help { rows, title: "rav" }, grid).as_bytes())?;
+        }
+        out.flush()?;
+        Ok(true)
     }
 
     /// Append a capture buffer to the rolling window, de-interleaving to mono.
@@ -867,6 +976,19 @@ impl App {
             } else {
                 None
             };
+
+            // Pixels first, when that is the surface and the terminal will say
+            // how big it is. A `false` here is a terminal that reports no pixel
+            // size or a window with no area, and the glyph renderer below draws
+            // the frame instead - so asking for a surface that cannot be had
+            // costs the label in the help overlay and nothing else.
+            #[cfg(not(test))]
+            if self.surface.surface == crate::surface::Surface::Kitty
+                && self.paint(status.as_deref(), help_rows.as_deref())?
+            {
+                frames += 1;
+                continue;
+            }
 
             // Destructure so the draw closure borrows fields, not all of `self`.
             let Self {
@@ -1484,6 +1606,100 @@ mod tests {
 
         a.apply(Action::ToggleHelp);
         assert!(!a.show_help);
+    }
+
+    /// Somewhere to stage frames that is not the directory a running rav uses.
+    ///
+    /// Left behind, these are megabytes each in `/dev/shm` - a test suite has
+    /// no business putting them where a real run stages its own.
+    fn scratch(name: &str) -> std::path::PathBuf {
+        let dir = std::env::temp_dir().join(format!("rav-ui-{name}-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    /// A window the size of a modest terminal, in the units a terminal reports.
+    fn window() -> crossterm::terminal::WindowSize {
+        crossterm::terminal::WindowSize {
+            columns: 80,
+            rows: 24,
+            width: 800,
+            height: 480,
+        }
+    }
+
+    #[test]
+    fn a_pixel_frame_goes_out_homed_and_the_overlay_after_it() {
+        // The order is the whole of it. An image lands wherever the cursor
+        // happens to be, so the cursor is homed first or the picture walks off
+        // the screen; and a written cell blanks the image, so the overlay can
+        // only go on afterwards.
+        let mut a = app();
+        a.resize(80, 24);
+        let dir = scratch("order");
+        let mut out = Vec::new();
+        assert!(
+            a.painted(&mut out, window(), &dir, Some("wide"), None)
+                .unwrap()
+        );
+
+        let sent = String::from_utf8_lossy(&out);
+        let home = sent.find("\x1b[H").expect("the cursor was never homed");
+        let image = sent.find("a=T").expect("no frame was transmitted");
+        // The note goes out a cell at a time, each with its own move and its own
+        // reset, so its letters are never next to each other in the stream. The
+        // first reset is the first cell the overlay wrote.
+        let note = sent.find("\x1b[0m").expect("the note was not written");
+        assert!(home < image, "the frame was placed before homing");
+        assert!(image < note, "the note was written before the frame");
+        for letter in ["w", "i", "d", "e"] {
+            assert!(sent[note - 40..].contains(letter), "{letter} is missing");
+        }
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn a_quiet_frame_writes_nothing_but_the_picture() {
+        // No note, help closed - almost every frame. One stray cell would blank
+        // the image it was written over.
+        let mut a = app();
+        a.resize(80, 24);
+        let dir = scratch("quiet");
+        let mut out = Vec::new();
+        assert!(a.painted(&mut out, window(), &dir, None, None).unwrap());
+
+        let sent = String::from_utf8_lossy(&out);
+        assert!(sent.contains("a=T"), "no frame");
+        assert!(!sent.contains("\x1b[0m"), "a cell was written: {sent:?}");
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn a_window_with_no_pixels_draws_no_frame() {
+        // A terminal that does not report a pixel size, which is most of them.
+        // The caller falls back to glyphs, so this is a label being wrong
+        // rather than a screen being blank.
+        let mut a = app();
+        a.resize(80, 24);
+        let empty = crossterm::terminal::WindowSize {
+            columns: 80,
+            rows: 24,
+            width: 0,
+            height: 0,
+        };
+        let dir = scratch("nopixels");
+        let mut out = Vec::new();
+        assert!(!a.painted(&mut out, empty, &dir, None, None).unwrap());
+        assert!(
+            out.is_empty(),
+            "it wrote {out:?} to a screen it cannot draw"
+        );
+        assert_eq!(
+            std::fs::read_dir(&dir).unwrap().count(),
+            0,
+            "it staged a frame it was never going to send",
+        );
+        std::fs::remove_dir_all(&dir).ok();
     }
 
     #[test]

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -533,7 +533,7 @@ impl App {
     fn stop_painting(&mut self, out: &mut impl Write) -> Result<()> {
         if self.painting {
             crate::surface::pixels::clear(out)?;
-            self.painter.tidy(crate::surface::pixels::staging());
+            crate::surface::pixels::tidy(crate::surface::pixels::staging());
             self.painted_cells.clear();
             self.painting = false;
         }
@@ -1139,10 +1139,18 @@ const WATCHDOG: Duration = Duration::from_millis(250);
 
 /// Put the terminal back the way it was found.
 ///
-/// Raw mode off, off the alternate screen, cursor visible. The one place that
-/// knows what setting rav up did, so the way out cannot drift from the way in.
+/// Images off the screen and their frames reclaimed, raw mode off, off the
+/// alternate screen, cursor visible. The one place that knows what setting rav
+/// up did, so the way out cannot drift from the way in.
+///
+/// Images go first: one left behind is painted over the shell the user comes
+/// back to. The frames go with them because in `/dev/shm` an unread frame is
+/// resident memory that outlives the process, and this runs on the paths where
+/// `stop_painting` never gets the chance - an error, and a panic.
 #[cfg(not(test))]
 fn hand_the_terminal_back() {
+    let _ = crate::surface::pixels::clear(&mut io::stdout());
+    crate::surface::pixels::tidy(crate::surface::pixels::staging());
     let _ = disable_raw_mode();
     let _ = io::stdout().execute(LeaveAlternateScreen);
     let _ = io::stdout().execute(crossterm::cursor::Show);
@@ -1837,7 +1845,7 @@ mod tests {
             "nothing was staged, so this proves nothing",
         );
 
-        a.painter.tidy(&dir);
+        crate::surface::pixels::tidy(&dir);
         assert_eq!(
             std::fs::read_dir(&dir).unwrap().count(),
             0,


### PR DESCRIPTION
`rav --surface kitty` draws the bars as pixels in WezTerm, Ghostty and kitty. Nobody gets them without typing it — `auto` is still block characters everywhere, and will be until this has had a beta in the open.

**The peak cap stops carving a notch through the backdrop.** Press `b` for solid, thick, half or line, leave the grid on, and watch a cap fall: in a terminal the backdrop is a glyph and the cap is a glyph, and a cell holds one. Measured, one bar low with its cap held high:

```
blocks  ["▁"," "," "," "," "," "," ","▆"]   backdrop is a background colour — cap sits on it
shade   ["▁"," "," "," "," "," "," ","▓"]   same

solid   ["▁","▇","▇","▇","▇","▇","▇","▇"]   ← the cap replaced a ▇
thick   ["▁","▆","▆","▆","▆","▆","▆","▆"]   ← and a ▆
half    ["▁","▄","▄","▄","▄","▄","▄","▄"]
line    ["▁","━","━","━","━","━","━","━"]
```

Four of the six styles. Not a bug to fix in the terminal renderer — `set_symbol` addresses one slot, so the cap and the backdrop cannot share a cell — which is the whole argument for owning the pixels. On this path they composite, and the cap rides over the backdrop instead of through it.

**What it cost to get a picture onto the screen, all of it measured rather than read.** A frame is staged as raw RGBA in `/dev/shm` where that is writable and the temp directory elsewhere, and the terminal is told where to find it — the pixels never go through base64, so the escape sequence is about thirty bytes whether the frame is 4KB or 400KB. The byte count is not optional for that transport: without it the terminal reads nothing, draws nothing, and reports success. Every frame gets a name of its own, because reusing one rewrites a file a pending escape sequence still points at.

**And a written cell blanks the image beneath it, at any z.** Even a space at the default background. So this surface cannot render through ratatui at all — `terminal.draw` writes every cell in the buffer, which would erase the frame the moment it was drawn. The overlay writes only the cells the status line and help panel actually occupy, straight out as escape sequences, and the rest of the grid is left alone.

Four things that were wrong and are not:

- the help panel stayed on screen after you closed it, because nothing repainted the cells it had written
- `space` stopped switching to the oscilloscope
- the frame counter counted twice, so the log would have claimed 120fps
- a frame the terminal never read stayed resident in `/dev/shm` — megabytes each, outliving the process

**A crash now takes the pixels down with it.** Images off the screen and their frames reclaimed, on every way out: returning normally, returning an error, and panicking. Without it a panic left the bars painted over the shell you came back to. Measured under a pty — a panic sends `a=d,d=A` before it leaves the alternate screen, and still exits 101.

Asking for pixels on a terminal that cannot say how big it is in pixels draws block characters instead and says so. Working a cell size out from the font is how #63 began.
