### PR TITLE
test: a pixel bar stands where the glyph bar did, without its rounding

### DIFF
--- a/src/surface/frame.rs
+++ b/src/surface/frame.rs
@@ -348,3 +348,64 @@ mod tests {
         assert_eq!(layout().column(1).left(), Length(24.0));
     }
 }
+
+#[cfg(test)]
+mod against_the_glyphs {
+    use super::*;
+    use crate::ui::scale::bar_eighths;
+    use rav_core::geometry::{BarLayout, Screen};
+
+    #[test]
+    fn a_pixel_bar_stands_where_the_glyph_bar_did_without_its_rounding() {
+        // The acceptance test for moving off glyphs: the first pixel release has
+        // to draw the picture the glyph release drew at the same size. Anything
+        // else is a regression rather than the redesign it was sold as.
+        //
+        // Not identical, and it would be wrong if it were. A glyph bar is
+        // truncated to a whole eighth of a cell - that is the finest a block
+        // character goes - so the pixel bar is the same height or up to one
+        // eighth taller, being the height nothing rounded. Never shorter, and
+        // never more than the one eighth the rounding could account for.
+        //
+        // 80x24 cells at 30x60 device pixels, which is what a WezTerm on this
+        // Mac reports, and one bar per cell column so the two line up.
+        let (cols, rows, cw, ch) = (80u16, 24u16, 30.0f32, 60.0f32);
+        let theme = Theme::default();
+        let palette = Palette::default();
+        let screen = Screen::new(Length(cols as f32 * cw), Length(rows as f32 * ch));
+        let layout = BarLayout::new(Length(cw), Length(0.0));
+
+        // A ramp across the display, so every height between silence and full
+        // scale is checked rather than a few chosen ones.
+        let levels: Vec<f32> = (0..cols as usize)
+            .map(|i| 0.05 + 0.9 * (i as f32 / cols as f32))
+            .collect();
+        let look = Look {
+            theme: &theme,
+            palette: &palette,
+            backdrop: false,
+            caps: None,
+        };
+        let rgba = Frame::new(&levels, &levels, &look, layout, screen)
+            .pixels()
+            .expect("a screen with area");
+
+        let width = (cols as f32 * cw) as u32;
+        let tall = (rows as f32 * ch) as u32;
+        let drawn = |x: u32, y: u32| rgba[((y * width + x) * 4 + 3) as usize] != 0;
+
+        for (i, &level) in levels.iter().enumerate() {
+            let x = (i as f32 * cw + cw / 2.0) as u32;
+            let top = (0..tall).find(|&y| drawn(x, y)).unwrap_or(tall);
+            let in_eighths = ((tall - top) as f32 / ch * 8.0).round() as i64;
+            let glyph = bar_eighths(level, rows) as i64;
+
+            assert!(
+                (in_eighths - glyph) == 0 || (in_eighths - glyph) == 1,
+                "bar {i} at level {level:.3}: the glyph renderer draws {glyph} \
+                 eighths and this draws {in_eighths} - the two have parted \
+                 company by more than the eighth a block character rounds to",
+            );
+        }
+    }
+}

--- a/src/surface/frame.rs
+++ b/src/surface/frame.rs
@@ -375,10 +375,11 @@ mod against_the_glyphs {
         let screen = Screen::new(Length(cols as f32 * cw), Length(rows as f32 * ch));
         let layout = BarLayout::new(Length(cw), Length(0.0));
 
-        // A ramp across the display, so every height between silence and full
-        // scale is checked rather than a few chosen ones.
+        // A ramp across the display, reaching both ends: bar 0 is silence and the
+        // last is full scale, which are the two heights most worth checking and
+        // the two a ramp that stops short of them never sees.
         let levels: Vec<f32> = (0..cols as usize)
-            .map(|i| 0.05 + 0.9 * (i as f32 / cols as f32))
+            .map(|i| i as f32 / (cols - 1) as f32)
             .collect();
         let look = Look {
             theme: &theme,


### PR DESCRIPTION
The plan set one acceptance test for moving off glyphs, and nothing was checking it:

> the first pixel release must match a screenshot of the glyph release at the same size. Any difference is a regression, not a redesign.

**Not identical, and it would be wrong if it were.** A glyph bar is truncated to a whole eighth of a cell — that is the finest a block character goes. So a pixel bar is the same height or one eighth *taller*: the height with nothing rounded off it. Never shorter, and never by more than the eighth the rounding accounts for.

Measured at 80×24 cells of 30×60 device pixels, which is what a WezTerm on this Mac reports, with one bar per cell column so the two line up, and a level ramp across the display so every height is checked rather than a chosen few:

```
  bar   glyph-eighths   pixel-height   as-eighths   diff
    0               9             72           10      1
    7              24            186           25      1
   20              52            396           53      1
   39              93            704           94      1
   60             139           1044          139      0
   79             180           1352          180      0
```

One eighth at the bottom of the display, none at the top. That is the truncation and nothing else — the pixel renderer is drawing the same bars, at the same heights, without the rounding that made the ladder uneven in the first place (#63).

Shrinking every bar by 3% fails it at bar 9.
