### PR TITLE
docs: say where a frame ends up, and what to do when it does not

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -58,3 +58,20 @@ where the newest run begins.
 On Linux that list is ALSA PCMs only — a PipeWire/PulseAudio `.monitor` source
 is not in it and cannot be selected with `-d`. Route the capture from the
 PipeWire side instead; see [audio.md](audio.md).
+
+## `--surface kitty` draws block characters anyway
+
+Press `h`. The last row of the panel names the surface and the reason, and it
+reports rather than forecasts: **drawing on** while the pixels are going,
+**would draw on** while they are not.
+
+| what it says | |
+|---|---|
+| `pixels (asked for)` | pixels are going, and nothing needs fixing |
+| `glyphs (your terminal will not say how big it is in pixels)` | rav asked the terminal how big it is and got no answer. Deriving a cell size from the font is the rounding the pixel surface exists to remove, so rav declines to guess |
+| `glyphs (your terminal can draw images - try --surface kitty)` | `auto`, on a terminal that could. Pixels are opt-in and stay that way for a few releases |
+| `glyphs (tmux or screen is in the way)` | image escapes do not pass through a multiplexer intact. An explicit `--surface kitty` is still honoured — asking always wins — but it is the terminal underneath that has to answer |
+
+**Pixels are the bars.** The oscilloscope is block characters on every surface,
+so `Space` takes the picture down and the panel goes back to saying *would*.
+Switching back brings it up again.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,9 @@
 //! tests and `rav` compile one copy of the tree rather than two.
 //!
 //! Capture is in [`audio`], analysis in [`signal`], and what a level looks like
-//! in [`visual`] and [`render`]. [`ui`] holds the event loop and the widgets.
+//! in [`visual`] and [`render`]. [`surface`] is where the picture ends up -
+//! block characters, or pixels carried by the kitty graphics protocol. [`ui`]
+//! holds the event loop and the widgets.
 //! The portable half - levels, geometry, colours, themes - lives in `rav-core`
 //! and `rav-appearance`, re-exported below.
 


### PR DESCRIPTION
Two gaps found by reading beta.9 as a whole release rather than as a stack of PRs — the same pass that caught #103.

**`src/lib.rs` never mentions `surface`.** The crate doc tours `audio`, `signal`, `visual`, `render` and `ui`, which was the whole of rav before #84. `surface` is the module this release is about, and this text is what docs.rs publishes — permanently, alongside the crates.io upload. #100 fixed exactly this in `docs/developing.md`; the crate's own front page was the copy nobody looked at.

**`docs/troubleshooting.md` has nothing about pixels.** The README sends people there when the display is wrong, and beta.9's headline is an opt-in surface that silently draws block characters when the terminal will not report its size. The new section is a key to the help panel rather than a second account of it — every row is a string rav already prints:

| what it says | |
|---|---|
| `pixels (asked for)` | pixels are going |
| `glyphs (your terminal will not say how big it is in pixels)` | `paint`'s fallback |
| `glyphs (your terminal can draw images - try --surface kitty)` | `auto` declining on a capable terminal |
| `glyphs (tmux or screen is in the way)` | `auto` under a multiplexer |

All four are `surface::choose` and `App::paint` verbatim, and the "drawing on" / "would draw on" distinction is #98's.

It also records something the panel shows but nothing explains: **pixels are the bars.** The oscilloscope is block characters on every surface, so `Space` calls `stop_painting`, the image comes down, and the row goes back to saying *would* — which reads as a fault if you do not know it is the design.

No test. Both changes are prose, and the assertions available are that a sentence contains a word.