### PR TITLE
perf: an angled view holds sixty frames a second again

### DIFF
--- a/src/render/raster.rs
+++ b/src/render/raster.rs
@@ -20,6 +20,7 @@ use tiny_skia::{Paint, PathBuilder, Pixmap, Rect as SkRect, Transform as SkTrans
 pub struct Canvas {
     pixmap: Pixmap,
     placing: Transform,
+    antialias: bool,
 }
 
 impl Canvas {
@@ -29,6 +30,7 @@ impl Canvas {
         Pixmap::new(width, height).map(|pixmap| Self {
             pixmap,
             placing: Transform::IDENTITY,
+            antialias: true,
         })
     }
 
@@ -45,6 +47,10 @@ impl Canvas {
 
     pub fn placing(&self) -> Transform {
         self.placing
+    }
+
+    pub fn antialias(&mut self, on: bool) {
+        self.antialias = on;
     }
 
     /// Sized to hold a screen exactly.
@@ -78,48 +84,75 @@ impl Canvas {
     /// the untransformed path untouched means today's frame is today's frame by
     /// construction rather than within a tolerance somebody chose.
     pub fn fill(&mut self, area: Rectangle, colour: Colour) {
+        self.fill_many(&[area], colour);
+    }
+
+    /// Paint several rectangles in the same colour, in one fill.
+    ///
+    /// Worth about a fifth of an angled frame, and no more than that - the
+    /// measurement is here because the obvious reading of it is wrong. Eighty
+    /// tall quads at 2400x1440 cost **5.595 ms** filled one at a time and
+    /// **4.474 ms** batched into a single path, which looks like per-call
+    /// overhead and is not: a batched path spans the whole picture, so every
+    /// scanline still walks every quad's edges. The same eighty without
+    /// antialiasing cost **0.802 ms** and **0.709 ms**. Smoothing the edges is
+    /// what an angled view actually pays for; see [`Draw::draw`], which spends
+    /// it on the bars and not on the backdrop.
+    ///
+    /// Callers may only batch shapes that cannot occlude each other - the same
+    /// colour, or laid out on one plane - because a single fill has no order
+    /// inside it.
+    pub fn fill_many(&mut self, areas: &[Rectangle], colour: Colour) {
+        if areas.is_empty() {
+            return;
+        }
         let mut paint = Paint::default();
         paint.set_color_rgba8(colour.red, colour.green, colour.blue, colour.alpha);
         // Antialiasing on, which is the whole argument for drawing pixels: a bar
         // edge lands where the arithmetic puts it instead of being snapped to a
         // boundary, and that snapping is the mechanism behind #63.
-        paint.anti_alias = true;
+        paint.anti_alias = self.antialias;
 
         if self.placing.is_identity() {
-            // The one place a distance stops being a `Length` and becomes the
-            // number tiny-skia takes, so the unit cannot be lost above here.
-            let Some(rect) = SkRect::from_xywh(
-                area.left().get(),
-                area.top().get(),
-                area.width().get(),
-                area.height().get(),
-            ) else {
-                return;
-            };
-            self.pixmap
-                .fill_rect(rect, &paint, SkTransform::identity(), None);
+            for area in areas {
+                // The one place a distance stops being a `Length` and becomes
+                // the number tiny-skia takes, so the unit cannot be lost above
+                // here.
+                let Some(rect) = SkRect::from_xywh(
+                    area.left().get(),
+                    area.top().get(),
+                    area.width().get(),
+                    area.height().get(),
+                ) else {
+                    continue;
+                };
+                self.pixmap
+                    .fill_rect(rect, &paint, SkTransform::identity(), None);
+            }
             return;
         }
 
-        if area.is_empty() {
-            return;
-        }
-        // A corner with no place on the picture takes the whole shape with it:
-        // three corners of a bar is not a bar, and half of one is worse than
-        // none.
-        let Some(quad) = self.placing.quad(area) else {
-            return;
-        };
         let mut path = PathBuilder::new();
-        for (at, corner) in quad.corners.iter().enumerate() {
-            let (x, y) = (corner.x.get(), corner.y.get());
-            if at == 0 {
-                path.move_to(x, y);
-            } else {
-                path.line_to(x, y);
+        for area in areas {
+            if area.is_empty() {
+                continue;
             }
+            // A corner with no place on the picture takes that shape with it:
+            // three corners of a bar is not a bar, and half of one is worse
+            // than none.
+            let Some(quad) = self.placing.quad(*area) else {
+                continue;
+            };
+            for (at, corner) in quad.corners.iter().enumerate() {
+                let (x, y) = (corner.x.get(), corner.y.get());
+                if at == 0 {
+                    path.move_to(x, y);
+                } else {
+                    path.line_to(x, y);
+                }
+            }
+            path.close();
         }
-        path.close();
         // `finish` refuses a path with no area, which a bar edge-on to the
         // viewer is - and a scene turned a quarter turn has every bar that way.
         let Some(path) = path.finish() else {
@@ -149,19 +182,43 @@ impl Canvas {
     /// glyph to carry it - the colour still comes from the height, so the bar
     /// still reddens as it rises, just fainter all the way up.
     pub fn fill_ramped_at(&mut self, area: Rectangle, ramp: &Ramp, screen: &Screen, opacity: f32) {
+        self.fill_many_ramped_at(&[area], ramp, screen, opacity);
+    }
+
+    /// Several rectangles through the same ramp, one fill per colour instead of
+    /// one per colour per rectangle.
+    ///
+    /// A stripe is a band of the screen's own height, so the piece each
+    /// rectangle contributes to it is the same colour as every other's - which
+    /// is what makes them safe to batch even where they overlap. See
+    /// [`Self::fill_many`] for why it matters; a backdrop pass at eighty bands
+    /// is the case it was written for.
+    pub fn fill_many_ramped_at(
+        &mut self,
+        areas: &[Rectangle],
+        ramp: &Ramp,
+        screen: &Screen,
+        opacity: f32,
+    ) {
         let opacity = opacity.clamp(0.0, 1.0);
+        // Reused down the stripes rather than allocated per stripe: this runs
+        // once per band per frame at sixty frames a second.
+        let mut pieces: Vec<Rectangle> = Vec::with_capacity(areas.len());
         for stripe in ramp.stripes(screen.height()) {
-            if let Some(part) = stripe.clip(area) {
-                let colour = if opacity >= 1.0 {
-                    stripe.colour
-                } else {
-                    Colour {
-                        alpha: (f32::from(stripe.colour.alpha) * opacity) as u8,
-                        ..stripe.colour
-                    }
-                };
-                self.fill(part, colour);
+            pieces.clear();
+            pieces.extend(areas.iter().filter_map(|area| stripe.clip(*area)));
+            if pieces.is_empty() {
+                continue;
             }
+            let colour = if opacity >= 1.0 {
+                stripe.colour
+            } else {
+                Colour {
+                    alpha: (f32::from(stripe.colour.alpha) * opacity) as u8,
+                    ..stripe.colour
+                }
+            };
+            self.fill_many(&pieces, colour);
         }
     }
 
@@ -220,11 +277,26 @@ impl Draw for Scene<'_> {
                 Transform::moving(0.0, 0.0, depth).then(placing)
             });
         };
+        // Antialiasing is what an angled edge costs: measured at 2400x1440,
+        // eighty tall quads take 5.595 ms smoothed and 0.802 ms not - seven
+        // times, for the same ink, and it is the whole of the difference
+        // between an angled view that holds sixty frames a second and one that
+        // does not. The backdrop goes without it: a dim field standing behind
+        // the bars, most of it covered by them, and none of its edges are what
+        // anyone is looking at. The bars and the caps keep it, because an edge
+        // landing where the arithmetic puts it rather than on a pixel boundary
+        // is the whole argument for drawing pixels at all.
+        //
+        // Only ever while angled. Flat draws rectangles through a route that
+        // smooths them for nothing, so today's picture keeps every edge it has.
+        let angled = !placing.is_identity() || self.view.recedes();
         let backdrop = |canvas: &mut Canvas, index: usize| {
             let band = &self.bands[index];
             if let Some(grid) = self.style_of(band).and_then(|style| style.grid) {
                 let area = self.layout.column(index).backdrop(screen);
+                canvas.antialias(!angled);
                 canvas.fill_ramped(area, grid, screen);
+                canvas.antialias(true);
             }
         };
         let bar = |canvas: &mut Canvas, index: usize| {
@@ -269,17 +341,142 @@ impl Draw for Scene<'_> {
         // respect and a different rule takes over: every backdrop before any
         // bar, and every bar before any cap. That is what keeps a band's cap
         // clear of its neighbour's backdrop when the two wear different styles.
-        for index in 0..drawable {
-            stand(canvas, index);
-            backdrop(canvas, index);
+        //
+        // And because nothing overlaps, a whole layer can go down in one fill
+        // per colour instead of one per colour per band - which is the
+        // difference between an angled view that holds sixty frames a second
+        // and one that does not. See [`Canvas::fill_many`].
+        stand(canvas, 0);
+        let wears = |index: usize| {
+            // `style_of`'s rule, as an index: a band naming a style that is not
+            // there is drawn in the first one.
+            let named = self.bands[index].style.index();
+            if named < self.styles.len() { named } else { 0 }
+        };
+        let mut areas: Vec<Rectangle> = Vec::with_capacity(drawable);
+        let mut wearers: Vec<usize> = Vec::with_capacity(drawable);
+
+        for (id, style) in self.styles.iter().enumerate() {
+            wearers.clear();
+            wearers.extend((0..drawable).filter(|&index| wears(index) == id));
+            if wearers.is_empty() {
+                continue;
+            }
+            if let Some(grid) = style.grid {
+                areas.clear();
+                areas.extend(
+                    wearers
+                        .iter()
+                        .map(|&index| self.layout.column(index).backdrop(screen)),
+                );
+                canvas.antialias(!angled);
+                canvas.fill_many_ramped_at(&areas, grid, screen, 1.0);
+                canvas.antialias(true);
+            }
         }
-        for index in 0..drawable {
-            stand(canvas, index);
-            bar(canvas, index);
+
+        for (id, style) in self.styles.iter().enumerate() {
+            wearers.clear();
+            wearers.extend((0..drawable).filter(|&index| wears(index) == id));
+            if wearers.is_empty() {
+                continue;
+            }
+            match style.ladder {
+                // A ladder is rungs, and rung `r` sits at the same height in
+                // every band, so it takes the same colour in every band - which
+                // is what lets a row of them go down together.
+                Some((skin, rung)) => {
+                    areas.clear();
+                    areas.extend(wearers.iter().map(|&index| {
+                        self.layout
+                            .column(index)
+                            .bar(self.bands[index].level, screen)
+                    }));
+                    draw_ladders(canvas, &areas, skin, rung, style.bars, screen);
+                }
+                None => {
+                    areas.clear();
+                    areas.extend(wearers.iter().map(|&index| {
+                        self.layout
+                            .column(index)
+                            .bar(self.bands[index].level, screen)
+                    }));
+                    canvas.fill_many_ramped_at(&areas, style.bars, screen, 1.0);
+                }
+            }
         }
-        for index in 0..drawable {
-            stand(canvas, index);
-            cap(canvas, index);
+        for (id, style) in self.styles.iter().enumerate() {
+            let Some(shape) = style.cap else {
+                continue;
+            };
+            areas.clear();
+            areas.extend(
+                (0..drawable)
+                    .filter(|&index| wears(index) == id)
+                    .map(|index| {
+                        self.layout.column(index).cap(
+                            self.bands[index].peak,
+                            shape.thickness,
+                            screen,
+                        )
+                    }),
+            );
+            canvas.fill_many(&areas, shape.colour);
+        }
+    }
+}
+
+/// A row of bars as the ladders their skin describes, a rung at a time.
+///
+/// Rung `r` sits at the same height in every bar, so every bar's `r` takes the
+/// same colour from the ramp - which is what makes a row of them one fill
+/// rather than one each. See [`Canvas::fill_many`] for why that is the
+/// difference between holding sixty frames a second and not.
+fn draw_ladders(
+    canvas: &mut Canvas,
+    bars: &[Rectangle],
+    skin: rav_appearance::Skin,
+    rung: Length,
+    ramp: &Ramp,
+    screen: &Screen,
+) {
+    if rung.get() <= 0.0 {
+        canvas.fill_many_ramped_at(bars, ramp, screen, 1.0);
+        return;
+    }
+    let shape = skin.rung;
+    let mut row: Vec<Rectangle> = Vec::with_capacity(bars.len());
+    let tallest = bars
+        .iter()
+        .map(|bar| bar.height().get())
+        .fold(0.0f32, f32::max);
+    let rungs = ((tallest / rung.get()).ceil() as usize).min(4096);
+
+    for index in 0..rungs {
+        row.clear();
+        for bar in bars {
+            if bar.height().get() <= 0.0 {
+                continue;
+            }
+            let floor = bar.bottom();
+            let rung_bottom = floor - rung * (index as f32);
+            let shape_bottom = rung_bottom - rung * shape.floats;
+            let shape_top = shape_bottom - rung * shape.covers;
+            // Clipped to the bar, so the rung a bar stops inside is drawn only
+            // as far as the bar reached.
+            let top = shape_top.largest(bar.top());
+            let bottom = shape_bottom.smallest(floor);
+            if bottom > top {
+                row.push(Rectangle::new(bar.left(), top, bar.width(), bottom - top));
+            }
+        }
+        if row.is_empty() {
+            continue;
+        }
+        if shape.opacity >= 1.0 {
+            canvas.fill_many_ramped_at(&row, ramp, screen, 1.0);
+        } else {
+            canvas.fill_many_ramped_at(&row, ramp, screen, shape.opacity);
         }
     }
 }


### PR DESCRIPTION
`v` shipped in beta.11 costing more than a third of the frame rate, and I should have measured it before it went out — the risk was pointed out to me and I skipped it. Nobody would have found this without pressing the key on a real terminal.

Measured at the geometry WezTerm reports on this Mac — 2400×1440, eighty bands, grid and caps on:

| view | before | after | budget |
|---|---|---|---|
| flat | 4.3 ms | 4.3 ms | 16.7 ms |
| raked | **26.7 ms** | 10.5 ms | |
| turned | **27.2 ms** | 12.5 ms | |
| corridor | **23.1 ms** | 10.5 ms | |

**The cost is antialiasing on the path rasteriser, and only there.** Eighty tall quads take **5.595 ms** smoothed and **0.802 ms** not, for identical ink — seven times. Meanwhile one full-screen fill costs 0.187 ms as a rectangle and 0.247 ms as a path, which is nothing. tiny-skia has a fast route for an axis-aligned rectangle and a much heavier one for an arbitrary quad, and everything an angled view draws is on the second.

So **the backdrop goes without it.** It is a dim field standing behind the bars, most of it covered by them, and none of its edges are what anyone is looking at. The bars and the caps keep it, because an edge landing where the arithmetic puts it rather than on a pixel boundary is the whole argument for drawing pixels at all — #63s mechanism, and not something to trade away for frames. Flat keeps antialiasing everywhere, so todays picture is untouched to the byte, which the existing frame tests hold.

**The first diagnosis was wrong and the numbers are in the code so nobody repeats it.** I read "eighty separate path fills cost 8× eighty rect fills" as per-call overhead and batched every quad of one colour into a single path. It bought about a fifth, not an order of magnitude: a batched path spans the whole picture, so every scanline still walks every quads edges. The batching is in — a fifth is worth having, and it is also what lets a row of ladder rungs go down together — but its doc comment now says what it is and is not worth.

No test moved. 417 tests, clippy clean.