### PR TITLE
test: hold the acceptance test to the ladder production passes

### DIFF
--- a/src/surface/frame.rs
+++ b/src/surface/frame.rs
@@ -520,9 +520,15 @@ mod against_the_glyphs {
             palette: &palette,
             backdrop: false,
             caps: None,
-            // The acceptance test is about where a bar stands, not what it is
-            // made of - a ladder here would compare a ladder to a solid glyph.
-            ladder: None,
+            // The ladder production actually passes, not `None`. `blocks` is
+            // what rav opens as, and testing the configuration nobody runs
+            // would leave the one everybody runs unchecked.
+            //
+            // Only the styles whose ink reaches the top of their rung can be
+            // compared this way: `line` is a rule at mid-height, so its topmost
+            // ink sits half a rung below its bar top - on the glyph renderer
+            // too, which draws the same stroke.
+            ladder: Some((crate::ui::analyzer::BarStyle::Blocks.skin(), Length(ch))),
         };
         let rgba = Frame::new(&levels, &levels, &look, layout, screen)
             .pixels()


### PR DESCRIPTION
Caught reviewing #93 after it merged, which is later than I would like.

The test that says *a pixel bar stands where the glyph bar did* was written before bar styles were shapes, and it passed `ladder: None`. Since #93 that is a configuration nothing runs: rav opens as `blocks`, and every frame it draws goes through a ladder. The acceptance test was checking a path no user has.

It uses the real one now, and the property is unchanged — **one eighth of a cell at the bottom of the display, none at the top**, which is the truncation a block character rounds to and nothing else. Shrinking every bar by 3% still fails it.

I checked the other styles the same way:

```
Blocks: worst disagreement with the glyph renderer = 1 eighths
Solid:  worst disagreement with the glyph renderer = 1 eighths
Line:   worst disagreement with the glyph renderer = 6 eighths
```

**`line` is my measurement being wrong, not the renderer.** A rule draws at mid-rung, so its topmost ink sits half a rung below its bar top — on the glyph renderer too, which draws the same stroke. Comparing topmost ink to bar height only means anything for styles whose ink reaches the top of their rung. The comment says so now rather than leaving the next person to rediscover it and file a bug against a correct picture.
