### PR TITLE
docs: the demo tour shows what rav does now, and says where to film it

### DIFF
--- a/devenv.nix
+++ b/devenv.nix
@@ -156,8 +156,9 @@
   # the same size as the committed one and drops straight into the README.
   #
   # The recording is a guided tour rather than a static shot - it drives rav from
-  # the outside while filming, so the GIF shows the three themes and then the
-  # oscilloscope instead of one view for the whole clip. RAV_DEMO_TOUR is a list
+  # the outside while filming, so the GIF shows the four themes, the four viewing
+  # angles and then the oscilloscope, instead of one view for the whole clip.
+  # RAV_DEMO_TOUR is a list
   # of `seconds:key` steps: hold for that many seconds, then send that key.
   # `-` sends nothing, which is how the last segment gets its screen time.
   scripts.record-demo.exec = ''

--- a/devenv.nix
+++ b/devenv.nix
@@ -182,11 +182,17 @@
     # re-record at a higher rate is pending.
     FPS="''${RAV_DEMO_FPS:-25}"
     LEAD="''${RAV_DEMO_LEAD:-5}"
-    # Every theme, then the oscilloscope, then the help overlay - and back to the
-    # defaults, so the GIF loops from the same frame it started on. There is one
-    # `t` per theme: the last press is what returns to the first, and leaving it
-    # out is how the tour quietly stops ending where it began.
-    TOUR="''${RAV_DEMO_TOUR:-3:t 3:t 3:t 3:t 1:space 4:space 1:h 4:h 2:-}"
+    # Every theme, then every viewing angle, then the oscilloscope and the help
+    # overlay - and back to the defaults, so the GIF loops from the same frame it
+    # started on. There is one `t` per theme and one `v` per angle: the last
+    # press of each is what returns to the first, and leaving it out is how the
+    # tour quietly stops ending where it began.
+    #
+    # The angles are the reason the terminal matters. `v` does nothing on block
+    # characters and the panel says `needs pixels`, so a recording made in a
+    # terminal that cannot draw images shows four seconds of a key not working.
+    # Record in WezTerm, Ghostty or kitty.
+    TOUR="''${RAV_DEMO_TOUR:-3:t 3:t 3:t 3:t 2:v 2:v 2:v 2:v 1:space 4:space 1:h 4:h 2:-}"
     # Total duration is the sum of the tour's holds, so the two never drift.
     # SETTLE covers the second avfoundation spends opening the capture device -
     # without it the first key lands before filming starts and that segment is

--- a/docs/developing.md
+++ b/docs/developing.md
@@ -76,6 +76,14 @@ at, so a re-record drops straight in.
 | `RAV_DEMO_FPS` | 25 by default, and it sets the capture rate too; see below |
 | `RAV_DEMO_OUT`, `RAV_DEMO_LEAD`, `RAV_DEMO_SETTLE` | the rest |
 
+**Record it in a terminal that can draw images** — WezTerm, Ghostty or kitty.
+rav draws pixels wherever the terminal says it can, so a recording made anywhere
+else shows the fall back rather than the thing: block characters, a peak cap
+erasing the grid it crosses, and four seconds of `v` doing nothing but printing
+`needs pixels`. The committed `assets/demo.gif` predates the pixel surface
+entirely and was shot in Terminal.app, which cannot even show rav's colours —
+it reports `colors#256` and no `Tc`.
+
 The capture and the GIF run at the same rate — one variable, so they cannot
 drift. Capturing above the GIF rate and sampling back down throws away real
 motion; capturing below it cannot be recovered downstream.

--- a/docs/developing.md
+++ b/docs/developing.md
@@ -61,9 +61,9 @@ github:i-am-logger/rav` is the install path in the README.
 `record-demo` screen-records the frontmost window and quantises it to a GIF, and
 it drives rav while filming rather than capturing one static view.
 `RAV_DEMO_TOUR` is a list of `seconds:key` steps — hold that long, then send that
-key, with `-` for "send nothing". The default walks the three themes, the
-oscilloscope and the help overlay, then returns to the defaults so the loop is
-seamless.
+key, with `-` for "send nothing". The default walks the four themes and the
+four viewing angles, then the oscilloscope and the help overlay, and returns to
+the defaults so the loop is seamless.
 
 Size the window to 941×249 first; that is the shape the committed GIF was shot
 at, so a re-record drops straight in.
@@ -78,7 +78,7 @@ at, so a re-record drops straight in.
 
 **Record it in a terminal that can draw images** — WezTerm, Ghostty or kitty.
 rav draws pixels wherever the terminal says it can, so a recording made anywhere
-else shows the fall back rather than the thing: block characters, a peak cap
+else shows the fallback rather than the thing: block characters, a peak cap
 erasing the grid it crosses, and four seconds of `v` doing nothing but printing
 `needs pixels`. The committed `assets/demo.gif` predates the pixel surface
 entirely and was shot in Terminal.app, which cannot even show rav's colours —

--- a/src/surface/mod.rs
+++ b/src/surface/mod.rs
@@ -163,7 +163,7 @@ pub fn choose(asked: Choice, multiplexed: bool, answers: impl FnOnce() -> bool) 
         // size, and neither of those is worth having only to whoever read the
         // README to the bottom.
         //
-        // The fall back is still there and is automatic: a terminal that will
+        // The fallback is still there and is automatic: a terminal that will
         // not report its size in pixels draws block characters anyway, because
         // working a cell size out from the font is the rounding this exists to
         // remove. See `App::paint`.


### PR DESCRIPTION
**`assets/demo.gif` is a picture of a renderer that is no longer the default**, and it is the first thing anyone sees of rav — on GitHub and on the crates.io page.

It was recorded on **2026-08-09**, before the pixel surface existed at all, in **Terminal.app** — which reports `colors#256` and no `Tc`, so it cannot show ravs truecolour ramp, let alone its pixels. Everything the last two weeks were about is absent from it.

Re-recording needs a screen and macOS Screen Recording permission, so it is not mine to do. This is the half that is: **the tour now walks the four viewing angles as well as the four themes**, and both the script and `docs/developing.md` say where to film it.

That is not a preference about which terminal is nicer. `v` does nothing on block characters and the panel says `needs pixels`, so a recording made anywhere else spends four seconds showing a key that does not work — and shows the fall back rather than the thing: a peak cap erasing the grid it crosses, and a ladder uneven at most font sizes.

```
RAV_DEMO_TOUR default:
  3:t 3:t 3:t 3:t   the four themes
  2:v 2:v 2:v 2:v   flat, raked, turned, corridor, back to flat
  1:space 4:space   the oscilloscope
  1:h 4:h 2:-       the help panel, then rest
```

One `v` per angle for the same reason there is one `t` per theme: the last press is what returns to the first, and leaving it out is how a looping GIF quietly stops ending where it began.

Ninth subject for `1.0.0-beta.13`. Nothing behavioural, and the GIF itself is linked from `raw.githubusercontent.com` rather than shipped in the crate — so re-recording it does not need a release, whenever you get to it.