### PR TITLE
feat: the bar styles are shapes on pixels, not six labels over one picture

### DIFF
--- a/crates/rav-appearance/src/lib.rs
+++ b/crates/rav-appearance/src/lib.rs
@@ -56,5 +56,5 @@ pub use palette::Palette;
 pub use preset::Preset;
 pub use ramp::{Ramp, Stripe};
 pub use scene::{Band, CapStyle, Scene, Style, StyleId};
-pub use skin::{Shapes, Skin};
+pub use skin::{Rung, Shapes, Skin, ladders};
 pub use theme::{SCOPE_LEVELS, STOPS, StaticTheme, Theme};

--- a/crates/rav-appearance/src/scene.rs
+++ b/crates/rav-appearance/src/scene.rs
@@ -17,6 +17,7 @@
 
 use crate::ink::Colour;
 use crate::ramp::Ramp;
+use crate::skin::Skin;
 use rav_core::geometry::{BarLayout, Screen};
 use rav_core::units::{Length, Level};
 
@@ -96,6 +97,14 @@ pub struct Style<'a> {
     pub grid: Option<&'a Ramp>,
     /// `None` when caps are switched off.
     pub cap: Option<CapStyle>,
+    /// The ladder a bar is built from, and how tall one of its rungs is here.
+    ///
+    /// `None` draws the bar as one shape from the floor, which is what a
+    /// surface with rungs of its own wants: a cell grid already draws the rung
+    /// with a glyph, and drawing it twice would fight the glyph. A surface with
+    /// no rungs of its own draws them from this, which is the only way `b`
+    /// means anything on it.
+    pub ladder: Option<(Skin, Length)>,
 }
 
 /// How the peak caps are drawn.
@@ -161,6 +170,7 @@ mod tests {
             bars: &green,
             grid: None,
             cap: None,
+            ladder: None,
         }];
         let many: Vec<Band> = (0..64).map(|_| Band::default()).collect();
 
@@ -186,11 +196,13 @@ mod tests {
                 bars: &left,
                 grid: None,
                 cap: None,
+                ladder: None,
             },
             Style {
                 bars: &right,
                 grid: None,
                 cap: None,
+                ladder: None,
             },
         ];
         let bands = [
@@ -218,6 +230,7 @@ mod tests {
             bars: &green,
             grid: None,
             cap: None,
+            ladder: None,
         }];
         let stale = Band::default().styled(StyleId(9));
         let bands = [stale];

--- a/crates/rav-appearance/src/skin.rs
+++ b/crates/rav-appearance/src/skin.rs
@@ -53,13 +53,70 @@ pub enum Shapes {
     Discrete,
 }
 
+/// One rung of the ladder a bar is built from, as a fraction of its pitch.
+///
+/// Fractions rather than lengths, so the same skin describes a cell sixty
+/// device pixels tall, a cell of eight, and one light on a strip. The surface
+/// multiplies by whatever a rung is worth to it.
+///
+/// Transcribed from what WezTerm actually draws rather than from the font: it
+/// renders these itself with `custom_block_glyphs`, so the outlines in a font
+/// file are not what anyone is looking at. `▇` is the lower seven eighths, `━`
+/// is a stroke across the middle, and `░▒▓` are a whole cell at flat opacity -
+/// **not** the dithers their outlines describe.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct Rung {
+    /// How much of the rung's height the lit shape fills. 1.0 is all of it.
+    pub covers: f32,
+    /// Where the shape's bottom sits, measured up from the rung's bottom.
+    ///
+    /// Zero for every ladder that grows off the floor, which is all of them but
+    /// the rule: `━` is a stroke at mid-height and has to float.
+    pub floats: f32,
+    /// Flat opacity of the lit shape.
+    ///
+    /// The shaded styles are the reason this exists. `▓` is a whole cell at
+    /// three quarters, and no clip of a full block yields it.
+    pub opacity: f32,
+}
+
+impl Rung {
+    /// The ordinary case: a shape that fills its rung, opaque, off the floor.
+    pub const FULL: Self = Self {
+        covers: 1.0,
+        floats: 0.0,
+        opacity: 1.0,
+    };
+
+    /// The lower `covers` of a rung, opaque - the partial block ladder.
+    pub const fn lower(covers: f32) -> Self {
+        Self {
+            covers,
+            floats: 0.0,
+            opacity: 1.0,
+        }
+    }
+
+    /// A whole rung at flat opacity - the shaded styles.
+    pub const fn shaded(opacity: f32) -> Self {
+        Self {
+            covers: 1.0,
+            floats: 0.0,
+            opacity,
+        }
+    }
+}
+
 /// The shapes a bar is drawn from.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub struct Skin {
     pub name: &'static str,
     /// How many steps a rung divides into. The one thing the core is told.
     steps: usize,
     pub shapes: Shapes,
