### PR TITLE
feat: the spectrum can stand as a corridor instead of a fence

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Everything else is a keypress, and `h` shows the lot with their current values:
 | `Space` / `Tab` / `o` | switch analyser ↔ oscilloscope |
 | `t` | theme — rav, winamp, terminal, mono |
 | `b` | bar style — blocks, solid, thick, half, line, shade |
-| `v` | viewing angle — flat, raked, turned; pixels only |
+| `v` | viewing angle — flat, raked, turned, corridor; pixels only |
 | `p` | peak caps — fine, coarse, off |
 | `g` | grid behind the bars, on/off |
 | `w` | bandwidth: wide (grouped) or thin |

--- a/crates/rav-appearance/src/scene.rs
+++ b/crates/rav-appearance/src/scene.rs
@@ -93,6 +93,13 @@ pub enum View {
     Raked,
     /// Turned to one side - a panel on a speaker grille, seen from off-axis.
     Turned,
+    /// Standing back from the bass and away toward the treble, so the spectrum
+    /// reads as a corridor rather than a fence.
+    ///
+    /// The only view where the bars are at different depths from each other
+    /// rather than the whole field being at an angle - so it is the only one
+    /// that changes what order they have to be drawn in.
+    Corridor,
 }
 
 impl View {
@@ -101,6 +108,7 @@ impl View {
             Self::Flat => "flat",
             Self::Raked => "raked",
             Self::Turned => "turned",
+            Self::Corridor => "corridor",
         }
     }
 
@@ -108,8 +116,36 @@ impl View {
         match self {
             Self::Flat => Self::Raked,
             Self::Raked => Self::Turned,
-            Self::Turned => Self::Flat,
+            Self::Turned => Self::Corridor,
+            Self::Corridor => Self::Flat,
         }
+    }
+
+    /// Whether the bands stand at different depths from one another.
+    ///
+    /// Which decides the order they are drawn in, and nothing else: near over
+    /// far is the whole of what a painter has instead of a depth buffer, and
+    /// getting it backwards puts the quiet distance on top of the loud
+    /// foreground.
+    pub fn recedes(self) -> bool {
+        matches!(self, Self::Corridor)
+    }
+
+    /// How far back the band at `index` of `bands` stands.
+    ///
+    /// Bass near, treble far, which is the way round a spectrum is already
+    /// read - and the way round that puts the bands people watch closest to
+    /// them. Zero for every view that keeps the field on one plane, so those
+    /// compose to exactly the transform they had before this existed.
+    pub fn depth(self, index: usize, bands: usize, screen: &Screen) -> f32 {
+        if !self.recedes() || bands < 2 {
+            return 0.0;
+        }
+        let along = index.min(bands - 1) as f32 / (bands - 1) as f32;
+        // Two thirds of the way to the eye at the far end: enough for the
+        // treble to read as distant, short of the vanishing point where a bar
+        // is a few pixels and its colour is the only thing left of it.
+        along * screen.width().get() * 2.0
     }
 
     /// The transform this comes to on a screen of a given size.
