### PR TITLE
fix(devenv): the portable build runs after the tests, not beside them

### DIFF
--- a/devenv.nix
+++ b/devenv.nix
@@ -430,7 +430,13 @@
       # clocks and fails this target with dozens of errors, which is the crate
       # boundary doing its job rather than a gap in this one.
       exec = "cargo build -p rav-core -p rav-appearance --target wasm32-unknown-unknown";
-      after = [ "test:clippy" ];
+      # After test:unit, not beside it. The `after` edges above exist to keep
+      # cargo invocations off each other's toes over the single lock on
+      # ./target, and a task that only waits for clippy runs concurrently with
+      # the tests - which is the contention those edges were measured to stop.
+      # Last in the chain also puts it after the cheapest failures, and it is
+      # the only task here that compiles for a second target.
+      after = [ "test:unit" ];
     };
   };
 


### PR DESCRIPTION
Copilot caught this on #126 and I merged before reading it, so it is a follow-up rather than a commit on that branch.

The `after` edges in `devenv.nix` are load-bearing and the file says so, with the measurement behind it: devenv runs tasks with no edge between them **concurrently**, so without the edges `fmt`, `clippy` and `test` all invoke cargo at once and block on the single lock over `./target`.

`test:portable` waited only for `test:clippy` — which is what `test:unit` waits for — so the two ran together and contended for exactly that lock. It waits for `test:unit` now.

That is also the right place for it on its own merits: it is the only task in the suite that compiles for a second target, so it belongs after every cheaper way to fail rather than racing the one task that takes longest.

`devenv test` exits 0.