### PR TITLE
feat(core): geometry a skin can lean, turn and recede through

### DIFF
--- a/crates/rav-core/src/lib.rs
+++ b/crates/rav-core/src/lib.rs
@@ -45,10 +45,12 @@ pub mod math;
 pub mod ballistics;
 pub mod capability;
 pub mod geometry;
+pub mod transform;
 pub mod units;
 
 pub use capability::{Capabilities, Requirements, Shortfall};
 pub use geometry::{Anchor, BarLayout, Column, Rectangle, Screen};
+pub use transform::{Point, Quad, Transform};
 pub use units::{
     Bounded, CellSize, Cells, Curve, Elapsed, Fill, Frames, Hz, Length, Level, SampleRate, Step,
 };

--- a/crates/rav-core/src/math.rs
+++ b/crates/rav-core/src/math.rs
@@ -48,6 +48,16 @@ pub fn powf(value: f32, exponent: f32) -> f32 {
     libm::powf(value, exponent)
 }
 
+/// Sine, in radians. Only [`crate::transform`] needs it, for the rotations.
+pub fn sin(radians: f32) -> f32 {
+    libm::sinf(radians)
+}
+
+/// Cosine, in radians. The other half of a rotation.
+pub fn cos(radians: f32) -> f32 {
+    libm::cosf(radians)
+}
+
 /// How far something travels when its speed is multiplied by `growth` every
 /// frame, in units of the speed it started at.
 ///