@@ -139,6 +175,11 @@ impl View {
             Self::Flat => return Transform::IDENTITY,
             Self::Raked => (Transform::leaning(0.35), down * 3.0),
             Self::Turned => (Transform::turning(0.44), across * 3.0),
+            // No rotation: the field stays square on and the bands travel back
+            // through it. Everything on the near plane is left exactly where it
+            // was, so the fit below finds nothing to do and the picture keeps
+            // the whole screen.
+            Self::Corridor => (Transform::IDENTITY, across * 3.0),
         };
         let centred = |about: Transform| {
             Transform::moving(-middle_x, -middle_y, 0.0)
@@ -281,7 +322,7 @@ mod tests {
         // than handed to a surface as a matrix to centre for itself.
         let screen = Screen::new(Length(240.0), Length(120.0));
         let middle = rav_core::transform::Point::flat(Length(120.0), Length(60.0));
-        for view in [View::Raked, View::Turned] {
+        for view in [View::Raked, View::Turned, View::Corridor] {
             let stays = view.placing(&screen).apply(middle).unwrap();
             assert!(
                 (stays.x.get() - 120.0).abs() < 0.01 && (stays.y.get() - 60.0).abs() < 0.01,
@@ -298,7 +339,7 @@ mod tests {
         // of every offered view has somewhere to land.
         let screen = Screen::new(Length(240.0), Length(120.0));
         let field = screen.bounds();
-        for view in [View::Flat, View::Raked, View::Turned] {
+        for view in [View::Flat, View::Raked, View::Turned, View::Corridor] {
             assert!(
                 view.placing(&screen).quad(field).is_some(),
                 "{} put a corner where it cannot be drawn",
@@ -317,7 +358,7 @@ mod tests {
         // whatever reads best and none of them can spill.
         let screen = Screen::new(Length(480.0), Length(240.0));
         let field = screen.bounds();
-        for view in [View::Flat, View::Raked, View::Turned] {
+        for view in [View::Flat, View::Raked, View::Turned, View::Corridor] {
             let quad = view.placing(&screen).quad(field).expect("undrawable");
             for corner in quad.corners {
                 let (x, y) = (corner.x.get(), corner.y.get());
@@ -335,7 +376,7 @@ mod tests {
         // Three presses and the picture is where it started, like every other
         // cycling setting in rav.
         let mut view = View::Flat;
-        for expected in [View::Raked, View::Turned, View::Flat] {
+        for expected in [View::Raked, View::Turned, View::Corridor, View::Flat] {
             view = view.next();
             assert_eq!(view, expected);
         }

--- a/src/render/raster.rs
+++ b/src/render/raster.rs
@@ -212,20 +212,6 @@ impl Draw for Scene<'_> {
         // corners, and it is the same for every band. Only the depth differs.
         let placing = self.view.placing(screen);
 
-        // Furthest first when the bands stand at different depths, because near
-        // over far is all a painter has instead of a depth buffer. Nothing else
-        // in rav has ever needed an order - a fence of bars on one plane cannot
-        // overlap - so this is where that stops being true.
-        //
-        // Counted rather than collected: a `Vec` of indices per frame is an
-        // allocation in the one loop that runs sixty times a second.
-        let order = |step: usize| {
-            if self.view.recedes() {
-                drawable - 1 - step
-            } else {
-                step
-            }
-        };
         let stand = |canvas: &mut Canvas, index: usize| {
             let depth = self.view.depth(index, drawable, screen);
             canvas.place_through(if depth == 0.0 {
@@ -234,38 +220,66 @@ impl Draw for Scene<'_> {
                 Transform::moving(0.0, 0.0, depth).then(placing)
             });
         };
-
-        for step in 0..drawable {
-            let index = order(step);
+        let backdrop = |canvas: &mut Canvas, index: usize| {
             let band = &self.bands[index];
             if let Some(grid) = self.style_of(band).and_then(|style| style.grid) {
-                stand(canvas, index);
-                let backdrop = self.layout.column(index).backdrop(screen);
-                canvas.fill_ramped(backdrop, grid, screen);
+                let area = self.layout.column(index).backdrop(screen);
+                canvas.fill_ramped(area, grid, screen);
             }
-        }
-
-        for step in 0..drawable {
-            let index = order(step);
+        };
+        let bar = |canvas: &mut Canvas, index: usize| {
             let band = &self.bands[index];
             if let Some(style) = self.style_of(band) {
-                stand(canvas, index);
-                let bar = self.layout.column(index).bar(band.level, screen);
+                let area = self.layout.column(index).bar(band.level, screen);
                 match style.ladder {
-                    Some((skin, rung)) => draw_ladder(canvas, bar, skin, rung, style.bars, screen),
-                    None => canvas.fill_ramped(bar, style.bars, screen),
+                    Some((skin, rung)) => draw_ladder(canvas, area, skin, rung, style.bars, screen),
+                    None => canvas.fill_ramped(area, style.bars, screen),
                 }
             }
-        }
-
-        for step in 0..drawable {
-            let index = order(step);
+        };
+        let cap = |canvas: &mut Canvas, index: usize| {
             let band = &self.bands[index];
             if let Some(cap) = self.style_of(band).and_then(|style| style.cap) {
-                stand(canvas, index);
                 let column = self.layout.column(index);
                 canvas.fill(column.cap(band.peak, cap.thickness, screen), cap.colour);
             }
+        };
+
+        if self.view.recedes() {
+            // A whole band at a time, furthest first. Once the bands are at
+            // different depths, near over far is the only order that means
+            // anything - and it has to hold across the three layers, not merely
+            // inside each: a far *cap* drawn in a later pass would land on top
+            // of a near *bar* drawn in an earlier one, which is a distant peak
+            // hanging in front of the loudest band in the picture.
+            //
+            // Counted rather than collected: a `Vec` of indices per frame is an
+            // allocation in the one loop that runs sixty times a second.
+            for step in 0..drawable {
+                let index = drawable - 1 - step;
+                stand(canvas, index);
+                backdrop(canvas, index);
+                bar(canvas, index);
+                cap(canvas, index);
+            }
+            return;
+        }
+
+        // On one plane nothing can overlap, so there is no depth for an order to
+        // respect and a different rule takes over: every backdrop before any
+        // bar, and every bar before any cap. That is what keeps a band's cap
+        // clear of its neighbour's backdrop when the two wear different styles.
+        for index in 0..drawable {
+            stand(canvas, index);
+            backdrop(canvas, index);
+        }
+        for index in 0..drawable {
+            stand(canvas, index);
+            bar(canvas, index);
+        }
+        for index in 0..drawable {
+            stand(canvas, index);
+            cap(canvas, index);
         }
     }
 }
@@ -641,6 +655,63 @@ mod tests {
             (0, 255, 0),
             "the far band was painted over the near one",
         );
+    }
+
+    #[test]
+    fn a_far_cap_does_not_hang_in_front_of_a_near_bar() {
+        // Ordering the bands inside each of the three layers is not enough once
+        // they are at different depths: caps are drawn after every bar, so a
+        // distant peak would land on top of the loudest band in the picture. In
+        // a corridor a whole band goes down at a time instead.
+        //
+        // The same three columns of forty as the test above, so the middle band
+        // covers 45 to 75 and the far one 72 to 96. The far band's cap rides at
+        // the top of its bar; the middle band is full height and nearer, and
+        // owns every pixel the two share.
+        let green = Ramp::new(vec![Colour::GREEN]);
+        let blue = Ramp::new(vec![Colour::BLUE]);
+        let styles = [
+            Style {
+                bars: &green,
+                grid: None,
+                cap: None,
+                ladder: None,
+            },
+            Style {
+                bars: &blue,
+                grid: None,
+                cap: Some(CapStyle {
+                    colour: Colour::WHITE,
+                    thickness: Length(8.0),
+                }),
+                ladder: None,
+            },
+        ];
+        let three = [
+            Band::new(Level::FULL, Level::FULL),
+            Band::new(Level::FULL, Level::FULL),
+            Band::new(Level::FULL, Level::FULL).styled(StyleId(1)),
+        ];
+        let screen = screen(120.0, 100.0);
+        let mut canvas = Canvas::for_screen(&screen).unwrap();
+        Scene {
+            bands: &three,
+            layout: BarLayout::new(Length(40.0), Length(0.0)),
+            screen,
+            view: rav_appearance::View::Corridor,
+            styles: &styles,
+        }
+        .draw(&mut canvas);
+
+        // Down the strip the two bands share, wherever the far cap reaches.
+        for y in 20..80 {
+            let there = at(&canvas, 73, y);
+            assert_ne!(
+                (there.red, there.green, there.blue),
+                (255, 255, 255),
+                "the far band's cap was drawn over the near band's bar, at y {y}",
+            );
+        }
     }
 
     #[test]

--- a/src/render/raster.rs
+++ b/src/render/raster.rs
@@ -205,23 +205,51 @@ impl Draw for Scene<'_> {
     /// neighbour's backdrop when the two wear different styles.
     fn draw(&self, canvas: &mut Canvas) {
         canvas.clear();
-        // Before anything is drawn, because it is how the picture is looked at
-        // rather than a property of any one bar. `Flat` leaves the canvas on the
-        // path it has always taken.
-        canvas.place_through(self.view.placing(&self.screen));
-
         let drawable = self.visible_bands();
         let screen = &self.screen;
 
-        for (index, band) in self.bands.iter().take(drawable).enumerate() {
+        // Computed once: it costs a rotation and a projection of the field's own
+        // corners, and it is the same for every band. Only the depth differs.
+        let placing = self.view.placing(screen);
+
+        // Furthest first when the bands stand at different depths, because near
+        // over far is all a painter has instead of a depth buffer. Nothing else
+        // in rav has ever needed an order - a fence of bars on one plane cannot
+        // overlap - so this is where that stops being true.
+        //
+        // Counted rather than collected: a `Vec` of indices per frame is an
+        // allocation in the one loop that runs sixty times a second.
+        let order = |step: usize| {
+            if self.view.recedes() {
+                drawable - 1 - step
+            } else {
+                step
+            }
+        };
+        let stand = |canvas: &mut Canvas, index: usize| {
+            let depth = self.view.depth(index, drawable, screen);
+            canvas.place_through(if depth == 0.0 {
+                placing
+            } else {
+                Transform::moving(0.0, 0.0, depth).then(placing)
+            });
+        };
+
+        for step in 0..drawable {
+            let index = order(step);
+            let band = &self.bands[index];
             if let Some(grid) = self.style_of(band).and_then(|style| style.grid) {
+                stand(canvas, index);
                 let backdrop = self.layout.column(index).backdrop(screen);
                 canvas.fill_ramped(backdrop, grid, screen);
             }
         }
 
-        for (index, band) in self.bands.iter().take(drawable).enumerate() {
+        for step in 0..drawable {
+            let index = order(step);
+            let band = &self.bands[index];
             if let Some(style) = self.style_of(band) {
+                stand(canvas, index);
                 let bar = self.layout.column(index).bar(band.level, screen);
                 match style.ladder {
                     Some((skin, rung)) => draw_ladder(canvas, bar, skin, rung, style.bars, screen),
@@ -230,8 +258,11 @@ impl Draw for Scene<'_> {
             }
         }
 
-        for (index, band) in self.bands.iter().take(drawable).enumerate() {
+        for step in 0..drawable {
+            let index = order(step);
+            let band = &self.bands[index];
             if let Some(cap) = self.style_of(band).and_then(|style| style.cap) {
+                stand(canvas, index);
                 let column = self.layout.column(index);
                 canvas.fill(column.cap(band.peak, cap.thickness, screen), cap.colour);
             }
@@ -550,6 +581,66 @@ mod tests {
                 );
             }
         }
+    }
+
+    #[test]
+    fn in_a_corridor_the_near_band_is_drawn_over_the_far_one() {
+        // The first thing in rav that needs a drawing order at all. A fence of
+        // bars on one plane cannot overlap, so the three passes could run in any
+        // order and did; put the bands at different depths and the far one
+        // shrinks toward the middle of the picture, straight across its
+        // neighbour. Near over far is the whole of what a painter has instead of
+        // a depth buffer, and backwards it puts the quiet distance on top of the
+        // loud foreground.
+        let near_ramp = Ramp::new(vec![Colour::GREEN]);
+        let far_ramp = Ramp::new(vec![Colour::BLUE]);
+        let styles = [
+            Style {
+                bars: &near_ramp,
+                grid: None,
+                cap: None,
+                ladder: None,
+            },
+            Style {
+                bars: &far_ramp,
+                grid: None,
+                cap: None,
+                ladder: None,
+            },
+        ];
+        // Three columns of forty on a screen of a hundred and twenty, so the
+        // middle of the picture falls inside the middle column rather than on a
+        // boundary. Two columns either side of the middle shrink toward it by
+        // different amounts and genuinely cross: worked out rather than hoped
+        // for, because the first version of this used two equal halves, where
+        // the far one's near edge lands exactly on the middle and nothing ever
+        // overlaps - it passed with the order reversed.
+        //
+        // At the eye three screens back, the middle band stands at `w = 4/3` and
+        // covers 45 to 75; the far one at `w = 5/3` covers 72 to 96. They share
+        // 72 to 75, and the middle band is the nearer of the two.
+        let three = [
+            Band::new(Level::FULL, Level::FULL),
+            Band::new(Level::FULL, Level::FULL),
+            Band::new(Level::FULL, Level::FULL).styled(StyleId(1)),
+        ];
+        let screen = screen(120.0, 100.0);
+        let scene = Scene {
+            bands: &three,
+            layout: BarLayout::new(Length(40.0), Length(0.0)),
+            screen,
+            view: rav_appearance::View::Corridor,
+            styles: &styles,
+        };
+        let mut canvas = Canvas::for_screen(&screen).unwrap();
+        scene.draw(&mut canvas);
+
+        let overlapped = at(&canvas, 73, 50);
+        assert_eq!(
+            (overlapped.red, overlapped.green, overlapped.blue),
+            (0, 255, 0),
+            "the far band was painted over the near one",
+        );
     }
 
     #[test]

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -2302,7 +2302,7 @@ mod tests {
 
         let mut a = app();
         assert_eq!(a.view, View::Flat, "rav does not open at an angle");
-        for expected in ["raked", "turned", "flat"] {
+        for expected in ["raked", "turned", "corridor", "flat"] {
             a.apply(Action::CycleView);
             assert_eq!(a.view.label(), expected);
             let row = a


### PR DESCRIPTION
#68 opens with this one, and it needed more than a viewing angle: **the bands stand at different depths from each other**, rather than the whole field being at an angle. Bass near, treble far — the way round a spectrum is already read, and the way round that puts the bands people watch closest to them. `v` cycles it in after `turned`.

Rendered at 480×240, sixteen bands: the bars shrink and converge toward the far end, the near ones full height, and the whole thing reads as a receding line rather than a row.

**It is the first thing in rav that needs a drawing order at all.** A fence of bars on one plane cannot overlap, so the three passes — backdrops, bars, caps — could run in any order and did. Give the bands depth and a far bar shrinks toward the middle of the picture straight across its neighbour. Near over far is the whole of what a painter has instead of a depth buffer, and backwards it puts the quiet distance on top of the loud foreground. The order is counted rather than collected, because a `Vec` of indices per frame is an allocation in the one loop that runs sixty times a second.

**The test for it was worth writing twice**, and the first version is the more useful thing to report. It used two equal halves of the screen — and the far one’s near edge lands *exactly* on the middle, so nothing ever overlaps. It passed with the drawing order reversed. Three columns of forty on a screen of a hundred and twenty put the middle of the picture inside a column instead of on a boundary; at an eye three screens back the middle band covers 45 to 75 and the far one 72 to 96, so they share 72 to 75 and the middle one is nearer. Sampled there, it now fails with the order reversed — blue where green should be — which is the only reason to believe it.

Everything else falls out of what is already there: `Flat`, `Raked` and `Turned` report zero depth, so they compose to exactly the transforms they had before this existed, and a corridor is a plain perspective with no rotation, so the near plane is untouched and the field keeps the whole screen.

416 tests. README key row updated; the glyph renderer goes on drawing flat, and the note still says so.