### PR TITLE
docs(appearance): two module notes describing the world before pixels

### DIFF
--- a/crates/rav-appearance/src/scene.rs
+++ b/crates/rav-appearance/src/scene.rs
@@ -9,11 +9,12 @@
 //! Nothing here can draw. A scene that knew how to rasterise itself would be a
 //! scene only a rasteriser could consume, and the LED matrix has none.
 //!
-//! # Taken by one thing
+//! # Taken by one surface
 //!
-//! The `tiny-skia` rasteriser, and only from the graphics spike so far. The
-//! glyph renderer takes levels and colours directly and quantises them itself,
-//! so this is the seam for one consumer until a second is built on it.
+//! The pixel surface, on every frame `--surface kitty` draws. The glyph
+//! renderer takes levels and colours directly and quantises them itself, so
+//! this is the seam for one consumer until a second is built on it - a window
+//! or an LED matrix would be the second, and neither exists yet.
 
 use crate::ink::Colour;
 use crate::ramp::Ramp;

--- a/crates/rav-appearance/src/skin.rs
+++ b/crates/rav-appearance/src/skin.rs
@@ -26,13 +26,17 @@
 //! for. That is the same number, read differently - which is the whole reason
 //! the core deals in counts.
 //!
-//! # Not yet read
+//! # What reads one, and what does not yet
 //!
-//! Every preset names a skin and nothing looks at one, and none carries
-//! artwork. The terminal draws from `BarStyle`, which names its glyphs
-//! directly; a [`Skin`] carries only the step count and leaves the glyphs to
-//! the surface. That difference is what would let one setting dress a glyph
-//! grid, a pixel surface and an LED strip at once.
+//! A skin decides two things today. Which ladder the pixel surface draws - see
+//! [`ladders`], where each of the six the `b` key offers is held as fractions
+//! of a rung - and which of those rav opens as, since a `Preset` names one and
+//! `BarStyle::from_skin` turns it back into a style.
+//!
+//! None carries artwork. The terminal draws from `BarStyle`, which names its
+//! glyphs directly, and it is right that it does: it has the glyph, and drawing
+//! the shape underneath would only fight it. What is left is a skin that is a
+//! genuine drawing rather than a rectangle, which is where `usvg` comes in.
 
 /// How a skin covers a partial rung.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]


### PR DESCRIPTION
Both of these were written in #74 to correct exactly this kind of drift. Both then drifted, when stages 3.2 and 4a shipped underneath them.

**`scene.rs`** said a scene is taken by *"the tiny-skia rasteriser, and only from the graphics spike so far"*. It is taken on every frame `--surface kitty` draws. The seam is still for one consumer, and the note now says which surface that is and what a second would be.

**`skin.rs`** said *"every preset names a skin and nothing looks at one"*. Two things look now: the pixel surface reads which ladder to draw (#93), and the opening bar style comes from the skin a preset names (#96). What remains true is that none carries artwork — which is where `usvg` comes in — so the heading is now what reads one and what does not, rather than nothing does.

**`capability.rs` was checked the same way and is still right**, which is worth saying too: nothing consults it, and `Surface::capabilities` has callers only inside its own test module. An honest "not yet" is as valuable as a corrected one.

Sixth and seventh findings from the pre-release read, and the first two in code rather than prose. The mechanism is identical: a note is accurate when written, the thing it describes moves, and nothing in the moving PR touches the note.