+    /// What one rung looks like. A surface with rungs of its own - a cell grid -
+    /// already draws this with a glyph; a surface without them draws it here.
+    pub rung: Rung,
 }
 
 impl Skin {
@@ -70,7 +127,13 @@ impl Skin {
             name,
             steps: if steps == 0 { 1 } else { steps },
             shapes,
+            rung: Rung::FULL,
         }
+    }
+
+    /// The same skin, drawn from a rung of a different shape.
+    pub const fn drawn_as(self, rung: Rung) -> Self {
+        Self { rung, ..self }
     }
 
     pub const fn steps(&self) -> usize {
@@ -95,6 +158,53 @@ pub const BLOCKS: Skin = Skin::new("blocks", 8, Shapes::Discrete);
 /// What an LED strip is, and what a pixel surface can draw at any size without
 /// a shape per step.
 pub const SOLID: Skin = Skin::new("solid", 1, Shapes::Clipped);
+
+/// The six ladders rav offers, as the terminal's `b` key cycles them.
+///
+/// Every one is a whole cell or a fraction of one - which is why they need no
+/// artwork and no parser, and why a surface that is not made of cells can draw
+/// them from these numbers alone. Anything richer is a skin with shapes in it,
+/// and arrives with them.
+///
+/// The fractions come from what WezTerm renders, not from a font: `wezterm
+/// ls-fonts` reports every one of these as `drawn by wezterm because
+/// custom_block_glyphs=true`, so the font's outlines are not on screen. The
+/// difference matters most for the shades, which are flat opacity here and
+/// genuine dithers in a font file.
+pub mod ladders {
+    use super::{Rung, Shapes, Skin};
+
+    /// `█` - the whole cell. The original's look, and the smoothest, because
+    /// `▁▂▃▄▅▆▇` give it eight steps within a cell.
+    pub const BLOCKS: Skin = Skin::new("blocks", 8, Shapes::Discrete);
+
+    /// `▓` - a whole cell at three quarters, with `░▒` beneath it.
+    ///
+    /// Three steps, not eight: Unicode has no shaded eighth-blocks, so the top
+    /// of a shade bar fades in rather than rising.
+    pub const SHADE: Skin = Skin::new("shade", 4, Shapes::Discrete).drawn_as(Rung::shaded(0.75));
+
+    /// `▇` - the lower seven eighths. The densest that still shows a seam.
+    pub const SOLID: Skin = Skin::new("solid", 1, Shapes::Clipped).drawn_as(Rung::lower(7.0 / 8.0));
+
+    /// `▆` - the lower three quarters. Near-solid with a thin dark separator.
+    pub const THICK: Skin = Skin::new("thick", 1, Shapes::Clipped).drawn_as(Rung::lower(0.75));
+
+    /// `▄` - the lower half. Visibly striped.
+    pub const HALF: Skin = Skin::new("half", 1, Shapes::Clipped).drawn_as(Rung::lower(0.5));
+
+    /// `━` - a thin rule at mid-height. The airiest ladder.
+    ///
+    /// The one that floats. WezTerm draws it as a stroke across the middle of
+    /// the cell, so it neither sits on the rung's floor nor fills it - and a
+    /// ladder of these reads as rungs with air between them rather than as a
+    /// bar with gaps cut out.
+    pub const LINE: Skin = Skin::new("line", 1, Shapes::Clipped).drawn_as(Rung {
+        covers: 1.0 / 8.0,
+        floats: 7.0 / 16.0,
+        opacity: 1.0,
+    });
+}
 
 #[cfg(test)]
 mod tests {

--- a/src/bin/kitty_spike.rs
+++ b/src/bin/kitty_spike.rs
@@ -472,6 +472,7 @@ fn paint(frame: &mut [u8], width: u32, tick: u64) {
             colour: Colour::rgb(0xff, 0xc0, 0xb0),
             thickness: Length(3.0),
         }),
+        ladder: None,
     }];
     Scene {
         bands: &bands,

--- a/src/render/raster.rs
+++ b/src/render/raster.rs
@@ -7,6 +7,7 @@
 
 use crate::render::{Colour, Ramp, Scene};
 use rav_core::geometry::{Rectangle, Screen};
+use rav_core::units::Length;
 use tiny_skia::{Paint, Pixmap, Rect as SkRect, Transform};
 
 /// An RGBA buffer that geometry is drawn into.
@@ -75,9 +76,28 @@ impl Canvas {
     /// Stripe by stripe rather than row by row, so the cost is the number of
     /// stops and not the height of the rectangle.
     pub fn fill_ramped(&mut self, area: Rectangle, ramp: &Ramp, screen: &Screen) {
+        self.fill_ramped_at(area, ramp, screen, 1.0);
+    }
+
+    /// The same, at a flat opacity over whatever the ramp gives.
+    ///
+    /// What the shaded styles are. `▓` is a whole cell at three quarters, and
+    /// scaling the ramp's own alpha is how that reaches a surface with no
+    /// glyph to carry it - the colour still comes from the height, so the bar
+    /// still reddens as it rises, just fainter all the way up.
+    pub fn fill_ramped_at(&mut self, area: Rectangle, ramp: &Ramp, screen: &Screen, opacity: f32) {
+        let opacity = opacity.clamp(0.0, 1.0);
         for stripe in ramp.stripes(screen.height()) {
             if let Some(part) = stripe.clip(area) {
-                self.fill(part, stripe.colour);
+                let colour = if opacity >= 1.0 {
+                    stripe.colour
+                } else {
+                    Colour {
+                        alpha: (f32::from(stripe.colour.alpha) * opacity) as u8,
+                        ..stripe.colour
+                    }
+                };
+                self.fill(part, colour);
             }
         }
     }
@@ -136,7 +156,10 @@ impl Draw for Scene<'_> {
         for (index, band) in self.bands.iter().take(drawable).enumerate() {
             if let Some(style) = self.style_of(band) {
                 let bar = self.layout.column(index).bar(band.level, screen);
-                canvas.fill_ramped(bar, style.bars, screen);
+                match style.ladder {
+                    Some((skin, rung)) => draw_ladder(canvas, bar, skin, rung, style.bars, screen),
+                    None => canvas.fill_ramped(bar, style.bars, screen),
+                }
             }
         }
 
@@ -145,6 +168,69 @@ impl Draw for Scene<'_> {
                 let column = self.layout.column(index);
                 canvas.fill(column.cap(band.peak, cap.thickness, screen), cap.colour);
             }
+        }
+    }
+}
+
+/// Draw a bar as the ladder its skin describes, rung by rung.
+///
+/// The bar is the same rectangle either way; what changes is what fills it. A
+/// solid style covers the lower seven eighths of each rung, so the ladder shows
+/// a seam every rung; a rule covers an eighth in the middle of one and reads as
+/// air. That is what `b` chooses, and on a cell grid the glyph does it - here
+/// nothing does unless this does.
+///
+/// The topmost rung is clipped to the bar rather than drawn whole, so a bar
+/// that stops part way up a rung stops there instead of rounding up to it.
+fn draw_ladder(
+    canvas: &mut Canvas,
+    bar: Rectangle,
+    skin: rav_appearance::Skin,
+    rung: Length,
+    ramp: &Ramp,
+    screen: &Screen,
+) {
+    // A rung with no height is a division by zero waiting to happen, and a
+    // screen mid-resize produces one. One shape is the honest fallback: it is
+    // what the ladder collapses to when there is no room for rungs.
+    if rung.get() <= 0.0 || bar.height().get() <= 0.0 {
+        canvas.fill_ramped(bar, ramp, screen);
+        return;
+    }
+
+    let shape = skin.rung;
+    let floor = bar.bottom();
+    let mut lit = bar.height().get();
+    let mut index = 0usize;
+
+    while lit > 0.0 {
+        // Rungs are counted from the floor, which is where a bar grows from.
+        let rung_bottom = floor - rung * (index as f32);
+        let rung_top = rung_bottom - rung;
+
+        let shape_bottom = rung_bottom - rung * shape.floats;
+        let shape_top = shape_bottom - rung * shape.covers;
+
+        // Clipped to the bar, so the rung the bar stops inside is drawn only as
+        // far as the bar reached.
+        let top = shape_top.largest(bar.top());
+        let bottom = shape_bottom.smallest(floor);
+        if bottom > top {
+            let piece = Rectangle::new(bar.left(), top, bar.width(), bottom - top);
+            if shape.opacity >= 1.0 {
+                canvas.fill_ramped(piece, ramp, screen);
+            } else {
+                canvas.fill_ramped_at(piece, ramp, screen, shape.opacity);
+            }
+        }
+
+        lit -= rung.get();
+        index += 1;
+        // Nothing draws below the floor or above the bar, so the loop is bounded
+        // by the bar's own height - but a rung smaller than float precision
+        // would not shrink `lit`, and this is the render path.
+        if index > 4096 || rung_top.get() < bar.top().get() - rung.get() {
+            break;
         }
     }
 }
