### PR TITLE
fix: the cursor stops blinking on top of the bars

### DIFF
--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -530,6 +530,16 @@ impl App {
             self.painted_cells = cells.clone();
         }
 
+        // Hidden for as long as the picture is up. Nothing on this path goes
+        // through ratatui, which hides the cursor on every draw of its own - so
+        // left alone it blinks at the home position, which is exactly where
+        // every frame puts it and therefore on top of the bars. The glyph
+        // renderer takes it back over when `stop_painting` hands the screen
+        // across, so this is the transition into pixels rather than every frame.
+        if !self.painting {
+            write!(out, "\x1b[?25l")?;
+        }
+
         write!(out, "\x1b[H")?;
         self.painter.send(
             out,
@@ -1819,6 +1829,41 @@ mod tests {
         assert!(
             !String::from_utf8_lossy(&steady).contains("\x1b[2J"),
             "it cleared a screen nothing had changed on",
+        );
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn the_cursor_goes_away_while_the_picture_is_up() {
+        // ratatui hides it on every draw of its own, and nothing here goes
+        // through ratatui. Left showing it blinks at the home position - which
+        // is where every frame puts it, so it lands on the bars rather than
+        // somewhere out of the way.
+        let mut a = app();
+        a.resize(80, 24);
+        let dir = scratch("cursor");
+
+        let mut first = Vec::new();
+        assert!(a.painted(&mut first, window(), &dir, None, None).unwrap());
+        let sent = String::from_utf8_lossy(&first);
+        let hidden = sent.find("\x1b[?25l").expect("the cursor was left showing");
+        assert!(
+            hidden < sent.find("a=T").expect("no frame"),
+            "the cursor was hidden after the picture was already up",
+        );
+
+        // The oscilloscope gives the screen back to ratatui, which owns the
+        // cursor again while it has it - so coming back to the bars has to hide
+        // it a second time.
+        a.apply(Action::CycleVisualisation);
+        a.painted(&mut Vec::new(), window(), &dir, None, None)
+            .unwrap();
+        a.apply(Action::CycleVisualisation);
+        let mut back = Vec::new();
+        assert!(a.painted(&mut back, window(), &dir, None, None).unwrap());
+        assert!(
+            String::from_utf8_lossy(&back).contains("\x1b[?25l"),
+            "the cursor stayed showing on the way back to the bars",
         );
         std::fs::remove_dir_all(&dir).ok();
     }


### PR DESCRIPTION
A visible defect in the release being held, found by making the pixel path actually execute on this machine for the first time.

**What was wrong.** Every pixel frame homes the cursor before placing the image — it has to, or the picture walks off-screen as each frame lands where the last one ended. So the cursor sits at the top-left corner of the bars. The glyph renderer hides it, because ratatui hides it on every draw of its own; nothing on the pixel path goes through ratatui, and nothing else was hiding it. `rav --surface kitty` put a blinking block on the picture.

Measured, not reasoned about — three seconds of each surface on a pty:

| | `ESC [ ?25l` sent |
|---|---|
| `--surface glyphs` | 181 |
| `--surface kitty` | **0** |

**How it was reachable at all.** `script`’s pty reports a winsize of 0×0, which is why everything about this surface has been verified except its actually running — rav gets no drawing area and falls back to block characters. `openpty` takes a winsize, so a harness can hand rav 80×24 at 2400×1440 — the `TIOCGWINSZ` reading measured in WezTerm on this Mac, 30×60 per cell. The one subtlety is that crossterm reads the size through `/dev/tty`, so the child needs the pty as its **controlling terminal**, not merely as fd 0/1/2: `setsid` then `TIOCSCTTY`.

With that, rav draws. The capture of a three-second run says so:

```
ESC[?1049h ESC[2J ESC[?25l ESC[H ESC_Ga=T,q=2,i=1,f=32,s=2400,v=1440,z=0,C=1,S=13824000,t=t;<path> ESC\
```

- 169 images in three seconds — the 60fps cap, so the loop is running the pixel path rather than emitting one frame and stalling
- every one of the 169 preceded immediately by `ESC[H`
- `S=13824000` is exactly 2400 × 1440 × 4
- `t=t`, staged under `$TMPDIR` since macOS has no `/dev/shm`, and **zero** `.rgba` files left behind afterwards
- one `a=d,d=A` on `q`, then out of the alternate screen and the cursor back

**The fix** hides the cursor on the transition into pixels rather than on every frame, because `stop_painting` hands the screen to ratatui, which owns the cursor again while it has it — so the oscilloscope and back is the case that matters, and the test covers it. `hand_the_terminal_back` already shows it on the way out, on every exit including a panic.

The test fails without the fix (`the cursor was left showing`), checked by removing the write rather than by watching it pass.

**What this still does not establish**: that a terminal acts on a correct command and puts pixels on glass. That is what the manual check on the release PR is for — this narrows it to exactly that, and takes one thing off the list it would otherwise have found.