### PR TITLE
feat: `v` bolts the analyser at an angle

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ Everything else is a keypress, and `h` shows the lot with their current values:
 | `Space` / `Tab` / `o` | switch analyser ↔ oscilloscope |
 | `t` | theme — rav, winamp, terminal, mono |
 | `b` | bar style — blocks, solid, thick, half, line, shade |
+| `v` | viewing angle — flat, raked, turned; pixels only |
 | `p` | peak caps — fine, coarse, off |
 | `g` | grid behind the bars, on/off |
 | `w` | bandwidth: wide (grouped) or thin |

--- a/crates/rav-appearance/src/lib.rs
+++ b/crates/rav-appearance/src/lib.rs
@@ -55,6 +55,6 @@ pub use ink::{ANSI_NAMES, Colour, DEFAULT_ANSI, Ink};
 pub use palette::Palette;
 pub use preset::Preset;
 pub use ramp::{Ramp, Stripe};
-pub use scene::{Band, CapStyle, Scene, Style, StyleId};
+pub use scene::{Band, CapStyle, Scene, Style, StyleId, View};
 pub use skin::{Rung, Shapes, Skin, ladders};
 pub use theme::{SCOPE_LEVELS, STOPS, StaticTheme, Theme};

--- a/crates/rav-appearance/src/scene.rs
+++ b/crates/rav-appearance/src/scene.rs
@@ -20,6 +20,7 @@ use crate::ink::Colour;
 use crate::ramp::Ramp;
 use crate::skin::Skin;
 use rav_core::geometry::{BarLayout, Screen};
+use rav_core::transform::Transform;
 use rav_core::units::{Length, Level};
 
 /// Which of a scene's styles a band wears.
@@ -71,6 +72,100 @@ impl Band {
     }
 }
 
+/// Where the viewer is standing.
+///
+/// A whole-field property, not a per-bar one: the analyser is a panel, and this
+/// is the angle it is bolted at. Named rather than handed over as a matrix so
+/// that a surface cannot get the centring wrong - a perspective shrinks toward
+/// the origin, and the middle of the picture is the only sensible place for it
+/// to shrink toward, which only the scene knows.
+///
+/// A surface that cannot honour one draws [`Flat`](Self::Flat) and is right to:
+/// a cell grid has no room for a bar that leans, and half a lean is worse than
+/// none.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum View {
+    /// Straight on, which is what every surface has always drawn.
+    #[default]
+    Flat,
+    /// Tipped back, so the top of the field falls away - a dashboard raked
+    /// back from the driver.
+    Raked,
+    /// Turned to one side - a panel on a speaker grille, seen from off-axis.
+    Turned,
+}
+
+impl View {
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Flat => "flat",
+            Self::Raked => "raked",
+            Self::Turned => "turned",
+        }
+    }
+
+    pub fn next(self) -> Self {
+        match self {
+            Self::Flat => Self::Raked,
+            Self::Raked => Self::Turned,
+            Self::Turned => Self::Flat,
+        }
+    }
+
+    /// The transform this comes to on a screen of a given size.
+    ///
+    /// Turn about the middle, then look at it from in front of the middle:
+    /// `move to the origin, rotate, recede, move back`. The move back survives
+    /// the perspective divide because it multiplies the `w` the projection just
+    /// set, which is what puts the picture in the middle of the screen rather
+    /// than in the middle of a screen that has itself been shrunk.
+    ///
+    /// The eye stands well back - three times the size of the field - so the
+    /// nearest corner never reaches it. A rake steep enough to swing a corner
+    /// behind the viewer would draw nothing at all, which reads as a fault
+    /// rather than as an angle.
+    ///
+    /// **And then it is scaled to fit.** An angle changes the shape of the
+    /// field, never how much of the screen it takes: a perspective magnifies
+    /// whatever it brings nearer, so a raked field spills off three edges and
+    /// the bars run out of the bottom of the picture. That is a rule rather
+    /// than a number chosen by looking - the fit is computed from the corners
+    /// the rotation actually produced, so the angles can be whatever reads best
+    /// and none of them can push the picture off the screen.
+    pub fn placing(self, screen: &Screen) -> Transform {
+        let (across, down) = (screen.width().get(), screen.height().get());
+        let (middle_x, middle_y) = (across / 2.0, down / 2.0);
+        let (turn, eye) = match self {
+            Self::Flat => return Transform::IDENTITY,
+            Self::Raked => (Transform::leaning(0.35), down * 3.0),
+            Self::Turned => (Transform::turning(0.44), across * 3.0),
+        };
+        let centred = |about: Transform| {
+            Transform::moving(-middle_x, -middle_y, 0.0)
+                .then(about)
+                .then(Transform::moving(middle_x, middle_y, 0.0))
+        };
+        let angled = Transform::moving(-middle_x, -middle_y, 0.0)
+            .then(turn)
+            .then(Transform::receding(eye))
+            .then(Transform::moving(middle_x, middle_y, 0.0));
+
+        let Some(field) = angled.quad(screen.bounds()) else {
+            return angled;
+        };
+        let (mut wide, mut tall) = (0.0f32, 0.0f32);
+        for corner in field.corners {
+            wide = wide.max((corner.x.get() - middle_x).abs() * 2.0);
+            tall = tall.max((corner.y.get() - middle_y).abs() * 2.0);
+        }
+        let fits = (across / wide).min(down / tall);
+        if !fits.is_finite() || fits >= 1.0 {
+            return angled;
+        }
+        angled.then(centred(Transform::scaling(fits, fits, 1.0)))
+    }
+}
+
 /// Everything a surface needs to draw one frame.
 ///
 /// Borrowed throughout, and built fresh each frame rather than kept: a scene is
