### PR TITLE
feat: a terminal that can draw images gets pixels

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,9 +45,11 @@ rav --clean           # log almost nothing
 rav --surface kitty   # auto, glyphs, kitty or window
 ```
 
-`--surface kitty` draws the bars as pixels in WezTerm, Ghostty and kitty; a peak
-cap then rides over the backdrop instead of erasing the cell it crosses, and the
-bar ladder is even at any font size. `auto` draws block characters. Press `h` for
+A terminal that can draw images gets **pixels**: a peak cap rides over the
+backdrop instead of erasing the cell it crosses, the bar ladder is even at any
+font size, and `v` bolts the field at an angle. WezTerm, Ghostty and kitty can;
+everything else draws block characters, as does a terminal that will not report
+its size in pixels. `--surface glyphs` forces the block characters. Press `h` for
 which surface rav is on and why.
 
 Everything else is a keypress, and `h` shows the lot with their current values:
@@ -100,8 +102,7 @@ The ballistics, and the ramp the `rav` and `winamp` themes use, come from
 
 ## What's next
 
-Pixels on `auto`, after the opt-in path has had a few releases in the open. A
-window of its own. Small displays — a strip of LEDs, or a matrix — which the
+A window of its own. Small displays — a strip of LEDs, or a matrix — which the
 same themes already cover, since what rav measures is kept apart from what it
 looks like.
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -59,7 +59,7 @@ On Linux that list is ALSA PCMs only — a PipeWire/PulseAudio `.monitor` source
 is not in it and cannot be selected with `-d`. Route the capture from the
 PipeWire side instead; see [audio.md](audio.md).
 
-## `--surface kitty` draws block characters anyway
+## rav draws block characters on a terminal that can do better
 
 Press `h`. The last row of the panel names the surface and the reason, and it
 reports rather than forecasts: **drawing on** while the pixels are going,
@@ -67,11 +67,12 @@ reports rather than forecasts: **drawing on** while the pixels are going,
 
 | what it says | |
 |---|---|
-| `pixels (asked for)` | pixels are going, and nothing needs fixing |
+| `pixels (your terminal can draw images)` | pixels are going, and nothing needs fixing. `asked for` in place of the reason means `--surface kitty` on the command line |
 | `glyphs (your terminal will not say how big it is in pixels)` | rav asked the terminal how big it is and got no answer. Deriving a cell size from the font is the rounding the pixel surface exists to remove, so rav declines to guess |
-| `glyphs (your terminal can draw images - try --surface kitty)` | `auto`, on a terminal that could. Pixels are opt-in and stay that way for a few releases |
 | `glyphs (tmux or screen is in the way)` | image escapes do not pass through a multiplexer intact. An explicit `--surface kitty` is still honoured — asking always wins — but it is the terminal underneath that has to answer |
 
 **Pixels are the bars.** The oscilloscope is block characters on every surface,
 so `Space` takes the picture down and the panel goes back to saying *would*.
-Switching back brings it up again.
+Switching back brings it up again - and `v`, the viewing angle, reads `needs
+pixels` for as long as either of those is true, rather than moving a setting
+nothing is drawing.

--- a/src/main.rs
+++ b/src/main.rs
@@ -40,11 +40,11 @@ struct Args {
     #[arg(long, value_name = "NAME|PATH")]
     theme: Option<String>,
 
-    /// Which surface to draw on. `kitty` draws the bars as pixels in WezTerm,
-    /// Ghostty or kitty, and drops back to block characters on a terminal
-    /// that will not say how big it is in pixels; `auto` still chooses them
-    /// however capable your terminal is, and `window` is not built yet. Press
-    /// `h` for what rav settled on and why.
+    /// Which surface to draw on. `auto` draws pixels wherever the terminal says
+    /// it can draw images - WezTerm, Ghostty, kitty - and block characters
+    /// everywhere else, including a terminal that will not say how big it is in
+    /// pixels. `glyphs` forces the block characters, `kitty` forces the pixels,
+    /// and `window` is not built yet. Press `h` for what rav settled on and why.
     #[arg(
         long,
         value_name = "auto|glyphs|kitty|window",

--- a/src/surface/mod.rs
+++ b/src/surface/mod.rs
@@ -143,19 +143,27 @@ pub fn choose(asked: Choice, multiplexed: bool, answers: impl FnOnce() -> bool) 
         // failure is a garbled screen rather than a missing picture - so auto
         // never picks pixels there, however the terminal answers.
         Choice::Auto if multiplexed => glyphs("tmux or screen is in the way"),
-        // Pixels are asked for, never assumed. A terminal that says it can draw
-        // images is told so and left on block characters, because "it looked
-        // fine on the one terminal that was tried" is not something a default
-        // can rest on - and a default that turns out wrong is a broken display
-        // for everybody rather than for whoever opted in.
+        // A terminal that says it can draw images gets them. Asking for what the
+        // terminal already told you it can do is a setting that exists to be
+        // found, and most people never find it - the whole point of the pixel
+        // surface is the peak cap that rides over the backdrop instead of
+        // erasing the cell it crosses, and the ladder that is even at any font
+        // size, and neither of those is worth having only to whoever read the
+        // README to the bottom.
         //
-        // The line to change when that is no longer true is the one below.
+        // The fall back is still there and is automatic: a terminal that will
+        // not report its size in pixels draws block characters anyway, because
+        // working a cell size out from the font is the rounding this exists to
+        // remove. See `App::paint`.
         //
         // Not a match guard, because calling `answers` consumes it and a guard
         // only gets a borrow.
         Choice::Auto => {
             if answers() {
-                glyphs("your terminal can draw images - try --surface kitty")
+                Chosen {
+                    surface: Surface::Kitty,
+                    because: "your terminal can draw images",
+                }
             } else {
                 glyphs("your terminal cannot draw images")
             }
@@ -334,28 +342,29 @@ mod tests {
     }
 
     #[test]
-    fn nobody_gets_pixels_without_asking_for_them() {
-        // Both ways round, auto draws block characters. A terminal that can do
-        // better is told how, rather than being switched over on its behalf:
-        // the pixel surface has been seen working on one terminal, and a
-        // default that turns out wrong breaks the display for everyone instead
-        // of for whoever chose it.
+    fn a_terminal_that_can_draw_images_is_given_them() {
+        // The setting stopped being a setting. A peak cap riding over the
+        // backdrop instead of erasing the cell it crosses is not worth having
+        // only to whoever read the README to the bottom, and asking for what the
+        // terminal already said it can do is a flag that exists to be found.
         let capable = choose(Choice::Auto, false, || true);
-        assert_eq!(capable.surface, Surface::Glyphs);
-        assert!(
-            capable.because.contains("--surface kitty"),
-            "a capable terminal was not told how to use it: {}",
-            capable.because,
-        );
-        assert_eq!(
-            choose(Choice::Auto, false, || false).surface,
-            Surface::Glyphs
-        );
+        assert_eq!(capable.surface, Surface::Kitty);
+        assert_eq!(capable.because, "your terminal can draw images");
 
-        // Asking is still honoured, or there would be no way in at all.
+        // And one that says it cannot is believed.
+        let plain = choose(Choice::Auto, false, || false);
+        assert_eq!(plain.surface, Surface::Glyphs);
+        assert_eq!(plain.because, "your terminal cannot draw images");
+
+        // Asking is still honoured either way - a terminal that draws images
+        // without answering the query is reachable no other way.
         assert_eq!(
             choose(Choice::Kitty, false, || false).surface,
             Surface::Kitty
+        );
+        assert_eq!(
+            choose(Choice::Glyphs, false, || true).surface,
+            Surface::Glyphs
         );
     }
 

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -634,6 +634,18 @@ impl App {
         self.status = Some((text, Instant::now()));
     }
 
+    /// Whether a viewing angle would change anything.
+    ///
+    /// The pixel surface, showing the analyser. A cell holds one character
+    /// upright and always will, and the oscilloscope is a line of them on every
+    /// surface - `stop_painting` hands the screen back for it. Asked of the
+    /// surface rather than of whether a picture happens to be up this instant,
+    /// so the answer is the same before the first frame as after it.
+    fn can_be_angled(&self) -> bool {
+        self.surface.surface == crate::surface::Surface::Kitty
+            && self.visualisation == Visualisation::Analyzer
+    }
+
     /// The message to draw, if one is still recent.
     fn active_status(&self) -> Option<&str> {
         self.status
@@ -735,16 +747,17 @@ impl App {
                 self.bar_style = self.bar_style.next();
                 self.note(format!("bars {}", self.bar_style.label()));
             }
-            // Pixels only. A cell holds one character upright, so a glyph grid
-            // draws `Flat` whatever this says - and the note tells the truth
-            // about that, rather than reporting an angle nothing took.
+            // Refused rather than cycled where it would do nothing. A setting
+            // that moves while the picture does not is worse than a key that
+            // says why it will not move it, and this is the one setting in rav
+            // that a whole surface cannot honour.
             Action::CycleView => {
-                self.view = self.view.next();
-                self.note(if self.painting {
-                    format!("view {}", self.view.label())
+                if self.can_be_angled() {
+                    self.view = self.view.next();
+                    self.note(format!("view {}", self.view.label()));
                 } else {
-                    format!("view {} - pixels only", self.view.label())
-                });
+                    self.note("viewing angle needs pixels".into());
+                }
             }
             Action::CycleTheme => {
                 let next = self.next_theme();
@@ -849,8 +862,12 @@ impl App {
             },
             HelpRow {
                 key: "v",
-                description: "viewing angle (pixels only)",
-                value: Some(self.view.label().to_string()),
+                description: "viewing angle",
+                value: Some(if self.can_be_angled() {
+                    self.view.label().to_string()
+                } else {
+                    "needs pixels".to_string()
+                }),
             },
             HelpRow {
                 key: "g",
@@ -2301,6 +2318,10 @@ mod tests {
         assert_eq!(map_key(KeyCode::Char('V')), Action::CycleView);
 
         let mut a = app();
+        a.surface = Chosen {
+            surface: crate::surface::Surface::Kitty,
+            because: "for the test",
+        };
         assert_eq!(a.view, View::Flat, "rav does not open at an angle");
         for expected in ["raked", "turned", "corridor", "flat"] {
             a.apply(Action::CycleView);
@@ -2315,29 +2336,48 @@ mod tests {
     }
 
     #[test]
-    fn the_note_says_when_an_angle_will_not_be_drawn() {
-        // `v` is the one setting that does nothing on a cell grid, and a note
-        // reporting an angle the picture did not take is the defect #92 fixed
-        // for bar style and #93 then made obsolete. Here it is real: a cell
-        // holds one character upright and always will.
+    fn v_refuses_where_an_angle_would_do_nothing() {
+        // A setting that moves while the picture does not is worse than a key
+        // saying why it will not move it. A cell holds one character upright and
+        // always will, and the oscilloscope is a line of them on every surface -
+        // so neither can be angled, and the panel says so where the value would
+        // otherwise sit.
+        let angle_row = |a: &App| {
+            a.help_rows()
+                .into_iter()
+                .find(|row| row.key == "v")
+                .and_then(|row| row.value)
+                .expect("no viewing angle row")
+        };
+
+        // A glyph terminal, which is what `app()` settles on with no probe.
         let mut a = app();
-        a.painting = false;
         a.apply(Action::CycleView);
+        assert_eq!(a.view, View::Flat, "the angle moved where nothing draws it");
+        assert_eq!(angle_row(&a), "needs pixels");
         assert!(
             a.active_status()
-                .is_some_and(|note| note.contains("pixels")),
-            "the note promised an angle the glyph renderer cannot draw: {:?}",
+                .is_some_and(|note| note.contains("needs pixels")),
+            "it changed nothing and said nothing: {:?}",
             a.active_status(),
         );
 
-        a.painting = true;
+        // Pixels, but showing the oscilloscope, which hands the screen back to
+        // the glyph renderer for as long as it is up.
+        a.surface = Chosen {
+            surface: crate::surface::Surface::Kitty,
+            because: "for the test",
+        };
+        a.apply(Action::CycleVisualisation);
         a.apply(Action::CycleView);
-        assert!(
-            a.active_status()
-                .is_some_and(|note| !note.contains("pixels only")),
-            "the note apologised while the pixels were drawing it: {:?}",
-            a.active_status(),
-        );
+        assert_eq!(a.view, View::Flat, "the oscilloscope took an angle");
+        assert_eq!(angle_row(&a), "needs pixels");
+
+        // Back to the bars, where it means something.
+        a.apply(Action::CycleVisualisation);
+        a.apply(Action::CycleView);
+        assert_eq!(a.view, View::Raked);
+        assert_eq!(angle_row(&a), "raked");
     }
 
     #[test]


### PR DESCRIPTION
Two things you asked for, which are the same change: `auto` draws pixels wherever the terminal says it can, and `v` stops pretending where it cannot.

**The setting stops being a setting.** A peak cap riding over the backdrop instead of erasing the cell it crosses, and a bar ladder even at any font size, are not worth having only to whoever read the README to the bottom — and asking for what the terminal already told you it can do is a flag that exists to be found. WezTerm, Ghostty and kitty answer the graphics query and get pixels.

The guards that were already there stay, and none of them needed changing:

- a terminal that will not report its size in pixels draws block characters anyway, automatically, because working a cell size out from the font is the rounding this whole surface exists to remove
- tmux and screen still refuse, since an image escape does not survive a multiplexer intact
- `--surface glyphs` forces the block characters back, and `--surface kitty` still forces pixels on a terminal that draws them without answering the query

**`v` refuses instead of moving.** The viewing angle is the one setting a whole surface cannot honour. On block characters — or on the oscilloscope, which is block characters on every surface — it now leaves the angle alone and the panel reads `needs pixels` where the value would sit. It was cycling happily and mentioning the problem only in a note that faded, which is the same defect as a bar style that named six looks and drew one.

Asked of the surface rather than of whether a picture happens to be up this instant, so the answer is the same before the first frame as after it.

**Four places said pixels were opt-in and now say what happens instead**: the README, `--help`, the troubleshooting page and the help panel. The troubleshooting table lost the row about `auto` declining and gained the distinction between `pixels (your terminal can draw images)` and `pixels (asked for)`.

417 tests, and the one that asserted the old default is now `a_terminal_that_can_draw_images_is_given_them`.

Worth saying plainly: nobody has yet watched this on glass. What is verified is that the escape sequences are right, on every PR, on both platforms — `tests/on_a_pty.rs` — and that a terminal which cannot report a pixel size falls back on its own. The blast radius if it is wrong is a terminal that can draw images and does it badly; the way out is `--surface glyphs`.