@@ -196,6 +282,7 @@ mod tests {
                 colour: Colour::WHITE,
                 thickness: Length(3.0),
             }),
+            ladder: None,
         }]
     }
 
@@ -297,11 +384,13 @@ mod tests {
                 bars: &left_ramp,
                 grid: None,
                 cap: None,
+                ladder: None,
             },
             Style {
                 bars: &right_ramp,
                 grid: None,
                 cap: None,
+                ladder: None,
             },
         ];
         // Two bands side by side, second one in the second style.
@@ -333,11 +422,13 @@ mod tests {
                 bars: &ramp,
                 grid: None,
                 cap: None,
+                ladder: None,
             },
             Style {
                 bars: &other,
                 grid: None,
                 cap: None,
+                ladder: None,
             },
         ];
         // Band 0 quiet, band 1 loud - both in style 0, with style 1 present but

--- a/src/surface/frame.rs
+++ b/src/surface/frame.rs
@@ -11,6 +11,7 @@
 
 use crate::render::{Band, Canvas, CapStyle, Draw, Ramp, Scene, Style};
 use crate::visual::{Palette, Theme};
+use rav_appearance::Skin;
 use rav_core::geometry::{BarLayout, Screen};
 use rav_core::units::{Length, Level};
 
@@ -28,6 +29,12 @@ pub struct Look<'a> {
     pub backdrop: bool,
     /// How thick a peak cap is, or `None` when `p` has switched them off.
     pub caps: Option<Length>,
