### PR TITLE
docs(release): say that the semver guard does not run during the beta

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -13,6 +13,20 @@ git_release_type = "auto"
 
 # cargo-semver-checks before each release: a breaking change proposed as a patch
 # bump is rejected and the version escalated.
+#
+# Inert for the whole 1.0.0-beta series, and left on so it starts working by
+# itself rather than needing to be remembered. Every bump between pre-release
+# versions is classified a *major* change, and a major change permits anything,
+# so every lint is skipped as vacuously satisfied:
+#
+#     $ cargo semver-checks check-release -p rav-appearance \
+#           --baseline-version 1.0.0-beta.7
+#     Checking rav-appearance v1.0.0-beta.7 -> v1.0.0-beta.8 (major change)
+#      Checked 0 checks: 0 pass, 254 skip
+#
+# `rav_appearance::skin::SOLID` was renamed in beta.9 and the release reported
+# "API compatible changes". So this guards nothing until 1.0.0 -> 1.0.1 - not
+# even the release *of* 1.0.0, which is a major change by the same rule.
 semver_check = true
 
 # Publishing requires merging a Release PR. An ordinary commit landing on master


### PR DESCRIPTION
`semver_check = true` reads as a guard against breaking changes. It is not one yet, and will not be until after 1.0.0.

Every bump between two pre-release versions is classified a *major* change, and a major change permits anything — so every lint is skipped as vacuously satisfied. Measured rather than inferred:

```
$ cargo semver-checks check-release -p rav-appearance --baseline-version 1.0.0-beta.7
Checking rav-appearance v1.0.0-beta.7 -> v1.0.0-beta.8 (major change)
 Checked  0 checks: 0 pass, 254 skip
 Summary  no semver update required
```

`rav_appearance::skin::SOLID` was renamed in #96 — a public item in a published crate — and the release PR still reports `✓ API compatible changes`.

The setting stays on, so it begins working by itself rather than having to be remembered. What changes is the comment, which now says what it covers and what it does not. A setting that reads as a guard and is not one is worse than no setting at all.

One consequence worth having written down: **not even the release of 1.0.0 is covered**, because reaching it from a beta is a major change by the same rule. The first release this can guard is 1.0.0 → 1.0.1 — the one after the one that matters most.