@@ -81,6 +176,9 @@ pub struct Scene<'a> {
     pub bands: &'a [Band],
     pub layout: BarLayout,
     pub screen: Screen,
+    /// The angle the whole field is bolted at. `Flat` is what every surface
+    /// has always drawn, and what one that cannot lean draws regardless.
+    pub view: View,
     /// The looks a band may wear, indexed by its [`StyleId`].
     ///
     /// Usually one. Two for a stereo pair, one per band for a rainbow. A scene
@@ -156,7 +254,90 @@ mod tests {
             bands,
             layout: BarLayout::new(Length(8.0), Length(2.0)),
             screen: Screen::new(Length(across), Length(100.0)),
+            view: View::Flat,
             styles,
+        }
+    }
+
+    #[test]
+    fn flat_is_the_view_that_asks_for_nothing() {
+        // Every surface has always drawn this, and one that cannot lean draws it
+        // regardless - so it has to come out as the transform that means "leave
+        // it alone", exactly, or the pixel surface stops taking the path it has
+        // taken since before transforms existed.
+        let screen = Screen::new(Length(240.0), Length(120.0));
+        assert!(View::default() == View::Flat);
+        assert!(View::Flat.placing(&screen).is_identity());
+        assert!(!View::Raked.placing(&screen).is_identity());
+        assert!(!View::Turned.placing(&screen).is_identity());
+    }
+
+    #[test]
+    fn the_middle_of_the_picture_stays_where_it_is() {
+        // A perspective shrinks toward the origin, and the origin is the top-left
+        // corner. Without turning about the middle and coming back, every angle
+        // would also slide the whole field up and to the left - which reads as a
+        // bug rather than as a viewing angle, and is why this is named rather
+        // than handed to a surface as a matrix to centre for itself.
+        let screen = Screen::new(Length(240.0), Length(120.0));
+        let middle = rav_core::transform::Point::flat(Length(120.0), Length(60.0));
+        for view in [View::Raked, View::Turned] {
+            let stays = view.placing(&screen).apply(middle).unwrap();
+            assert!(
+                (stays.x.get() - 120.0).abs() < 0.01 && (stays.y.get() - 60.0).abs() < 0.01,
+                "{} moved the middle to {stays:?}",
+                view.label(),
+            );
+        }
+    }
+
+    #[test]
+    fn every_angle_keeps_the_whole_field_in_front_of_the_viewer() {
+        // A corner swung behind the eye draws nothing, which reads as a fault
+        // rather than as an angle - so the eye stands well back and every corner
+        // of every offered view has somewhere to land.
+        let screen = Screen::new(Length(240.0), Length(120.0));
+        let field = screen.bounds();
+        for view in [View::Flat, View::Raked, View::Turned] {
+            assert!(
+                view.placing(&screen).quad(field).is_some(),
+                "{} put a corner where it cannot be drawn",
+                view.label(),
+            );
+        }
+    }
+
+    #[test]
+    fn an_angle_changes_the_shape_of_the_field_not_how_much_screen_it_takes() {
+        // A perspective magnifies whatever it brings nearer, so a rake with
+        // nothing holding it fans the near edge out past three sides and the
+        // bars run off the bottom of the picture - which was measured by
+        // rendering one and looking at it. The fit is computed from the corners
+        // the rotation produced rather than chosen by eye, so the angles can be
+        // whatever reads best and none of them can spill.
+        let screen = Screen::new(Length(480.0), Length(240.0));
+        let field = screen.bounds();
+        for view in [View::Flat, View::Raked, View::Turned] {
+            let quad = view.placing(&screen).quad(field).expect("undrawable");
+            for corner in quad.corners {
+                let (x, y) = (corner.x.get(), corner.y.get());
+                assert!(
+                    (-0.01..=480.01).contains(&x) && (-0.01..=240.01).contains(&y),
+                    "{} put a corner at ({x}, {y}), off a 480x240 screen",
+                    view.label(),
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn the_angles_cycle_back_to_flat() {
+        // Three presses and the picture is where it started, like every other
+        // cycling setting in rav.
+        let mut view = View::Flat;
+        for expected in [View::Raked, View::Turned, View::Flat] {
+            view = view.next();
+            assert_eq!(view, expected);
         }
     }
 

--- a/src/bin/kitty_spike.rs
+++ b/src/bin/kitty_spike.rs
@@ -476,6 +476,7 @@ fn paint(frame: &mut [u8], width: u32, tick: u64) {
     }];
     Scene {
         bands: &bands,
+        view: rav_appearance::View::Flat,
         layout,
         screen,
         styles: &styles,

--- a/src/render/raster.rs
+++ b/src/render/raster.rs
@@ -205,6 +205,10 @@ impl Draw for Scene<'_> {
     /// neighbour's backdrop when the two wear different styles.
     fn draw(&self, canvas: &mut Canvas) {
         canvas.clear();
+        // Before anything is drawn, because it is how the picture is looked at
+        // rather than a property of any one bar. `Flat` leaves the canvas on the
+        // path it has always taken.
+        canvas.place_through(self.view.placing(&self.screen));
 
         let drawable = self.visible_bands();
         let screen = &self.screen;
@@ -352,6 +356,7 @@ mod tests {
     fn scene<'a>(bands: &'a [Band], styles: &'a [Style<'a>]) -> Scene<'a> {
         Scene {
             bands,
+            view: rav_appearance::View::Flat,
             layout: layout(10.0, 0.0),
             screen: screen(10.0, 60.0),
             styles,

--- a/src/surface/frame.rs
+++ b/src/surface/frame.rs
@@ -11,7 +11,7 @@
 
 use crate::render::{Band, Canvas, CapStyle, Draw, Ramp, Scene, Style};
 use crate::visual::{Palette, Theme};
-use rav_appearance::Skin;
+use rav_appearance::{Skin, View};
 use rav_core::geometry::{BarLayout, Screen};
 use rav_core::units::{Length, Level};
 
@@ -35,6 +35,11 @@ pub struct Look<'a> {
     /// pixels has no rungs of its own, so without this every bar style draws the
     /// same solid bar and `b` is six labels over one picture.
     pub ladder: Option<(Skin, Length)>,
+    /// The angle the field is bolted at, which `v` cycles.
+    ///
+    /// A cell grid draws `Flat` whatever this says - there is no room in a cell
+    /// for a bar that leans - so it reaches only the pixel surface.
+    pub view: View,
 }
 
 /// Everything a frame needs, held for as long as it takes to draw.
@@ -44,6 +49,7 @@ pub struct Frame {
     grid: Option<Ramp>,
     cap: Option<CapStyle>,
     ladder: Option<(Skin, Length)>,
+    view: View,
     layout: BarLayout,
     screen: Screen,
 }
@@ -74,6 +80,7 @@ impl Frame {
                 thickness,
             }),
             ladder: look.ladder,
+            view: look.view,
             layout,
             screen,
         }
@@ -96,6 +103,7 @@ impl Frame {
             bands: &self.bands,
             layout: self.layout,
             screen: self.screen,
+            view: self.view,
             styles: &styles,
         }
         .draw(&mut canvas);
@@ -132,6 +140,7 @@ mod tests {
     fn plain() -> Look<'static> {
         Look {
             theme: Box::leak(Box::new(Theme::default())),
+            view: View::Flat,
             palette: Box::leak(Box::new(Palette::default())),
             backdrop: true,
             caps: None,
@@ -148,6 +157,7 @@ mod tests {
         let palette = Palette::default();
         let look = Look {
             theme: &theme,
+            view: View::Flat,
             palette: &palette,
             backdrop,
             caps,
@@ -156,6 +166,76 @@ mod tests {
         Frame::new(levels, peaks, &look, layout(), screen())
             .pixels()
             .expect("a screen with area")
+    }
+
+    /// The same frame at a chosen viewing angle.
+    fn angled(view: View) -> Vec<u8> {
+        let theme = Theme::default();
+        let palette = Palette::default();
+        let look = Look {
+            theme: &theme,
+            view,
+            palette: &palette,
+            backdrop: true,
+            caps: Some(Length(2.0)),
+            ladder: None,
+        };
+        Frame::new(
+            &[0.8, 0.5, 0.3],
+            &[0.9, 0.6, 0.4],
+            &look,
+            layout(),
+            screen(),
+        )
+        .pixels()
+        .expect("a screen with area")
+    }
+
+    #[test]
+    fn an_angle_changes_the_picture_and_flat_leaves_it_alone() {
+        // The whole of what `v` is for. Flat has to come out byte-identical to
+        // the frame rav has always drawn, because it takes the same path through
+        // the canvas that it always did - and the two angles have to differ from
+        // it and from each other, or the key is three labels over one picture.
+        let flat = angled(View::Flat);
+        assert_eq!(flat, frame(&[0.8, 0.5, 0.3], &[0.9, 0.6, 0.4], true));
+
+        let raked = angled(View::Raked);
+        let turned = angled(View::Turned);
+        assert_ne!(flat, raked, "raking it drew the same picture");
+        assert_ne!(flat, turned, "turning it drew the same picture");
+        assert_ne!(raked, turned, "the two angles are the same picture");
+
+        // And each still draws something: an angle that emptied the frame would
+        // pass every assertion above.
+        for (name, pixels) in [("raked", &raked), ("turned", &turned)] {
+            let ink: u64 = pixels.chunks(4).map(|pixel| u64::from(pixel[3])).sum();
+            assert!(ink > 0, "{name} drew nothing at all");
+        }
+    }
+
+    #[test]
+    fn an_angled_frame_keeps_its_ink_inside_the_screen() {
+        // A perspective that put bars past the edge would be clipped in silence
+        // by the rasteriser, so the check is that the picture is still mostly
+        // there rather than that nothing overflowed - a raked field loses a
+        // little at the top, where the far edge falls away, and that is the
+        // angle rather than a fault.
+        let flat: u64 = angled(View::Flat)
+            .chunks(4)
+            .map(|pixel| u64::from(pixel[3]))
+            .sum();
+        for view in [View::Raked, View::Turned] {
+            let ink: u64 = angled(view)
+                .chunks(4)
+                .map(|pixel| u64::from(pixel[3]))
+                .sum();
+            assert!(
+                ink * 2 > flat,
+                "{} kept only {ink} of {flat} - most of the picture went over the edge",
+                view.label(),
+            );
+        }
     }
 
     #[test]
@@ -366,6 +446,7 @@ mod tests {
         let palette = Palette::default();
         let look = Look {
             theme: &theme,
+            view: View::Flat,
             palette: &palette,
             backdrop: false,
             caps: None,
@@ -448,6 +529,7 @@ mod tests {
         let palette = Palette::default();
         let look = Look {
             theme: &theme,
+            view: View::Flat,
             palette: &palette,
             backdrop: false,
             caps: None,
@@ -488,6 +570,7 @@ mod tests {
         // Built once: nothing in the loop changes the look, only the level.
         let look = Look {
             theme: &theme,
+            view: View::Flat,
             palette: &palette,
             backdrop: false,
             caps: None,
@@ -574,6 +657,7 @@ mod against_the_glyphs {
             .collect();
         let look = Look {
             theme: &theme,
+            view: View::Flat,
             palette: &palette,
             backdrop: false,
             caps: None,

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -21,6 +21,7 @@ use crate::{
 };
 use analyzer::{Analyzer, BarLayout, BarStyle, Peaks, grid_colors, row_colors};
 use anyhow::Result;
+use rav_appearance::View;
 // The event types are named by the render loop whichever backend it is driving,
 // so only the parts that touch a real terminal are gated.
 use crossterm::event::{Event, KeyCode, KeyEventKind};
@@ -117,6 +118,7 @@ pub enum Action {
     CycleFrequencyLimit,
     ToggleHelp,
     CycleBarStyle,
+    CycleView,
     CycleTheme,
     /// Trim in whole dB steps; kept an integer so `Action` stays `Eq`.
     Gain(i8),
@@ -135,6 +137,7 @@ pub fn map_key(code: KeyCode) -> Action {
         KeyCode::Char('g') | KeyCode::Char('G') => Action::ToggleGrid,
         KeyCode::Char('w') | KeyCode::Char('W') => Action::CycleBandwidth,
         KeyCode::Char('b') | KeyCode::Char('B') => Action::CycleBarStyle,
+        KeyCode::Char('v') | KeyCode::Char('V') => Action::CycleView,
         KeyCode::Char('t') | KeyCode::Char('T') => Action::CycleTheme,
         KeyCode::Char('f') | KeyCode::Char('F') => Action::CycleBarFall,
         KeyCode::Char('r') | KeyCode::Char('R') => Action::CycleFrequencyLimit,
@@ -227,6 +230,8 @@ pub struct App {
     peaks: Peaks,
     show_grid: bool,
     bar_style: BarStyle,
+    /// The angle the field is bolted at. Pixels only - see `Action::CycleView`.
+    view: View,
     show_help: bool,
     /// Briefly shown after a settings key, so a change is visible without a
     /// permanent status bar cluttering the display.
@@ -317,6 +322,7 @@ impl App {
             // reads is a preset that cannot describe how rav opens, and two
             // answers to that question agree only until one of them moves.
             bar_style: BarStyle::from_skin(preset.skin).unwrap_or_default(),
+            view: View::default(),
             show_help: false,
             status: None,
             source: None,
@@ -494,6 +500,7 @@ impl App {
             // renderer draws at the same size - the two are meant to be the
             // same picture, and a ladder on its own pitch would not be.
             ladder: Some((self.bar_style.skin(), cell.down(Cells(1)))),
+            view: self.view,
         };
         // `coarse` and `fine` are the same cap on a cell grid - one position per
         // row is all a cell offers - so the difference has to be made here or
@@ -728,6 +735,17 @@ impl App {
                 self.bar_style = self.bar_style.next();
                 self.note(format!("bars {}", self.bar_style.label()));
             }
+            // Pixels only. A cell holds one character upright, so a glyph grid
+            // draws `Flat` whatever this says - and the note tells the truth
+            // about that, rather than reporting an angle nothing took.
+            Action::CycleView => {
+                self.view = self.view.next();
+                self.note(if self.painting {
+                    format!("view {}", self.view.label())
+                } else {
+                    format!("view {} - pixels only", self.view.label())
+                });
+            }
             Action::CycleTheme => {
                 let next = self.next_theme();
                 self.set_theme(next);
@@ -828,6 +846,11 @@ impl App {
                 key: "b",
                 description: "bar style",
                 value: Some(self.bar_style.label().to_string()),
+            },
+            HelpRow {
+                key: "v",
+                description: "viewing angle (pixels only)",
+                value: Some(self.view.label().to_string()),
             },
             HelpRow {
                 key: "g",
@@ -2267,6 +2290,53 @@ mod tests {
         assert!(
             grid.iter().all(|c| !c.is_exact()),
             "an unanswered palette must not turn names into RGB"
+        );
+    }
+
+    #[test]
+    fn v_cycles_the_viewing_angle_and_says_where_it_lands() {
+        // A key wired to a field nothing reads is a key that does nothing, so
+        // this follows it all the way to the row a user reads it off.
+        assert_eq!(map_key(KeyCode::Char('v')), Action::CycleView);
+        assert_eq!(map_key(KeyCode::Char('V')), Action::CycleView);
+
+        let mut a = app();
+        assert_eq!(a.view, View::Flat, "rav does not open at an angle");
+        for expected in ["raked", "turned", "flat"] {
+            a.apply(Action::CycleView);
+            assert_eq!(a.view.label(), expected);
+            let row = a
+                .help_rows()
+                .into_iter()
+                .find(|row| row.key == "v")
+                .expect("no viewing angle row");
+            assert_eq!(row.value.as_deref(), Some(expected));
+        }
+    }
+
+    #[test]
+    fn the_note_says_when_an_angle_will_not_be_drawn() {
+        // `v` is the one setting that does nothing on a cell grid, and a note
+        // reporting an angle the picture did not take is the defect #92 fixed
+        // for bar style and #93 then made obsolete. Here it is real: a cell
+        // holds one character upright and always will.
+        let mut a = app();
+        a.painting = false;
+        a.apply(Action::CycleView);
+        assert!(
+            a.active_status()
+                .is_some_and(|note| note.contains("pixels")),
+            "the note promised an angle the glyph renderer cannot draw: {:?}",
+            a.active_status(),
+        );
+
+        a.painting = true;
+        a.apply(Action::CycleView);
+        assert!(
+            a.active_status()
+                .is_some_and(|note| !note.contains("pixels only")),
+            "the note apologised while the pixels were drawing it: {:?}",
+            a.active_status(),
         );
     }
 


### PR DESCRIPTION
The second slice of #68, and the first thing anyone can see of it. `v` cycles **flat**, **raked** and **turned**: the panel straight on, tipped back like a dashboard raked away from a driver, or turned to one side like a panel on a speaker grille seen off-axis — the two examples #68 names.

Rendered, since the point of it is what it looks like. Sixteen bands, blocks ladder, 480×240:

| | |
|---|---|
| flat | bars straight on, exactly as before |
| raked | the top of the field falls away, the near edge nearer |
| turned | the left of the panel recedes, the right comes forward |

**A whole-field property, not a per-bar one**, and named rather than handed to a surface as a matrix. A perspective shrinks toward the origin, and the only sensible thing to shrink toward is the middle of the picture — which only the scene knows. So `View::placing(&screen)` does the centring, and a surface cannot get it wrong.

**An angle changes the shape of the field, never how much of the screen it takes.** That is the part worth reading. The first render of `raked` fanned the near edge out past three sides and ran the bars off the bottom — a perspective magnifies whatever it brings nearer, and nothing was holding it. The fix is a rule rather than a number picked by eye: the fit is computed from the corners the rotation actually produced, and scaled about the middle only when it would otherwise overflow. So the angles can be whatever reads best and none of them can spill, at any screen size. `an_angle_changes_the_shape_of_the_field_not_how_much_screen_it_takes` holds every corner of the field inside a 480×240 screen for all three.

**Flat is byte-identical to the frame rav has always drawn** — `an_angle_changes_the_picture_and_flat_leaves_it_alone` asserts that against the existing frame helper, and `View::Flat.placing()` is exactly `Transform::IDENTITY`, so the canvas takes the `fill_rect` path it has always taken.

**A cell grid draws flat whatever this says.** A cell holds one character upright and always will, so `v` is the one setting that genuinely does nothing on the glyph renderer — and the note says so out loud (`view raked - pixels only`) rather than reporting an angle the picture did not take. That is the defect #92 fixed for bar style before #93 made it obsolete; here it is real and permanent.

415 tests. Also in: the README key table, the help panel row, and `every_angle_keeps_the_whole_field_in_front_of_the_viewer` — a corner swung behind the eye draws nothing, which reads as a fault rather than as an angle, so the eye stands three field-widths back.