+    /// The ladder `b` chose, and how tall a rung is on this surface.
+    ///
+    /// A cell grid draws its own rungs with a glyph and wants `None`. A frame of
+    /// pixels has no rungs of its own, so without this every bar style draws the
+    /// same solid bar and `b` is six labels over one picture.
+    pub ladder: Option<(Skin, Length)>,
 }
 
 /// Everything a frame needs, held for as long as it takes to draw.
@@ -36,6 +43,7 @@ pub struct Frame {
     bars: Ramp,
     grid: Option<Ramp>,
     cap: Option<CapStyle>,
+    ladder: Option<(Skin, Length)>,
     layout: BarLayout,
     screen: Screen,
 }
@@ -65,6 +73,7 @@ impl Frame {
                 colour: look.theme.cap_colour(look.palette),
                 thickness,
             }),
+            ladder: look.ladder,
             layout,
             screen,
         }
@@ -81,6 +90,7 @@ impl Frame {
             bars: &self.bars,
             grid: self.grid.as_ref(),
             cap: self.cap,
+            ladder: self.ladder,
         }];
         Scene {
             bands: &self.bands,
@@ -125,6 +135,7 @@ mod tests {
             palette: Box::leak(Box::new(Palette::default())),
             backdrop: true,
             caps: None,
+            ladder: None,
         }
     }
 
