### PR TITLE
fix: --help stopped saying the surface flag draws nothing

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -40,8 +40,10 @@ struct Args {
     #[arg(long, value_name = "NAME|PATH")]
     theme: Option<String>,
 
-    /// Which surface to draw on. Reported in the help overlay; nothing draws on
-    /// it yet, so today this only changes what rav says it would use.
+    /// Which surface to draw on. `kitty` draws the bars as pixels in WezTerm,
+    /// Ghostty or kitty; `auto` still chooses glyphs however capable your
+    /// terminal is, and `window` is not built yet. Press `h` for what was
+    /// chosen and why.
     #[arg(
         long,
         value_name = "auto|glyphs|kitty|window",

--- a/src/main.rs
+++ b/src/main.rs
@@ -41,9 +41,10 @@ struct Args {
     theme: Option<String>,
 
     /// Which surface to draw on. `kitty` draws the bars as pixels in WezTerm,
-    /// Ghostty or kitty; `auto` still chooses glyphs however capable your
-    /// terminal is, and `window` is not built yet. Press `h` for what was
-    /// chosen and why.
+    /// Ghostty or kitty, and drops back to block characters on a terminal
+    /// that will not say how big it is in pixels; `auto` still chooses them
+    /// however capable your terminal is, and `window` is not built yet. Press
+    /// `h` for what rav settled on and why.
     #[arg(
         long,
         value_name = "auto|glyphs|kitty|window",


### PR DESCRIPTION
Found while assembling the command for the beta.9 visual check — the first thing anyone types is `rav --help`, and it says the flag does nothing:

```
--surface <auto|glyphs|kitty|window>
    Which surface to draw on. Reported in the help overlay; nothing draws on it
    yet, so today this only changes what rav says it would use
```

That was true for exactly one release. #84 made `--surface kitty` draw the bars as pixels, and #98 fixed the help *panel* to stop saying it *would* draw — the flag's own line was missed, and it is the more visible of the two. Both ship in the same unpublished beta.9, so this is a line correcting itself before it ever reaches anyone.

It now reads:

```
--surface <auto|glyphs|kitty|window>
    Which surface to draw on. `kitty` draws the bars as pixels in WezTerm,
    Ghostty or kitty; `auto` still chooses glyphs however capable your terminal
    is, and `window` is not built yet. Press `h` for what was chosen and why
    [default: auto]
```

Each of the four claims is what `surface::choose` actually does: `Choice::Window` falls back to glyphs with "a window of rav's own is not built yet", `Choice::Auto` on a terminal that answers the graphics probe returns glyphs with "your terminal can draw images - try --surface kitty", and `Choice::Kitty` is the only path to pixels. Its tests already pin all three.

No test added. The assertion would be that a sentence contains a word, which cannot be broken in a way that means anything — the defect here is a string outliving the stage it described, and no test catches that class. What does catch it is reading the whole release rather than each PR, which is how this one surfaced.