### PR TITLE
docs: say that rav.log holds every run, not just this one

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -49,6 +49,11 @@ Which of the two depends on where the sound is coming from, and the line above
 it says which rav chose. Neither line at all means nothing is arriving; a peak
 near zero means the source is silent rather than absent.
 
+Read it from the bottom. The file is appended to, so it holds every run since
+you last deleted it — and if two ravs are going at once their lines interleave
+with nothing to tell them apart. `🚀 RAV Audio Visualizer starting up` marks
+where the newest run begins.
+
 `rav --list-devices` shows what rav can see and `rav -d "<name>"` selects one.
 On Linux that list is ALSA PCMs only — a PipeWire/PulseAudio `.monitor` source
 is not in it and cannot be selected with `-d`. Route the capture from the


### PR DESCRIPTION
The troubleshooting page sends you to `rav.log` to find one line — the one that tells a silent source from an absent one. It does not mention that the file is appended to.

So the line you find may be from a run last week. And if two ravs are going at once, their lines interleave with nothing in them to say which is which.

Both are now stated, along with the marker that separates runs. Verified against a log with two runs in it: `🚀 RAV Audio Visualizer starting up` appears exactly where the page now says it does.

**This cost me an hour today**, which is why it is worth a paragraph. A leftover rav from an earlier test was writing to the same file, and the doubled startup lines read exactly like rav opening its capture device twice — a real defect, if it had been real. A controlled run settled it: one startup line per invocation, three different ways.

Documenting rather than changing the behaviour, deliberately. Every fix has a trade-off worse than the problem: truncating on start means a second instance silently wipes the first one's log mid-run; a file per process leaves a directory of them; a pid on each line does not reach the ALSA output that `stderr` is redirected into, so half the file would still be unattributed.