@@ -140,6 +151,7 @@ mod tests {
             palette: &palette,
             backdrop,
             caps,
+            ladder: None,
         };
         Frame::new(levels, peaks, &look, layout(), screen())
             .pixels()
@@ -347,6 +359,128 @@ mod tests {
         assert_eq!(first.right(), Length(20.0));
         assert_eq!(layout().column(1).left(), Length(24.0));
     }
+
+    /// The same frame, drawn as the ladder `style` describes with 20px rungs.
+    fn laddered(level: f32, style: crate::ui::analyzer::BarStyle) -> Vec<u8> {
+        let theme = Theme::default();
+        let palette = Palette::default();
+        let look = Look {
+            theme: &theme,
+            palette: &palette,
+            backdrop: false,
+            caps: None,
+            ladder: Some((style.skin(), Length(20.0))),
+        };
+        Frame::new(&[level], &[level], &look, layout(), screen())
+            .pixels()
+            .expect("a screen with area")
+    }
+
+    #[test]
+    fn a_ladder_leaves_a_seam_where_its_glyph_does() {
+        use crate::ui::analyzer::BarStyle;
+        // What `b` chooses, drawn rather than named. `▇` is the lower seven
+        // eighths of a cell, so a bar of it shows a gap in the top eighth of
+        // every rung - which is the seam you see on a terminal, and which a
+        // frame of pixels has to draw for itself.
+        let inside = layout().column(0).left().get() as u32 + 5;
+        // Rungs are 20 tall and the bar is full, so the floor of the second rung
+        // up is 20 from the bottom and its top is 40.
+        let second_rung_top = TALL as u32 - 40;
+
+        let solid = laddered(1.0, BarStyle::Solid);
+        // Seven eighths of 20 is 17.5, so the top two and a half pixels of the
+        // rung are the seam. Two in is inside it; five in is under it.
+        assert_eq!(
+            at(&solid, inside, second_rung_top + 1).3,
+            0,
+            "no seam at the top of the rung - solid drew a solid bar",
+        );
+        assert_ne!(
+            at(&solid, inside, second_rung_top + 5).3,
+            0,
+            "the rung itself is missing below its seam",
+        );
+
+        // Blocks fill the cell, so the same place is drawn.
+        let blocks = laddered(1.0, BarStyle::Blocks);
+        assert_ne!(
+            at(&blocks, inside, second_rung_top + 1).3,
+            0,
+            "blocks left a seam, and a full block has none",
+        );
+    }
+
+    #[test]
+    fn a_rule_floats_and_a_ladder_does_not() {
+        use crate::ui::analyzer::BarStyle;
+        // `━` is a stroke across the middle of its cell, so a ladder of them is
+        // rules with air above *and below* each one. Every other style sits on
+        // the rung's floor.
+        let inside = layout().column(0).left().get() as u32 + 5;
+        let floor = TALL as u32 - 1;
+
+        assert_eq!(
+            at(&laddered(1.0, BarStyle::Line), inside, floor).3,
+            0,
+            "the rule is sitting on the floor rather than floating above it",
+        );
+        for style in [BarStyle::Blocks, BarStyle::Solid, BarStyle::Half] {
+            assert_ne!(
+                at(&laddered(1.0, style), inside, floor).3,
+                0,
+                "{style:?} left the floor of its bottom rung empty",
+            );
+        }
+    }
+
+    #[test]
+    fn the_default_style_draws_exactly_what_it_drew_before_ladders() {
+        // The acceptance property for giving `b` a meaning here: `blocks` is a
+        // full cell, so its ladder tiles the bar and has to come out as the one
+        // rectangle that was drawn before there were ladders at all. Byte for
+        // byte - abutting antialiased edges could have left hairlines at every
+        // rung boundary, and on the default style nobody would have called it a
+        // regression, only "the bars look a bit odd now".
+        use crate::ui::analyzer::BarStyle;
+        let plain = capped(&[1.0], &[1.0], false, None);
+        let theme = Theme::default();
+        let palette = Palette::default();
+        let look = Look {
+            theme: &theme,
+            palette: &palette,
+            backdrop: false,
+            caps: None,
+            ladder: Some((BarStyle::Blocks.skin(), Length(20.0))),
+        };
+        let laddered = Frame::new(&[1.0], &[1.0], &look, layout(), screen())
+            .pixels()
+            .unwrap();
+        assert_eq!(
+            plain, laddered,
+            "the blocks ladder is not the bar it replaced - look for hairlines \
+             where the rungs meet",
+        );
+    }
+
+    #[test]
+    fn a_shaded_ladder_is_the_same_colour_more_faintly() {
+        use crate::ui::analyzer::BarStyle;
+        // `▓` is a whole cell at three quarters - a density, not a height. The
+        // bar still reddens as it rises, because the colour still comes from
+        // the height; it is only fainter all the way up.
+        let inside = layout().column(0).left().get() as u32 + 5;
+        let low = TALL as u32 - 5;
+
+        let solid = at(&laddered(1.0, BarStyle::Blocks), inside, low);
+        let shaded = at(&laddered(1.0, BarStyle::Shade), inside, low);
+        assert_ne!(solid.3, 0, "nothing to compare against");
+        assert!(
+            shaded.3 < solid.3,
+            "the shade is not fainter: {shaded:?} against {solid:?}",
+        );
+        assert!(shaded.3 > 0, "the shade vanished entirely");
+    }
 }
 
 #[cfg(test)]
