### PR TITLE
fix: rav opens as the skin its own preset names

### DIFF
--- a/crates/rav-appearance/src/preset.rs
+++ b/crates/rav-appearance/src/preset.rs
@@ -72,7 +72,7 @@ pub const STRIP: Preset = Preset {
     name: "strip",
     ballistics: ballistics::WINAMP,
     theme: &crate::theme::RAV,
-    skin: skin::SOLID,
+    skin: skin::PLAIN,
     curve: Curve::Decibel { floor: -48.0 },
 };
 

--- a/crates/rav-appearance/src/skin.rs
+++ b/crates/rav-appearance/src/skin.rs
@@ -157,7 +157,11 @@ pub const BLOCKS: Skin = Skin::new("blocks", 8, Shapes::Discrete);
 ///
 /// What an LED strip is, and what a pixel surface can draw at any size without
 /// a shape per step.
-pub const SOLID: Skin = Skin::new("solid", 1, Shapes::Clipped);
+///
+/// Not to be confused with [`ladders::SOLID`], which is the terminal bar style
+/// `▇` - the lower seven eighths of every rung. This one has no rungs at all.
+/// They were both called "solid" for a day and that was one day too many.
+pub const PLAIN: Skin = Skin::new("plain", 1, Shapes::Clipped);
 
 /// The six ladders rav offers, as the terminal's `b` key cycles them.
 ///
@@ -240,7 +244,7 @@ mod tests {
         // cell that yields a half-density one, so a skin carrying the shades
         // cannot be drawn by clipping.
         assert!(BLOCKS.needs_a_shape_per_step());
-        assert!(!SOLID.needs_a_shape_per_step());
+        assert!(!PLAIN.needs_a_shape_per_step());
     }
 
     #[test]

--- a/src/ui/analyzer.rs
+++ b/src/ui/analyzer.rs
@@ -80,6 +80,29 @@ impl BarStyle {
         }
     }
 
+    /// The style a preset asked for, or `None` if it named a skin no bar style
+    /// corresponds to.
+    ///
+    /// The inverse of [`Self::skin`], so a preset naming `blocks` opens as
+    /// `Blocks` rather than as whatever `Default` happens to say. Without it a
+    /// preset carries a skin nothing reads, and rav has two answers to "what
+    /// does it open as" that agree only by coincidence.
+    ///
+    /// `None` is an ordinary outcome: `skin::PLAIN` is what a strip of lights
+    /// is, and no terminal bar style is that. The caller keeps its default.
+    pub fn from_skin(skin: rav_appearance::Skin) -> Option<Self> {
+        [
+            BarStyle::Shade,
+            BarStyle::Blocks,
+            BarStyle::Solid,
+            BarStyle::Thick,
+            BarStyle::Half,
+            BarStyle::Line,
+        ]
+        .into_iter()
+        .find(|style| style.skin() == skin)
+    }
+
     /// Glyph for a fully lit row.
     fn glyph(self) -> &'static str {
         match self {
@@ -1017,5 +1040,45 @@ mod tests {
         for x in 0..4u16 {
             assert_eq!(buf[(x, 0)].symbol(), "█", "column {x} should be filled");
         }
+    }
+
+    #[test]
+    fn every_bar_style_is_a_skin_and_back_again() {
+        // The two directions have to agree, or a preset naming a skin opens as
+        // something else and the panel reports a style the picture is not.
+        for style in [
+            BarStyle::Shade,
+            BarStyle::Blocks,
+            BarStyle::Solid,
+            BarStyle::Thick,
+            BarStyle::Half,
+            BarStyle::Line,
+        ] {
+            assert_eq!(
+                BarStyle::from_skin(style.skin()),
+                Some(style),
+                "{style:?} does not come back from its own skin",
+            );
+        }
+
+        // Every ladder is distinct, so the round trip above is not six styles
+        // agreeing to be the same one.
+        let skins: std::collections::BTreeSet<&str> = [
+            BarStyle::Shade,
+            BarStyle::Blocks,
+            BarStyle::Solid,
+            BarStyle::Thick,
+            BarStyle::Half,
+            BarStyle::Line,
+        ]
+        .into_iter()
+        .map(|s| s.skin().name)
+        .collect();
+        assert_eq!(skins.len(), 6, "two bar styles share a skin: {skins:?}");
+
+        // A skin that is not a bar style is not one: `plain` is what a strip of
+        // lights is, and the caller keeps its own default rather than being
+        // given a wrong answer.
+        assert_eq!(BarStyle::from_skin(rav_appearance::skin::PLAIN), None);
     }
 }

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -313,7 +313,10 @@ impl App {
             scope_style: ScopeStyle::default(),
             peaks: Peaks::default(),
             show_grid: true,
-            bar_style: BarStyle::default(),
+            // From the preset, not from `Default`: a preset naming a skin nothing
+            // reads is a preset that cannot describe how rav opens, and two
+            // answers to that question agree only until one of them moves.
+            bar_style: BarStyle::from_skin(preset.skin).unwrap_or_default(),
             show_help: false,
             status: None,
             source: None,
@@ -2498,5 +2501,27 @@ mod tests {
                 "{name} changed nothing in the pixels",
             );
         }
+    }
+
+    #[test]
+    fn rav_opens_as_the_preset_says_it_does() {
+        // One answer to "what does rav open as", not two that agree by accident.
+        // The preset names a skin; without this it is a field nothing reads and
+        // `BarStyle::default()` is the real answer, so a preset built for other
+        // hardware would be quietly ignored.
+        //
+        // Two assertions, because one would agree with itself. The first pins
+        // what the preset says - written out, so changing it fails here and asks
+        // to be told. The second pins that rav follows it.
+        assert_eq!(
+            rav_appearance::preset::RAV.skin,
+            rav_appearance::skin::ladders::BLOCKS,
+            "the preset rav ships with changed - is the opening style still right?",
+        );
+        assert_eq!(
+            app().bar_style,
+            BarStyle::Blocks,
+            "rav did not open as the skin its own preset names",
+        );
     }
 }


### PR DESCRIPTION
Two things #93 left behind, both mine, both found by reviewing it after the fact.

**A `Preset` carries a skin and nothing read it.** `App` opened with `BarStyle::default()`, so rav had two answers to "what does it open as" — and they agreed only because both happened to say `blocks`. A preset written for other hardware named a skin that was quietly ignored, which is exactly what the strip preset does.

The skin decides now. `BarStyle::from_skin` is the inverse of the mapping the ladders added, and returns `None` for a skin that is no bar style — `plain` is what a strip of lights is, and no terminal style is that, so the caller keeps its own default rather than being handed a wrong answer.

This also makes a doc claim from #74 obsolete in the right direction: *"every preset names a skin and nothing looks at one"*. Something looks now.

**And `skin::SOLID` was two different things under one name.** `ladders::SOLID` is the terminal bar style `▇` — the lower seven eighths of every rung. `skin::SOLID` was a bar with no rungs at all, which is what an LED strip is. Renamed to `skin::PLAIN`, with a note on each pointing at the other.

**The test needed writing twice.** My first version compared `app().bar_style.skin()` against `preset.skin` — reading the preset on both sides, so changing the preset changed both and it could never fail. It is two assertions now: one writes out what the preset says, so changing it fails and asks to be told; the other pins that rav follows. Both directions are mutation-checked — pointing the preset at `line`, and hard-coding the opening style — and each fails one of the two.

That is the third test today that passed for the wrong reason until it was mutated, which is why the mutation step is not optional.
