### PR TITLE
docs: three claims the release stopped being true

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ rav --theme winamp    # rav, winamp, terminal, mono, or a path to a theme
 rav --list-devices    # what rav can capture from
 rav -d "<name>"       # capture from a named device
 rav --clean           # log almost nothing
-rav --surface kitty   # auto, glyphs, kitty or window
+rav --surface glyphs  # auto, glyphs, kitty or window
 ```
 
 A terminal that can draw images gets **pixels**: a peak cap rides over the

--- a/crates/rav-appearance/src/scene.rs
+++ b/crates/rav-appearance/src/scene.rs
@@ -11,10 +11,11 @@
 //!
 //! # Taken by one surface
 //!
-//! The pixel surface, on every frame `--surface kitty` draws. The glyph
-//! renderer takes levels and colours directly and quantises them itself, so
-//! this is the seam for one consumer until a second is built on it - a window
-//! or an LED matrix would be the second, and neither exists yet.
+//! The pixel surface, on every frame it draws - which is every frame on a
+//! terminal that says it can draw images. The glyph renderer takes levels and
+//! colours directly and quantises them itself, so this is the seam for one
+//! consumer until a second is built on it: a window or an LED matrix would be
+//! the second, and neither exists yet.
 
 use crate::ink::Colour;
 use crate::ramp::Ramp;

--- a/src/surface/mod.rs
+++ b/src/surface/mod.rs
@@ -1,10 +1,22 @@
-//! Which surface rav would draw on, and asking the terminal whether it can.
+//! Which surface rav draws on, and asking the terminal whether it can draw
+//! images at all.
 //!
-//! Reporting only. Nothing here changes what is drawn - the choice is made,
-//! logged and shown in the help overlay, and the glyph renderer draws every
-//! frame regardless. A probe that hangs or garbles a terminal is the worst bug
-//! class in this area, so it ships first with its only possible symptom being a
-//! wrong label.
+//! The question is asked once, before the alternate screen: a query the
+//! terminal either accepts or does not, chained with a device attributes
+//! request so one that has never heard of graphics is a definite no
+//! immediately rather than a timeout's worth of silence.
+//!
+//! A terminal that says yes is given pixels. Everything else gets block
+//! characters, and so does a multiplexer, because an image escape does not
+//! survive one intact and a garbled screen is worse than a plain one.
+//! `--surface` overrides the lot in either direction.
+//!
+//! **This is not the last word.** The answer here is what the terminal says it
+//! can do; whether it says how big it is in pixels is a separate question, asked
+//! every frame, and a terminal that will not say drops back to block characters
+//! however this came out - see `App::paint`. So the help overlay distinguishes
+//! what rav is drawing on from what it would draw on, and this module is only
+//! ever half of that answer.
 
 pub mod frame;
 pub mod kitty;

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -910,10 +910,11 @@ impl App {
             // No key, because there is none: `--surface` is a flag.
             //
             // "Drawing on" while the pixels are going and "would draw on" when
-            // they are not. The distinction is the whole of what this row is
-            // for: `auto` still picks glyphs however capable the terminal is,
-            // so a reader who sees "pixels" needs to know whether that is a
-            // report or a forecast.
+            // they are not, which is the whole of what this row is for. A
+            // terminal that says it can draw images is given them, and then
+            // asked how big it is - and one that will not say drops back to
+            // block characters. So "pixels" here can still be a forecast the
+            // next frame overturns, and a reader has to be able to tell.
             HelpRow {
                 key: "",
                 description: if self.painting {


### PR DESCRIPTION
Read beta.13 the way someone arriving at it would, rather than PR by PR. That has caught this class twice before — seven stale claims before beta.9, the `--help` line before beta.11 — and it caught it again. None of these is in a PR I opened this week; they are sentences that quietly stopped being true underneath.

**`src/surface/mod.rs` opened with "Reporting only."** In full: *"Nothing here changes what is drawn — the choice is made, logged and shown in the help overlay, and the glyph renderer draws every frame regardless."* False since the pixel surface shipped in beta.9, and this is the module note **docs.rs publishes** for the layer that now decides what everybody gets. It says what the module does now, and says the part that is easy to miss: the answer here is what the terminal *claims* it can draw, while whether it will report a size in pixels is a separate question asked every frame that overrules it. That is why the help overlay distinguishes drawing-on from would-draw-on, and this module is only ever half of that answer.

**The help panels surface row explained itself with "`auto` still picks glyphs however capable the terminal is".** The row is still right; the reason is not. What makes the report-or-forecast distinction matter now is the size fall back, not the default.

**The READMEs usage block offered `--surface kitty` as the example** — the flag nobody needs any more. `--surface glyphs` is the one someone actually reaches for.

**And the scene note** described itself as the seam for the frames `--surface kitty` draws, which is now the frames anything with images draws.

Nothing behavioural. Fifth subject for `1.0.0-beta.13`, and the standing release PR stays open.