@@ -386,6 +520,9 @@ mod against_the_glyphs {
             palette: &palette,
             backdrop: false,
             caps: None,
+            // The acceptance test is about where a bar stands, not what it is
+            // made of - a ladder here would compare a ladder to a solid glyph.
+            ladder: None,
         };
         let rgba = Frame::new(&levels, &levels, &look, layout, screen)
             .pixels()

--- a/src/ui/analyzer.rs
+++ b/src/ui/analyzer.rs
@@ -61,6 +61,25 @@ impl BarStyle {
         }
     }
 
+    /// The ladder this style is, for a surface that has to draw the shape
+    /// rather than name a glyph.
+    ///
+    /// The same six the `b` key cycles, held as fractions of a rung in
+    /// `rav-appearance` so a surface with no cells can still draw them. A cell
+    /// grid never asks: it has the glyph, and drawing the shape underneath it
+    /// would only fight it.
+    pub fn skin(self) -> rav_appearance::Skin {
+        use rav_appearance::skin::ladders;
+        match self {
+            BarStyle::Shade => ladders::SHADE,
+            BarStyle::Blocks => ladders::BLOCKS,
+            BarStyle::Solid => ladders::SOLID,
+            BarStyle::Thick => ladders::THICK,
+            BarStyle::Half => ladders::HALF,
+            BarStyle::Line => ladders::LINE,
+        }
+    }
+
     /// Glyph for a fully lit row.
     fn glyph(self) -> &'static str {
         match self {
@@ -161,7 +180,7 @@ impl Peaks {
     /// A fraction of full scale, so a pixel surface can place it directly.
     ///
     /// `Coarse` is one position per row - the middle of the row the peak falls
-    /// in, which is where the original panel drew it and what [`Self::cell`]
+    /// in, which is where the original panel drew it and what `Self::cell`
     /// still does with `CAP_MID`. Keeping that on a surface that could place the
     /// cap anywhere is the whole point of offering the setting: coarse is a
     /// look, not a limitation, and it steps as it falls.

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -474,6 +474,10 @@ impl App {
             // One row of the sixteen the original panel had, which is the
             // proportion its caps were drawn at.
             caps: (self.peaks != Peaks::Off).then(|| screen.height() / 16.0),
+            // A rung is a cell tall, so the ladder lines up with what the glyph
+            // renderer draws at the same size - the two are meant to be the
+            // same picture, and a ladder on its own pitch would not be.
+            ladder: Some((self.bar_style.skin(), cell.down(Cells(1)))),
         };
         // `coarse` and `fine` are the same cap on a cell grid - one position per
         // row is all a cell offers - so the difference has to be made here or
@@ -797,16 +801,7 @@ impl App {
             HelpRow {
                 key: "b",
                 description: "bar style",
-                // Says so while the pixels are drawing, because it is the one
-                // setting here that does nothing on that surface. A bar style
-                // names glyphs - `▇`, `▆`, `━` - and a frame of pixels has none
-                // until the shapes arrive with the skins. Better to say that
-                // than to report a change the picture does not make.
-                value: Some(if self.painting {
-                    format!("{} (glyphs only)", self.bar_style.label())
-                } else {
-                    self.bar_style.label().to_string()
-                }),
+                value: Some(self.bar_style.label().to_string()),
             },
             HelpRow {
                 key: "g",
@@ -2495,6 +2490,7 @@ mod tests {
             ("p", Action::TogglePeaks),
             ("g", Action::ToggleGrid),
             ("+", Action::BarSize(1)),
+            ("b", Action::CycleBarStyle),
         ] {
             assert_ne!(
                 render(&[action], name),
@@ -2502,39 +2498,5 @@ mod tests {
                 "{name} changed nothing in the pixels",
             );
         }
-
-        // And the one that knowingly does nothing here, so the day it starts
-        // working this fails and asks to be told about it. Bar styles name
-        // glyphs; the shapes that would replace them arrive with the skins.
-        assert_eq!(
-            render(&[Action::CycleBarStyle], "b"),
-            base,
-            "`b` now changes the pixels - say so in the help panel, which \
-             currently tells the user it does not",
-        );
-    }
-
-    #[test]
-    fn the_bar_style_row_admits_it_does_nothing_to_pixels() {
-        // The panel is the one place a user finds out why pressing a key
-        // changed nothing. Reporting "bars solid" while the picture is
-        // identical to "bars blocks" is the kind of lie this display keeps
-        // being caught in.
-        let mut a = app();
-        let row = |a: &App| {
-            a.help_rows()
-                .into_iter()
-                .find(|r| r.key == "b")
-                .and_then(|r| r.value)
-                .expect("no bar style row")
-        };
-        assert_eq!(row(&a), "blocks", "on glyphs the style is simply the style");
-
-        a.painting = true;
-        assert_eq!(
-            row(&a),
-            "blocks (glyphs only)",
-            "the panel claims the bar style is doing something to the pixels",
-        );
     }
 }


### PR DESCRIPTION
Pressing `b` on the pixel surface named six styles and drew one. #92 made the help panel admit that; this makes it stop being true.

They are shapes now. A skin carries what one rung of its ladder looks like — as *fractions* of the rung rather than lengths, so the same numbers describe a cell sixty device pixels tall, a cell of eight, and one light on a strip:

| style | rung |
|---|---|
| `blocks` `█` | the whole rung |
| `shade` `▓` | the whole rung at three quarters opacity |
| `solid` `▇` | the lower seven eighths — a seam every rung |
| `thick` `▆` | the lower three quarters |
| `half` `▄` | the lower half — visibly striped |
| `line` `━` | an eighth in the **middle**, floating — which is why a rule reads as air rather than as a bar with slots cut in it |

Transcribed from what WezTerm draws, not from a font. It renders all of these itself with `custom_block_glyphs`, so a font's outlines are not what is on screen — most visibly for the shades, which are flat opacity here and genuine dithers in a font file. That distinction is the reason the plan says not to source these from `assets/glyphs.svg`.

**The default is byte-identical to what it drew before.** `blocks` is a whole rung, so its ladder tiles the bar and must come out as the single rectangle that was there before ladders existed. Abutting antialiased edges could have left a hairline at every rung boundary — and on the *default* style that reads as "the bars look a bit odd now" rather than as a regression anyone reports. Asserted byte for byte.

**Measured before assuming.** I expected the per-rung stripe iteration to be a cost worth avoiding. At 2400×1440 with 80 bars a frame goes 3.58ms → 3.75ms for blocks, 3.92ms for solid, against a 16.7ms budget. It isn't where the time goes, so there is no fast path here — adding one would be optimising something measured as not mattering.

Each property is checked by the test that owns it, and each was mutated to prove it bites: taking the seam off `solid`, standing `line` on the floor, and making `shade` opaque each fail exactly one test.

This is the built-in half of stage 4. User-supplied SVG skins are the other half and need `usvg`, tessellation caching, and `flake.nix` learning `.svg` — none of which the built-ins want, because every one of them is a rectangle or a fraction of one.
