### PR TITLE
docs: say where the block shapes ended up

### DIFF
--- a/docs/glyphs.md
+++ b/docs/glyphs.md
@@ -30,6 +30,25 @@ as the deliberate change it was.
 Skin shapes come from WezTerm's `customglyph.rs`: eighth blocks are full-width
 rectangles from `(8-n)·h/8`, and `░▒▓` are the whole cell at flat alpha.
 
+## Where they went
+
+The six built-in ladders now live in `rav-appearance`'s `skin::ladders`, as
+fractions of a rung rather than artwork:
+
+| style | rung |
+|---|---|
+| `blocks` `█` | the whole rung |
+| `shade` `▓` | the whole rung at 0.75 opacity — flat, per the above, not a dither |
+| `solid` `▇` | the lower seven eighths |
+| `thick` `▆` | the lower three quarters |
+| `half` `▄` | the lower half |
+| `line` `━` | an eighth in the middle, floating |
+
+Numbers rather than SVG because every one of them is a rectangle or a fraction
+of one. That keeps them on a target with no parser, no filesystem and no
+allocator — the same reason the themes are generated `const`s. Artwork is for
+skins that are actually drawings, and brings `usvg` with it when it arrives.
+
 This file stays as documentation of the other half of the story, and as the
 reason issue #63 looks different on Linux and macOS: the terminal, not the font,
 decides.


### PR DESCRIPTION
`docs/glyphs.md` warned against tracing a skin from the font's outlines — WezTerm draws these itself and renders `░▒▓` as flat alpha rather than the dithers a font contains, so a traced skin would have made the first pixel release differ from the glyph release it is meant to reproduce.

The warning was heeded in #93. The page did not say so, and still read as advice about work nobody had done.

It now lists where the six ladders ended up — `rav-appearance`'s `skin::ladders`, as fractions of a rung — and why they are numbers rather than artwork: every one is a rectangle or a fraction of one, which keeps them on a target with no parser, no filesystem and no allocator. The same argument that made the themes generated `const`s.

Artwork is for skins that are actually drawings, and brings `usvg` with it when it arrives.