### PR TITLE
docs: put the demo back on the crates.io page, and cut the sales pitch

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 Bars, peak caps and an oscilloscope, in truecolour.
 Terminal today, GUI next.
 
-![rav](assets/demo.gif)
+![rav](https://raw.githubusercontent.com/i-am-logger/rav/master/assets/demo.gif)
 
 [![crates.io](https://img.shields.io/crates/v/rav?logo=rust&logoColor=white)](https://crates.io/crates/rav)
 [![Downloads](https://img.shields.io/crates/d/rav?logo=rust&logoColor=white)](https://crates.io/crates/rav)
@@ -45,14 +45,10 @@ rav --clean           # log almost nothing
 rav --surface kitty   # auto, glyphs, kitty or window
 ```
 
-`--surface kitty` draws the bars as **pixels** in WezTerm, Ghostty or kitty. A
-peak cap then rides over the backdrop instead of erasing the cell it crosses,
-and the bar ladder is even at any font size — the two things a terminal cell
-cannot do.
-
-You have to ask for it. `auto` still draws block characters everywhere, however
-capable your terminal is. Press `h` and the panel names the surface rav is on
-and why it chose it.
+`--surface kitty` draws the bars as pixels in WezTerm, Ghostty and kitty; a peak
+cap then rides over the backdrop instead of erasing the cell it crosses, and the
+bar ladder is even at any font size. `auto` draws block characters. Press `h` for
+which surface rav is on and why.
 
 Everything else is a keypress, and `h` shows the lot with their current values:
 
@@ -103,17 +99,10 @@ The ballistics, and the ramp the `rav` and `winamp` themes use, come from
 
 ## What's next
 
-**Pixels by default.** They are here behind `--surface kitty`; what is left is
-choosing them for you. A terminal cell holds one character and one background,
-so on the default path a peak cap still erases the grid it crosses and the bar
-ladder is still uneven at most font sizes. Drawing the pixels fixes both, and
-that is where every terminal capable of it is headed once the opt-in path has
-had a few releases in the open.
-
-**Then a window of its own, and small displays** — the same bars and the same
-colours on a strip of LEDs in a speaker cabinet, or a matrix behind a car
-dashboard. What rav measures is already kept apart from what it looks like, so a
-theme written for the terminal dresses those too.
+Pixels on `auto`, after the opt-in path has had a few releases in the open. A
+window of its own. Small displays — a strip of LEDs, or a matrix — which the
+same themes already cover, since what rav measures is kept apart from what it
+looks like.
 
 ## License
 


### PR DESCRIPTION
Two things wrong with the first page anyone reads.

**The demo is a broken image on crates.io and docs.rs.** `Cargo.toml` excludes `assets/` wholesale, so `assets/demo.gif` is not in the published crate, while the README links to it by relative path. It renders on GitHub and nowhere else — including the page people install from. beta.9 went out that way.

The gif is still in the repository and nothing about it changes; the link becomes absolute, so it resolves from every renderer and the crate stays the size it is rather than carrying 2.4 MB per version.

**The surface note and "What's next" had grown a register the rest of the page does not have.** They were arguing rather than stating — a cap that "rides over the backdrop" was fine, "the two things a terminal cell cannot do" and "that is where every terminal capable of it is headed" were not. Same facts, in the words the README used before:

> `--surface kitty` draws the bars as pixels in WezTerm, Ghostty and kitty; a peak cap then rides over the backdrop instead of erasing the cell it crosses, and the bar ladder is even at any font size. `auto` draws block characters. Press `h` for which surface rav is on and why.

> **What's next** — Pixels on `auto`, after the opt-in path has had a few releases in the open. A window of its own. Small displays — a strip of LEDs, or a matrix — which the same themes already cover, since what rav measures is kept apart from what it looks like.

`every_key_the_readme_documents_is_bound` and `the_readme_lists_the_values_the_code_offers` both read this file and both still pass; the key table is untouched.