--- a/crates/rav-core/src/transform.rs
+++ b/crates/rav-core/src/transform.rs
@@ -1,0 +1,425 @@
+//! Where a shape ends up, when it is not simply where it was laid out.
+//!
+//! rav lays a bar out as an axis-aligned [`Rectangle`]: so far across, so far
+//! down, standing on the floor. That is the right shape for a terminal and it
+//! is the only shape a terminal can draw. Every other surface rav is heading
+//! towards can do more - a panel raked away from a driver, a spectrum receding
+//! into a corridor, a strip of lights wrapped round a cylinder - and all of
+//! those are one matrix away from the layout that already exists.
+//!
+//! # Why a 4x4 of `f32`, and not a library
+//!
+//! `rav-core` runs on a microcontroller with no allocator, and a transform has
+//! to be affordable per frame there as well as on a display. Sixteen floats is
+//! nothing: composing two is 64 multiplies, and applying one to the four
+//! corners of a bar is 64 more. A general tensor library is not, and would
+//! bring an allocator with it.
+//!
+//! # The convention, since half of them are wrong somewhere
+//!
+//! Column vectors: a point is transformed as `M * p`, so
+//! [`then`](Transform::then) composes left to right in the order things happen.
+//! Storage is row-major, `m[row][column]`, which is how the entries are written
+//! down in every reference this was checked against.
+//!
+//! Screen axes, so `x` runs right and `y` runs **down** - the same sense
+//! [`Rectangle`] uses, because a transform that disagreed with the layout about
+//! which way is down would be a sign error waiting in every skin. `z` runs away
+//! from the viewer, so a larger `z` is farther off.
+//!
+//! # Nothing here decides anything
+//!
+//! A transform says where a shape goes, never what it looks like: no colour, no
+//! opacity, no shape of its own. A surface that cannot honour one is free to
+//! ignore it and draw the layout it was given, which is exactly what the glyph
+//! renderer does - a cell grid has no room for a bar that leans.
+
+use crate::geometry::Rectangle;
+use crate::math::{cos, sin};
+use crate::units::Length;
+
+/// A place in the space a scene is laid out in.
+///
+/// Continuous, where `embedded_graphics::Point` is whole pixels. That is not a
+/// preference: a bar edge landing where the arithmetic puts it rather than on a
+/// pixel boundary is the whole argument for drawing pixels at all, and snapping
+/// is the mechanism behind the uneven ladder in #63. The rounding happens once,
+/// in a rasteriser, at the end.
+#[derive(Debug, Clone, Copy, PartialEq, Default)]
+pub struct Point {
+    pub x: Length,
+    pub y: Length,
+    /// Depth, away from the viewer.
+    ///
+    /// Everything rav lays out today is at zero - a terminal is flat and every
+    /// bar stands on the same plane. It is here because a transform that cannot
+    /// move a point back cannot make one recede either.
+    pub z: Length,
+}
+
+impl Point {
+    /// On the plane everything is laid out on.
+    pub const fn flat(x: Length, y: Length) -> Self {
+        Self {
+            x,
+            y,
+            z: Length::NONE,
+        }
+    }
+}
+
+/// Four corners, in the order a rectangle's are read: top-left, top-right,
+/// bottom-right, bottom-left.
+///
+/// What a [`Rectangle`] becomes once it has been through a transform, because
+/// almost nothing survives one as a rectangle - a turn alone leaves a
+/// parallelogram, and a perspective leaves a trapezium. Surfaces that can only
+/// draw rectangles never see one of these.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct Quad {
+    pub corners: [Point; 4],
+}
+
+impl Quad {
+    /// The corners of a rectangle, untransformed.
+    pub fn of(area: Rectangle) -> Self {
+        let (left, top) = (area.left(), area.top());
+        let (right, bottom) = (area.right(), area.bottom());
+        Self {
+            corners: [
+                Point::flat(left, top),
+                Point::flat(right, top),
+                Point::flat(right, bottom),
+                Point::flat(left, bottom),
+            ],
+        }
+    }
+}
+
+/// Where a shape goes: a 4x4 of `f32`, row-major, applied as `M * p`.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct Transform {
+    rows: [[f32; 4]; 4],
+}
+
+impl Default for Transform {
+    fn default() -> Self {
+        Self::IDENTITY
+    }
+}
+
+impl Transform {
+    /// Leaves everything where the layout put it.
+    pub const IDENTITY: Self = Self {
+        rows: [
+            [1.0, 0.0, 0.0, 0.0],
+            [0.0, 1.0, 0.0, 0.0],
+            [0.0, 0.0, 1.0, 0.0],
+            [0.0, 0.0, 0.0, 1.0],
+        ],
+    };
+
+    /// Build one from its entries, row by row.
+    pub const fn from_rows(rows: [[f32; 4]; 4]) -> Self {
+        Self { rows }
+    }
+
+    pub const fn rows(&self) -> &[[f32; 4]; 4] {
+        &self.rows
+    }
+
+    /// Whether this would move anything at all.
+    ///
+    /// Exactly, not nearly: the question a surface asks is "did anyone set one
+    /// of these", so that it can take the path it has always taken and produce
+    /// the picture it has always produced. A tolerance here would mean a nearly
+    /// flat skin silently drawing as a flat one.
+    pub fn is_identity(&self) -> bool {
+        *self == Self::IDENTITY
+    }
+
+    /// Shift by a distance on each axis.
+    pub const fn moving(x: f32, y: f32, z: f32) -> Self {
+        Self::from_rows([
+            [1.0, 0.0, 0.0, x],
+            [0.0, 1.0, 0.0, y],
+            [0.0, 0.0, 1.0, z],
+            [0.0, 0.0, 0.0, 1.0],
+        ])
+    }
+
+    /// Stretch about the origin.
+    pub const fn scaling(x: f32, y: f32, z: f32) -> Self {
+        Self::from_rows([
+            [x, 0.0, 0.0, 0.0],
+            [0.0, y, 0.0, 0.0],
+            [0.0, 0.0, z, 0.0],
+            [0.0, 0.0, 0.0, 1.0],
+        ])
+    }
+
+    /// Turn about the vertical, so the field swings to face away.
+    ///
+    /// A panel bolted flat to a speaker grille, seen from off to one side.
+    pub fn turning(radians: f32) -> Self {
+        let (s, c) = (sin(radians), cos(radians));
+        Self::from_rows([
+            [c, 0.0, s, 0.0],
+            [0.0, 1.0, 0.0, 0.0],
+            [-s, 0.0, c, 0.0],
+            [0.0, 0.0, 0.0, 1.0],
+        ])
+    }
+
+    /// Tip about the horizontal, so the far edge falls away.
+    ///
+    /// A dashboard raked back from the driver.
+    pub fn leaning(radians: f32) -> Self {
+        let (s, c) = (sin(radians), cos(radians));
+        Self::from_rows([
+            [1.0, 0.0, 0.0, 0.0],
+            [0.0, c, -s, 0.0],
+            [0.0, s, c, 0.0],
+            [0.0, 0.0, 0.0, 1.0],
+        ])
+    }
+
+    /// Spin in the plane of the screen.
+    pub fn rolling(radians: f32) -> Self {
+        let (s, c) = (sin(radians), cos(radians));
+        Self::from_rows([
+            [c, -s, 0.0, 0.0],
+            [s, c, 0.0, 0.0],
+            [0.0, 0.0, 1.0, 0.0],
+            [0.0, 0.0, 0.0, 1.0],
+        ])
+    }
+
+    /// Make depth read as depth: the farther off, the smaller.
+    ///
+    /// `eye` is how far in front of the plane the viewer stands, in the same
+    /// unit everything else is in. Large values approach a flat drawing; small
+    /// ones exaggerate. Zero or less is refused, because an eye on the plane it
+    /// is looking at has nothing to look at - it comes back as
+    /// [`IDENTITY`](Self::IDENTITY), so a skin with a nonsense number draws flat
+    /// rather than draws nothing.
+    ///
+    /// Shrinking is toward the origin, so a scene wanting it toward the middle
+    /// of the picture composes a move there and back - which is what a stack is
+    /// for, and is not assumed here because only the caller knows where the
+    /// middle of its picture is.
+    pub fn receding(eye: f32) -> Self {
+        // NaN spelled out rather than left to `!(eye > 0.0)`: it is the case a
+        // skin file reaches by arithmetic rather than by typing, and the
+        // negated comparison that catches it reads like a mistake.
+        if eye.is_nan() || eye <= 0.0 {
+            return Self::IDENTITY;
+        }
+        Self::from_rows([
+            [1.0, 0.0, 0.0, 0.0],
+            [0.0, 1.0, 0.0, 0.0],
+            [0.0, 0.0, 1.0, 0.0],
+            [0.0, 0.0, 1.0 / eye, 1.0],
+        ])
+    }
+
+    /// This one, and then the other.
+    ///
+    /// Reads in the order things happen - `turning(a).then(receding(d))` turns
+    /// the field and then looks at it from a distance - which is the opposite
+    /// order to how the multiplication is written, and the reason this exists
+    /// rather than an operator.
+    pub fn then(self, next: Self) -> Self {
+        let mut rows = [[0.0f32; 4]; 4];
+        for (r, row) in rows.iter_mut().enumerate() {
+            for (c, cell) in row.iter_mut().enumerate() {
+                *cell = (0..4).map(|k| next.rows[r][k] * self.rows[k][c]).sum();
+            }
+        }
+        Self { rows }
+    }
+
+    /// Where a point ends up.
+    ///
+    /// `None` when the perspective divide has nothing to say: a point level
+    /// with the eye or behind it has no place on the picture, and inventing one
+    /// puts a bar in the reflection of where it should be. A caller that gets
+    /// `None` should draw nothing rather than draw something wrong.
+    pub fn apply(&self, point: Point) -> Option<Point> {
+        let p = [point.x.get(), point.y.get(), point.z.get(), 1.0];
+        let out = |row: usize| (0..4).map(|k| self.rows[row][k] * p[k]).sum::<f32>();
+        let (x, y, z, w) = (out(0), out(1), out(2), out(3));
+        if !w.is_finite() || w <= 0.0 {
+            return None;
+        }
+        let point = Point {
+            x: Length(x / w),
+            y: Length(y / w),
+            z: Length(z / w),
+        };
+        point
+            .x
+            .get()
+            .is_finite()
+            .then_some(point)
+            .filter(|p| p.y.get().is_finite() && p.z.get().is_finite())
+    }
+
+    /// Where a laid-out rectangle ends up.
+    ///
+    /// `None` if any corner does, because three corners of a bar is not a bar.
+    pub fn quad(&self, area: Rectangle) -> Option<Quad> {
+        let mut corners = [Point::default(); 4];
+        for (out, corner) in corners.iter_mut().zip(Quad::of(area).corners) {
+            *out = self.apply(corner)?;
+        }
+        Some(Quad { corners })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const CLOSE: f32 = 1e-4;
+
+    fn near(a: Length, b: f32) -> bool {
+        (a.get() - b).abs() < CLOSE
+    }
+
+    fn area() -> Rectangle {
+        Rectangle::new(Length(10.0), Length(20.0), Length(30.0), Length(40.0))
+    }
+
+    #[test]
+    fn identity_is_the_only_thing_a_surface_has_to_recognise() {
+        // A surface takes the path it has always taken when nothing set a
+        // transform, which is what keeps today's picture exactly today's
+        // picture. Exact, so a nearly-flat skin cannot be mistaken for a flat
+        // one and silently lose its lean.
+        assert!(Transform::IDENTITY.is_identity());
+        assert!(Transform::default().is_identity());
+        assert!(!Transform::moving(0.0, 0.001, 0.0).is_identity());
+        assert!(!Transform::rolling(0.001).is_identity());
+    }
+
+    #[test]
+    fn a_point_comes_back_where_it_started_through_identity() {
+        let there = Transform::IDENTITY
+            .apply(Point::flat(Length(3.0), Length(4.0)))
+            .unwrap();
+        assert_eq!(there, Point::flat(Length(3.0), Length(4.0)));
+    }
+
+    #[test]
+    fn then_reads_in_the_order_things_happen() {
+        // The reason this is a method and not an operator: the multiplication
+        // is written the other way round, and a skin author thinks in the order
+        // the moves are made.
+        let moved_then_doubled =
+            Transform::moving(1.0, 0.0, 0.0).then(Transform::scaling(2.0, 2.0, 2.0));
+        let there = moved_then_doubled
+            .apply(Point::flat(Length::NONE, Length::NONE))
+            .unwrap();
+        assert!(near(there.x, 2.0), "moved by one, then doubled: {there:?}");
+
+        let doubled_then_moved =
+            Transform::scaling(2.0, 2.0, 2.0).then(Transform::moving(1.0, 0.0, 0.0));
+        let there = doubled_then_moved
+            .apply(Point::flat(Length::NONE, Length::NONE))
+            .unwrap();
+        assert!(near(there.x, 1.0), "doubled, then moved by one: {there:?}");
+    }
+
+    #[test]
+    fn a_roll_turns_the_picture_in_its_own_plane() {
+        // Screen sense: `y` is down, so a quarter turn takes the point on the
+        // positive `x` axis to the one below the origin, not above it. A sign
+        // error here leans every skin the wrong way and looks deliberate.
+        let there = Transform::rolling(core::f32::consts::FRAC_PI_2)
+            .apply(Point::flat(Length(1.0), Length::NONE))
+            .unwrap();
+        assert!(near(there.x, 0.0) && near(there.y, 1.0), "{there:?}");
+    }
+
+    #[test]
+    fn receding_makes_the_far_edge_smaller_and_the_near_one_alone() {
+        // What "depth" has to come to on a flat surface. The plane everything
+        // is laid out on is untouched, so a scene that sets a perspective and
+        // leaves every bar at zero depth draws exactly what it drew before.
+        let eye = Transform::receding(100.0);
+        let near_edge = eye.apply(Point::flat(Length(50.0), Length(50.0))).unwrap();
+        assert!(near(near_edge.x, 50.0) && near(near_edge.y, 50.0));
+
+        let far = eye
+            .apply(Point {
+                x: Length(50.0),
+                y: Length(50.0),
+                z: Length(100.0),
+            })
+            .unwrap();
+        assert!(near(far.x, 25.0) && near(far.y, 25.0), "{far:?}");
+    }
+
+    #[test]
+    fn an_eye_on_the_plane_it_looks_at_draws_flat_rather_than_nothing() {
+        // A skin carrying a nonsense number is a picture in the wrong shape,
+        // not a reason to have no picture. Division by zero is the alternative.
+        assert!(Transform::receding(0.0).is_identity());
+        assert!(Transform::receding(-1.0).is_identity());
+        assert!(Transform::receding(f32::NAN).is_identity());
+    }
+
+    #[test]
+    fn a_point_at_or_behind_the_eye_has_no_place_on_the_picture() {
+        // Inventing one puts the bar in the reflection of where it belongs,
+        // which reads as a glitch rather than as depth.
+        let eye = Transform::receding(10.0);
+        let behind = Point {
+            x: Length(1.0),
+            y: Length(1.0),
+            z: Length(-10.0),
+        };
+        assert!(eye.apply(behind).is_none());
+        assert!(
+            eye.quad(Rectangle::new(
+                Length(1.0),
+                Length(1.0),
+                Length(1.0),
+                Length(1.0)
+            ))
+            .is_some(),
+            "a bar on the plane is always drawable",
+        );
+    }
+
+    #[test]
+    fn a_rectangle_keeps_its_corner_order_through_a_transform() {
+        // Top-left, top-right, bottom-right, bottom-left - the order a
+        // rasteriser walks to close a path. Scrambling it draws a bow tie.
+        let plain = Quad::of(area());
+        assert_eq!(plain.corners[0], Point::flat(Length(10.0), Length(20.0)));
+        assert_eq!(plain.corners[1], Point::flat(Length(40.0), Length(20.0)));
+        assert_eq!(plain.corners[2], Point::flat(Length(40.0), Length(60.0)));
+        assert_eq!(plain.corners[3], Point::flat(Length(10.0), Length(60.0)));
+
+        let same = Transform::IDENTITY.quad(area()).unwrap();
+        assert_eq!(same, plain, "identity moved a corner");
+    }
+
+    #[test]
+    fn a_turn_leaves_a_shape_no_rectangle_can_hold() {
+        // The reason a transformed rectangle is a `Quad` and not a `Rectangle`:
+        // once the field turns, the two vertical edges are at different depths
+        // and a perspective makes them different lengths. There is no
+        // axis-aligned box that is this shape.
+        let turned = Transform::turning(0.6).then(Transform::receding(200.0));
+        let quad = turned.quad(area()).unwrap();
+        let left_edge = (quad.corners[3].y - quad.corners[0].y).get();
+        let right_edge = (quad.corners[2].y - quad.corners[1].y).get();
+        assert!(
+            (left_edge - right_edge).abs() > 1.0,
+            "the two sides came out the same length: {left_edge} and {right_edge}",
+        );
+    }
+}

--- a/src/render/raster.rs
+++ b/src/render/raster.rs
@@ -7,8 +7,9 @@
 
 use crate::render::{Colour, Ramp, Scene};
 use rav_core::geometry::{Rectangle, Screen};
+use rav_core::transform::Transform;
 use rav_core::units::Length;
-use tiny_skia::{Paint, Pixmap, Rect as SkRect, Transform};
+use tiny_skia::{Paint, PathBuilder, Pixmap, Rect as SkRect, Transform as SkTransform};
 
 /// An RGBA buffer that geometry is drawn into.
 ///
@@ -18,13 +19,32 @@ use tiny_skia::{Paint, Pixmap, Rect as SkRect, Transform};
 /// no reason to suspect it.
 pub struct Canvas {
     pixmap: Pixmap,
+    placing: Transform,
 }
 
 impl Canvas {
     /// `None` for a zero dimension, which is a terminal mid-resize rather than a
     /// programming error, and is the caller's to skip.
     pub fn new(width: u32, height: u32) -> Option<Self> {
-        Pixmap::new(width, height).map(|pixmap| Self { pixmap })
+        Pixmap::new(width, height).map(|pixmap| Self {
+            pixmap,
+            placing: Transform::IDENTITY,
+        })
+    }
+
+    /// Draw everything from here on through a transform - leaning, turning or
+    /// receding, per its own documentation.
+    ///
+    /// Set on the canvas rather than passed to each fill because it is a
+    /// property of how the picture is being looked at, not of one bar. A scene
+    /// that never calls this is drawn exactly as it was before transforms
+    /// existed, down to the byte - see [`Self::fill`].
+    pub fn place_through(&mut self, placing: Transform) {
+        self.placing = placing;
+    }
+
+    pub fn placing(&self) -> Transform {
+        self.placing
     }
 
     /// Sized to hold a screen exactly.
@@ -50,25 +70,68 @@ impl Canvas {
     ///
     /// An empty rectangle is skipped rather than refused: a bar at rest is one,
     /// and every frame of silence would otherwise be an error to handle.
+    ///
+    /// A canvas with no transform takes the rectangle straight to `fill_rect`,
+    /// which is not a shortcut but the point: measured, the same rectangle sent
+    /// as a four-point path differs in 62 bytes of 38,400, by up to 2 of 255,
+    /// along the antialiased edges. Small, and still a changed picture. Keeping
+    /// the untransformed path untouched means today's frame is today's frame by
+    /// construction rather than within a tolerance somebody chose.
     pub fn fill(&mut self, area: Rectangle, colour: Colour) {
-        // The one place a distance stops being a `Length` and becomes the number
-        // tiny-skia takes, so the unit cannot be lost anywhere above here.
-        let Some(rect) = SkRect::from_xywh(
-            area.left().get(),
-            area.top().get(),
-            area.width().get(),
-            area.height().get(),
-        ) else {
-            return;
-        };
         let mut paint = Paint::default();
         paint.set_color_rgba8(colour.red, colour.green, colour.blue, colour.alpha);
         // Antialiasing on, which is the whole argument for drawing pixels: a bar
         // edge lands where the arithmetic puts it instead of being snapped to a
         // boundary, and that snapping is the mechanism behind #63.
         paint.anti_alias = true;
-        self.pixmap
-            .fill_rect(rect, &paint, Transform::identity(), None);
+
+        if self.placing.is_identity() {
+            // The one place a distance stops being a `Length` and becomes the
+            // number tiny-skia takes, so the unit cannot be lost above here.
+            let Some(rect) = SkRect::from_xywh(
+                area.left().get(),
+                area.top().get(),
+                area.width().get(),
+                area.height().get(),
+            ) else {
+                return;
+            };
+            self.pixmap
+                .fill_rect(rect, &paint, SkTransform::identity(), None);
+            return;
+        }
+
+        if area.is_empty() {
+            return;
+        }
+        // A corner with no place on the picture takes the whole shape with it:
+        // three corners of a bar is not a bar, and half of one is worse than
+        // none.
+        let Some(quad) = self.placing.quad(area) else {
+            return;
+        };
+        let mut path = PathBuilder::new();
+        for (at, corner) in quad.corners.iter().enumerate() {
+            let (x, y) = (corner.x.get(), corner.y.get());
+            if at == 0 {
+                path.move_to(x, y);
+            } else {
+                path.line_to(x, y);
+            }
+        }
+        path.close();
+        // `finish` refuses a path with no area, which a bar edge-on to the
+        // viewer is - and a scene turned a quarter turn has every bar that way.
+        let Some(path) = path.finish() else {
+            return;
+        };
+        self.pixmap.fill_path(
+            &path,
+            &paint,
+            tiny_skia::FillRule::Winding,
+            SkTransform::identity(),
+            None,
+        );
     }
 
     /// Paint one rectangle in whatever colour the ramp gives at each height.
@@ -293,6 +356,117 @@ mod tests {
             screen: screen(10.0, 60.0),
             styles,
         }
+    }
+
+    /// A bar in the middle of a small canvas, for the transform tests.
+    fn a_bar() -> Rectangle {
+        Rectangle::new(Length(20.0), Length(20.0), Length(40.0), Length(60.0))
+    }
+
+    #[test]
+    fn a_canvas_nobody_transformed_draws_what_it_always_drew() {
+        // The whole of what makes this safe to add. `fill_rect` and a four-point
+        // path are not the same pixels - measured at 62 bytes of 38,400,
+        // differing by up to 2 of 255 along the antialiased edges - so the
+        // untransformed picture keeps the code path it has always had rather
+        // than a tolerance. Every other test in this file is the rest of the
+        // guard: they all draw through `fill` and none of them moved.
+        let screen = screen(120.0, 100.0);
+        let mut untouched = Canvas::for_screen(&screen).unwrap();
+        untouched.fill(a_bar(), Colour::GREEN);
+
+        let mut told_to_do_nothing = Canvas::for_screen(&screen).unwrap();
+        told_to_do_nothing.place_through(Transform::IDENTITY);
+        told_to_do_nothing.fill(a_bar(), Colour::GREEN);
+
+        assert!(untouched.placing().is_identity());
+        assert_eq!(
+            untouched.to_rgba(),
+            told_to_do_nothing.to_rgba(),
+            "setting the transform that means nothing changed the picture",
+        );
+    }
+
+    #[test]
+    fn a_transform_moves_the_picture_and_not_the_layout() {
+        // The bar is laid out in the same place either way - what changed is
+        // where the canvas puts it. A skin leans; the analyser does not learn
+        // about leaning.
+        let screen = screen(120.0, 100.0);
+        let mut flat = Canvas::for_screen(&screen).unwrap();
+        flat.fill(a_bar(), Colour::GREEN);
+
+        let mut shifted = Canvas::for_screen(&screen).unwrap();
+        shifted.place_through(Transform::moving(30.0, 0.0, 0.0));
+        shifted.fill(a_bar(), Colour::GREEN);
+
+        assert_eq!(at(&flat, 30, 50).green, 255, "the bar was not where it was");
+        assert_eq!(
+            at(&flat, 70, 50).alpha,
+            0,
+            "something is already over there"
+        );
+        assert_eq!(at(&shifted, 70, 50).green, 255, "it did not move");
+        assert_eq!(at(&shifted, 30, 50).alpha, 0, "it is in both places");
+    }
+
+    #[test]
+    fn a_receding_bar_is_smaller_at_the_far_end() {
+        // Depth reading as depth, which is the point of the exercise: the same
+        // rectangle, pushed back, covers less of the picture. Compared by ink
+        // rather than by an edge, because an edge under perspective is
+        // antialiased across a pixel and its exact position is a choice the
+        // rasteriser makes.
+        let screen = screen(120.0, 100.0);
+        let ink = |placing: Transform| {
+            let mut canvas = Canvas::for_screen(&screen).unwrap();
+            canvas.place_through(placing);
+            canvas.fill(a_bar(), Colour::GREEN);
+            canvas
+                .to_rgba()
+                .chunks(4)
+                .map(|pixel| u32::from(pixel[3]))
+                .sum::<u32>()
+        };
+
+        let near = ink(Transform::receding(400.0));
+        let far = ink(Transform::moving(0.0, 0.0, 200.0).then(Transform::receding(400.0)));
+        assert!(
+            far * 2 < near,
+            "pushed back twice as far as the eye is near, and it covered {far} against {near}",
+        );
+        assert!(far > 0, "it receded out of existence");
+    }
+
+    #[test]
+    fn a_bar_turned_edge_on_draws_nothing_rather_than_a_seam() {
+        // A quarter turn puts every bar side-on. `PathBuilder::finish` refuses a
+        // path with no area, and taking that as "nothing to draw" is the
+        // difference between a scene that fades out and one that leaves a line
+        // of stray pixels down the screen.
+        let screen = screen(120.0, 100.0);
+        let mut canvas = Canvas::for_screen(&screen).unwrap();
+        canvas.place_through(Transform::turning(core::f32::consts::FRAC_PI_2));
+        canvas.fill(a_bar(), Colour::GREEN);
+        assert!(
+            canvas.to_rgba().chunks(4).all(|pixel| pixel[3] == 0),
+            "an edge-on bar left ink behind",
+        );
+    }
+
+    #[test]
+    fn a_bar_behind_the_viewer_draws_nothing() {
+        // Not a contrived case once a scene turns: half a turned field is behind
+        // the eye. Projecting it anyway puts the bar in the reflection of where
+        // it belongs, which reads as a glitch rather than as depth.
+        let screen = screen(120.0, 100.0);
+        let mut canvas = Canvas::for_screen(&screen).unwrap();
+        canvas.place_through(Transform::moving(0.0, 0.0, -200.0).then(Transform::receding(100.0)));
+        canvas.fill(a_bar(), Colour::GREEN);
+        assert!(
+            canvas.to_rgba().chunks(4).all(|pixel| pixel[3] == 0),
+            "a bar behind the eye was drawn somewhere",
+        );
     }
 
     #[test]


### PR DESCRIPTION
The first slice of #68, and the answer to a question I put badly a few messages ago. I asked whether skins should become SVG artwork; #68 already said the direction is depth and a transform stack, which keeps the property SVG would have cost — one description of a shape that a terminal, a pixel frame and a strip of LEDs all read the same way. It also said "worth doing when the pixel surface has settled", and it has: shipped in beta.9, two defects found and fixed since, and a pty test now running on every PR.

**`Transform` is a 4×4 of `f32`** in `rav-core`. Sixteen floats, no allocator: composing two is 64 multiplies and applying one to a bar’s four corners is 64 more, which an ESP32 can afford per frame and a tensor library could not. `moving`, `scaling`, `turning`, `leaning`, `rolling`, `receding`, composed with `then` — which reads in the order the moves are made, the opposite of how the multiplication is written, and the reason it is a method rather than an operator.

**A rectangle through one comes back as a `Quad`.** Almost nothing survives a transform as a rectangle: a turn leaves a parallelogram, a perspective leaves a trapezium. A corner with no place on the picture — a point level with the eye or behind it — takes the whole shape with it, because three corners of a bar is not a bar, and projecting it anyway puts the bar in the reflection of where it belongs.

**The untransformed picture keeps the code path it has always had, and that is the point of the PR rather than an optimisation.** I measured it before designing around it: the same rectangle sent as a four-point path differs from `fill_rect` in **62 bytes of 38,400, by up to 2 of 255**, along the antialiased edges. Small, and still a changed picture — and "within two" is a tolerance somebody chose. So `Canvas::fill` branches on `is_identity()`, exactly, and today’s frame is today’s frame by construction. The other 250-odd pixel tests are the rest of that guard: they all draw through `fill` and not one moved.

What the new tests hold:

- identity is recognised exactly, so a nearly-flat skin cannot silently lose its lean
- `then` reads in the order things happen — moved-then-doubled lands somewhere different from doubled-then-moved
- a roll turns the right way for screen axes, where `y` is down; a sign error here leans every skin the wrong way and looks deliberate
- receding leaves the plane everything is laid out on untouched and shrinks what is behind it
- an eye on the plane it is looking at draws flat rather than dividing by zero
- a bar turned edge-on draws nothing rather than a seam of stray pixels
- a bar behind the viewer draws nothing
- setting `Transform::IDENTITY` explicitly gives byte-identical pixels to never setting one

**Nothing sets a transform yet**, deliberately — this is the arithmetic, and a skin that leans is the next slice, where it becomes visible and worth your eye. The glyph renderer goes on ignoring all of it, because a cell grid has no room for a bar that leans.

406 tests, clippy clean, `devenv test` green.