### PR TITLE
docs(developing): the module map was missing the pixel surface

### DIFF
--- a/docs/developing.md
+++ b/docs/developing.md
@@ -118,7 +118,8 @@ prevent.
 | `src/signal/` | FFT front end, bin-to-bar mapping, bar and cap ballistics |
 | `src/visual/` | reading a theme a *user* wrote, and asking the terminal for its palette — the halves that need a filesystem and a terminal |
 | `src/ui/` | the `App` event loop and the analyser, scope, status and help widgets |
-| `src/render/` | the pixel surface: a `Canvas` over tiny-skia, and the one impl that puts a scene onto it |
+| `src/render/` | the rasteriser: a `Canvas` over tiny-skia, and the one impl that puts a scene onto it. Knows nothing about terminals |
+| `src/surface/` | where a frame goes. Asking the terminal what it can draw, composing a frame of pixels, and the kitty protocol that carries one — see the module note in `surface/pixels.rs` for the rules the terminal imposes |
 | `src/testing/` | signal sources with known ground truth — tones, noise, and notes by MIDI number |
 | `tests/`, `crates/rav-core/tests/` | the tests that have to see a crate from outside, and the ones that hold for *every* input rather than a chosen one |
 


### PR DESCRIPTION
`src/surface/` is five files — the probe, the kitty protocol, staging, composing a frame, and the overlay — and the map a contributor reads to find their way around does not mention it at all.

Worse, `src/render/` was labelled *"the pixel surface"*. It stopped being that when the surface got a module of its own. It is the rasteriser: a canvas and one impl, knowing nothing about terminals — and that distinction is the whole reason the same scene can go to a glyph grid or an LED matrix instead. Losing it in the map is worse than the omission.

Every path the page names now resolves, checked rather than read:

```
ok  crates/rav-appearance/   ok  src/render/    ok  src/testing/
ok  crates/rav-core/         ok  src/signal/    ok  src/ui/
ok  src/audio/               ok  src/surface/   ok  src/visual/
```

Fifth finding from reading beta.9 whole. Like the others, it was accurate when written and nobody revisited it when the code moved underneath.