### PR TITLE
test: the portable half has to build for a machine that is not this one

### DIFF
--- a/devenv.nix
+++ b/devenv.nix
@@ -415,7 +415,24 @@
       exec = "cargo test --workspace --all-features";
       after = [ "test:clippy" ];
     };
+    "test:portable" = {
+      # The two crates the whole split exists for claim to run anywhere - a
+      # microcontroller driving an LED strip, a browser canvas. `#![no_std]`
+      # already stops them reaching for a filesystem or a clock; what it does
+      # not stop is a *machine* assumption, and that is what this catches.
+      #
+      # Measured rather than assumed: a NEON intrinsic added to `rav-core`
+      # compiles on this Mac and fails here, which is the shape of the mistake
+      # - portable by every other check, and unbuildable on the target the
+      # split exists to serve.
+      #
+      # rav itself is deliberately not in the list. It is full of terminals and
+      # clocks and fails this target with dozens of errors, which is the crate
+      # boundary doing its job rather than a gap in this one.
+      exec = "cargo build -p rav-core -p rav-appearance --target wasm32-unknown-unknown";
+      after = [ "test:clippy" ];
+    };
   };
 
-  enterTest = lib.mkForce "devenv tasks run test:fmt test:clippy test:nix test:unit";
+  enterTest = lib.mkForce "devenv tasks run test:fmt test:clippy test:nix test:unit test:portable";
 }


### PR DESCRIPTION
`rav-core` and `rav-appearance` are the reason this is three crates: they claim to run on a microcontroller driving an LED strip, or a browser canvas, knowing nothing about terminals, files or clocks. **Nothing checked it.**

`#![no_std]` already stops them reaching for a filesystem or a clock. What it does not stop is a *machine* assumption — and that is the gap. `devenv test` now builds both for `wasm32-unknown-unknown`, which has no operating system behind it at all.

**Measured, not assumed.** I added a NEON intrinsic to `rav-core` to see whether the check could fail:

```
--- host build ---   Finished `dev` profile
--- wasm build ---   error: could not compile `rav-core`
```

That is exactly the shape of the mistake worth catching: portable by every other check in the suite — `no_std`, clippy, 400-odd tests — and unbuildable on the target the split exists to serve.

**rav itself is deliberately not in the list.** It is full of terminals and clocks and fails that target with dozens of errors, which is the crate boundary doing its job rather than a gap in this task.

**One wrinkle worth recording.** The target is not declared in `languages.rust.targets`: devenv refuses that on the nixpkgs channel — *"The nixpkgs channel does not support cross-compiling with targets"* — and taking the alternative would move the whole toolchain to the stable channel, changing the rustc and clippy under everything for the sake of one line. The pinned toolchain carries the target already, and the task fails loudly if that ever stops being true.

This is also what #69 needs before anything else: a page that runs the same crates is either proof of the split or a list of everything still wired to a terminal, and now the list is checked on every run rather than discovered halfway through building the page.

`devenv test` exits 0 with it in the chain.