### PR TITLE
feat: the field can sway, which is the last line of #68

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Everything else is a keypress, and `h` shows the lot with their current values:
 | `Space` / `Tab` / `o` | switch analyser ↔ oscilloscope |
 | `t` | theme — rav, winamp, terminal, mono |
 | `b` | bar style — blocks, solid, thick, half, line, shade |
-| `v` | viewing angle — flat, raked, turned, corridor; pixels only |
+| `v` | viewing angle — flat, raked, turned, corridor, swaying; pixels only |
 | `p` | peak caps — fine, coarse, off |
 | `g` | grid behind the bars, on/off |
 | `w` | bandwidth: wide (grouped) or thin |

--- a/crates/rav-appearance/src/scene.rs
+++ b/crates/rav-appearance/src/scene.rs
@@ -21,8 +21,19 @@ use crate::ink::Colour;
 use crate::ramp::Ramp;
 use crate::skin::Skin;
 use rav_core::geometry::{BarLayout, Screen};
+use rav_core::math::sin;
 use rav_core::transform::Transform;
-use rav_core::units::{Length, Level};
+use rav_core::units::{Elapsed, Length, Level};
+
+/// How long a [`View::Swaying`] field takes to cross and come back.
+///
+/// Slow enough to read as the panel moving rather than as the picture shaking:
+/// at twelve seconds a bar drifts by a fraction of its own width between one
+/// frame and the next.
+pub const SWAY_SECONDS: f32 = 12.0;
+
+/// A whole turn, which `core` has as `TAU` and a `no_std` build still needs.
+const TAU: f32 = core::f32::consts::TAU;
 
 /// Which of a scene's styles a band wears.
 ///
@@ -101,6 +112,15 @@ pub enum View {
     /// rather than the whole field being at an angle - so it is the only one
     /// that changes what order they have to be drawn in.
     Corridor,
+    /// Turning slowly from one side to the other and back, for as long as it is
+    /// showing.
+    ///
+    /// The only view that is not the same picture twice, and the only one that
+    /// asks what time it is. It sways rather than turning all the way round
+    /// because a field edge-on to the viewer has no area, so a full rotation
+    /// would take the picture away twice a turn - which reads as a fault rather
+    /// than as motion.
+    Swaying,
 }
 
 impl View {
@@ -110,6 +130,7 @@ impl View {
             Self::Raked => "raked",
             Self::Turned => "turned",
             Self::Corridor => "corridor",
+            Self::Swaying => "swaying",
         }
     }
 
@@ -118,7 +139,8 @@ impl View {
             Self::Flat => Self::Raked,
             Self::Raked => Self::Turned,
             Self::Turned => Self::Corridor,
-            Self::Corridor => Self::Flat,
+            Self::Corridor => Self::Swaying,
+            Self::Swaying => Self::Flat,
         }
     }
 
@@ -170,6 +192,18 @@ impl View {
     /// the rotation actually produced, so the angles can be whatever reads best
     /// and none of them can push the picture off the screen.
     pub fn placing(self, screen: &Screen) -> Transform {
+        self.placing_at(screen, Elapsed::seconds(0.0))
+    }
+
+    /// The same, for a view that is somewhere in a movement.
+    ///
+    /// Every angle but [`Swaying`](Self::Swaying) ignores the time and comes
+    /// back with what [`placing`](Self::placing) gives, so a caller with no
+    /// clock loses nothing by not having one. The sway is a full cycle every
+    /// [`SWAY_SECONDS`], between the same extremes [`Turned`](Self::Turned)
+    /// holds still at - slow enough to read as the panel moving rather than as
+    /// the picture shaking.
+    pub fn placing_at(self, screen: &Screen, elapsed: Elapsed) -> Transform {
         let (across, down) = (screen.width().get(), screen.height().get());
         let (middle_x, middle_y) = (across / 2.0, down / 2.0);
         let (turn, eye) = match self {
@@ -181,6 +215,14 @@ impl View {
             // was, so the fit below finds nothing to do and the picture keeps
             // the whole screen.
             Self::Corridor => (Transform::IDENTITY, across * 3.0),
+            // The same extremes `Turned` holds still at, crossed and recrossed.
+            // `sin` rather than a sawtooth: a fold in the motion at each end
+            // reads as a jolt, and this is the one view whose whole point is
+            // that it moves smoothly.
+            Self::Swaying => {
+                let turn = TAU * elapsed.as_seconds() / SWAY_SECONDS;
+                (Transform::turning(0.44 * sin(turn)), across * 3.0)
+            }
         };
         let centred = |about: Transform| {
             Transform::moving(-middle_x, -middle_y, 0.0)
@@ -221,6 +263,14 @@ pub struct Scene<'a> {
     /// The angle the whole field is bolted at. `Flat` is what every surface
     /// has always drawn, and what one that cannot lean draws regardless.
     pub view: View,
+    /// How long the analyser has been running.
+    ///
+    /// Only [`View::Swaying`] reads it - every other angle is the same picture
+    /// whenever it is drawn. It is here rather than in the view because a view
+    /// is a setting a user chose and this is a fact about the frame, and
+    /// because a scene is what to draw *now*: once anything moves, "now" is
+    /// part of what a surface is being asked for.
+    pub elapsed: Elapsed,
     /// The looks a band may wear, indexed by its [`StyleId`].
     ///
     /// Usually one. Two for a stereo pair, one per band for a rainbow. A scene
@@ -297,6 +347,7 @@ mod tests {
             layout: BarLayout::new(Length(8.0), Length(2.0)),
             screen: Screen::new(Length(across), Length(100.0)),
             view: View::Flat,
+            elapsed: Elapsed::seconds(0.0),
             styles,
         }
     }
@@ -323,7 +374,7 @@ mod tests {
         // than handed to a surface as a matrix to centre for itself.
         let screen = Screen::new(Length(240.0), Length(120.0));
         let middle = rav_core::transform::Point::flat(Length(120.0), Length(60.0));
-        for view in [View::Raked, View::Turned, View::Corridor] {
+        for view in [View::Raked, View::Turned, View::Corridor, View::Swaying] {
             let stays = view.placing(&screen).apply(middle).unwrap();
             assert!(
                 (stays.x.get() - 120.0).abs() < 0.01 && (stays.y.get() - 60.0).abs() < 0.01,
@@ -340,7 +391,13 @@ mod tests {
         // of every offered view has somewhere to land.
         let screen = Screen::new(Length(240.0), Length(120.0));
         let field = screen.bounds();
-        for view in [View::Flat, View::Raked, View::Turned, View::Corridor] {
+        for view in [
+            View::Flat,
+            View::Raked,
+            View::Turned,
+            View::Corridor,
+            View::Swaying,
+        ] {
             assert!(
                 view.placing(&screen).quad(field).is_some(),
                 "{} put a corner where it cannot be drawn",
@@ -359,7 +416,13 @@ mod tests {
         // whatever reads best and none of them can spill.
         let screen = Screen::new(Length(480.0), Length(240.0));
         let field = screen.bounds();
-        for view in [View::Flat, View::Raked, View::Turned, View::Corridor] {
+        for view in [
+            View::Flat,
+            View::Raked,
+            View::Turned,
+            View::Corridor,
+            View::Swaying,
+        ] {
             let quad = view.placing(&screen).quad(field).expect("undrawable");
             for corner in quad.corners {
                 let (x, y) = (corner.x.get(), corner.y.get());
@@ -377,7 +440,13 @@ mod tests {
         // Three presses and the picture is where it started, like every other
         // cycling setting in rav.
         let mut view = View::Flat;
-        for expected in [View::Raked, View::Turned, View::Corridor, View::Flat] {
+        for expected in [
+            View::Raked,
+            View::Turned,
+            View::Corridor,
+            View::Swaying,
+            View::Flat,
+        ] {
             view = view.next();
             assert_eq!(view, expected);
         }

--- a/crates/rav-appearance/src/scene.rs
+++ b/crates/rav-appearance/src/scene.rs
@@ -21,7 +21,7 @@ use crate::ink::Colour;
 use crate::ramp::Ramp;
 use crate::skin::Skin;
 use rav_core::geometry::{BarLayout, Screen};
-use rav_core::math::sin;
+use rav_core::math::{floor, sin};
 use rav_core::transform::Transform;
 use rav_core::units::{Elapsed, Length, Level};
 
@@ -34,6 +34,26 @@ pub const SWAY_SECONDS: f32 = 12.0;
 
 /// A whole turn, which `core` has as `TAU` and a `no_std` build still needs.
 const TAU: f32 = core::f32::consts::TAU;
+
+/// How far into the sway a run of this length is.
+///
+/// Takes seconds as `f64` and hands back a fraction of one cycle, because the
+/// wrapping has to happen *before* the number becomes an `f32` and there is no
+/// way to do that afterwards. [`Elapsed`] holds `f32` seconds, which has 24 bits
+/// of mantissa: past about 280,000 seconds - three days or so - one frame at
+/// sixty a second no longer changes the value at all, and at a week the
+/// resolution is 62 milliseconds. A display left running in a rack would stop
+/// swaying and start stepping, and then stop moving between frames entirely,
+/// which is the one view whose whole point is that it moves smoothly.
+///
+/// Measured: at a week of uptime, `604800.0f32 + 1.0/60.0 == 604800.0f32`. The
+/// time is gone before any arithmetic touches it.
+pub fn sway_phase(uptime_seconds: f64) -> Elapsed {
+    // `%` rather than `rem_euclid`, which is `std`: this crate has neither, and
+    // an uptime is never negative anyway. `Elapsed` clamps what it is handed.
+    let within = uptime_seconds % f64::from(SWAY_SECONDS);
+    Elapsed::seconds(within as f32)
+}
 
 /// Which of a scene's styles a band wears.
 ///
@@ -220,7 +240,14 @@ impl View {
             // reads as a jolt, and this is the one view whose whole point is
             // that it moves smoothly.
             Self::Swaying => {
-                let turn = TAU * elapsed.as_seconds() / SWAY_SECONDS;
+                // Wrapped into one cycle before it reaches `sin`. rav is left
+                // running: a display in a rack has an uptime measured in days,
+                // and by then `TAU * elapsed / 12` is a number whose argument
+                // reduction has thrown away the low bits - the sway would
+                // coarsen and eventually stall, on the one view whose whole
+                // point is that it moves smoothly.
+                let cycles = elapsed.as_seconds() / SWAY_SECONDS;
+                let turn = TAU * (cycles - floor(cycles));
                 (Transform::turning(0.44 * sin(turn)), across * 3.0)
             }
         };
@@ -433,6 +460,41 @@ mod tests {
                 );
             }
         }
+    }
+
+    #[test]
+    fn a_sway_still_moves_between_frames_after_a_week_of_uptime() {
+        // What `sway_phase` is for, and it is not what it first looked like.
+        // The danger is not that a large angle reaches `sin` badly - `sinf`
+        // reduces its own argument. It is that `Elapsed` holds `f32` *seconds*,
+        // so past about three days one frame at sixty a second stops changing
+        // the number at all: `604800.0f32 + 1.0/60.0 == 604800.0f32`. The time
+        // is gone before any arithmetic touches it, and the picture stops.
+        //
+        // So the wrapping has to happen in `f64`, before the value is narrowed,
+        // and this asks the only question that matters: a frame later, is it a
+        // different angle? Measured on the `sin` entry of the matrix, because
+        // the `cos` one is flat where the sway crosses the middle and would
+        // hide exactly this.
+        let screen = Screen::new(Length(480.0), Length(240.0));
+        let frame = 1.0 / 60.0;
+        let leaning =
+            |uptime: f64| View::Swaying.placing_at(&screen, sway_phase(uptime)).rows()[0][2];
+
+        for uptime in [0.0, 3600.0, 86_400.0, 604_800.0] {
+            assert_ne!(
+                leaning(uptime),
+                leaning(uptime + frame),
+                "after {uptime} seconds up, a frame later was the same angle",
+            );
+        }
+
+        // And a whole number of cycles later is where it started, which is what
+        // makes the wrap a wrap rather than a reset.
+        assert!(
+            (leaning(604_800.0) - leaning(604_800.0 % f64::from(SWAY_SECONDS))).abs() < 1e-6,
+            "a week of cycles drifted out of phase",
+        );
     }
 
     #[test]

--- a/src/bin/kitty_spike.rs
+++ b/src/bin/kitty_spike.rs
@@ -477,6 +477,7 @@ fn paint(frame: &mut [u8], width: u32, tick: u64) {
     Scene {
         bands: &bands,
         view: rav_appearance::View::Flat,
+        elapsed: rav_core::units::Elapsed::seconds(0.0),
         layout,
         screen,
         styles: &styles,

--- a/src/render/raster.rs
+++ b/src/render/raster.rs
@@ -267,7 +267,7 @@ impl Draw for Scene<'_> {
 
         // Computed once: it costs a rotation and a projection of the field's own
         // corners, and it is the same for every band. Only the depth differs.
-        let placing = self.view.placing(screen);
+        let placing = self.view.placing_at(screen, self.elapsed);
 
         let stand = |canvas: &mut Canvas, index: usize| {
             let depth = self.view.depth(index, drawable, screen);
@@ -599,6 +599,7 @@ mod tests {
         Scene {
             bands,
             view: rav_appearance::View::Flat,
+            elapsed: rav_core::units::Elapsed::seconds(0.0),
             layout: layout(10.0, 0.0),
             screen: screen(10.0, 60.0),
             styles,
@@ -841,6 +842,7 @@ mod tests {
             layout: BarLayout::new(Length(40.0), Length(0.0)),
             screen,
             view: rav_appearance::View::Corridor,
+            elapsed: rav_core::units::Elapsed::seconds(0.0),
             styles: &styles,
         };
         let mut canvas = Canvas::for_screen(&screen).unwrap();
@@ -896,6 +898,7 @@ mod tests {
             layout: BarLayout::new(Length(40.0), Length(0.0)),
             screen,
             view: rav_appearance::View::Corridor,
+            elapsed: rav_core::units::Elapsed::seconds(0.0),
             styles: &styles,
         }
         .draw(&mut canvas);

--- a/src/surface/frame.rs
+++ b/src/surface/frame.rs
@@ -236,13 +236,21 @@ mod tests {
             "a whole sway did not come back round",
         );
 
-        // And it crosses the middle rather than swinging to one side: half a
-        // period is the mirror of the start, which is only true of a turn that
-        // passes through square-on.
+        // Back through the middle at half a period. On its own that proves
+        // nothing about which side it went - `abs(sin)` satisfies it too, and a
+        // field that only ever leans one way would pass.
         assert_eq!(
             angled_at(View::Swaying, Elapsed::seconds(0.0)),
             angled_at(View::Swaying, Elapsed::seconds(SWAY_SECONDS / 2.0)),
-            "the sway does not pass back through the middle",
+            "the sway did not come back through the middle",
+        );
+        // So: the quarter and three-quarter points are the two extremes, and
+        // they have to be different pictures. That is what makes it a sway
+        // rather than a lean repeated.
+        assert_ne!(
+            angled_at(View::Swaying, quarter),
+            angled_at(View::Swaying, Elapsed::seconds(SWAY_SECONDS * 3.0 / 4.0)),
+            "both ends of the sway are the same side",
         );
     }
 

--- a/src/surface/frame.rs
+++ b/src/surface/frame.rs
@@ -11,9 +11,11 @@
 
 use crate::render::{Band, Canvas, CapStyle, Draw, Ramp, Scene, Style};
 use crate::visual::{Palette, Theme};
+#[cfg(test)]
+use rav_appearance::scene::SWAY_SECONDS;
 use rav_appearance::{Skin, View};
 use rav_core::geometry::{BarLayout, Screen};
-use rav_core::units::{Length, Level};
+use rav_core::units::{Elapsed, Length, Level};
 
 /// How the picture should look, before any of it is resolved to colours.
 ///
@@ -40,6 +42,8 @@ pub struct Look<'a> {
     /// A cell grid draws `Flat` whatever this says - there is no room in a cell
     /// for a bar that leans - so it reaches only the pixel surface.
     pub view: View,
+    /// How long rav has been running, for the one angle that moves.
+    pub elapsed: Elapsed,
 }
 
 /// Everything a frame needs, held for as long as it takes to draw.
@@ -50,6 +54,7 @@ pub struct Frame {
     cap: Option<CapStyle>,
     ladder: Option<(Skin, Length)>,
     view: View,
+    elapsed: Elapsed,
     layout: BarLayout,
     screen: Screen,
 }
@@ -81,6 +86,7 @@ impl Frame {
             }),
             ladder: look.ladder,
             view: look.view,
+            elapsed: look.elapsed,
             layout,
             screen,
         }
@@ -104,6 +110,7 @@ impl Frame {
             layout: self.layout,
             screen: self.screen,
             view: self.view,
+            elapsed: self.elapsed,
             styles: &styles,
         }
         .draw(&mut canvas);
@@ -141,6 +148,7 @@ mod tests {
         Look {
             theme: Box::leak(Box::new(Theme::default())),
             view: View::Flat,
+            elapsed: Elapsed::seconds(0.0),
             palette: Box::leak(Box::new(Palette::default())),
             backdrop: true,
             caps: None,
@@ -158,6 +166,7 @@ mod tests {
         let look = Look {
             theme: &theme,
             view: View::Flat,
+            elapsed: Elapsed::seconds(0.0),
             palette: &palette,
             backdrop,
             caps,
@@ -170,11 +179,17 @@ mod tests {
 
     /// The same frame at a chosen viewing angle.
     fn angled(view: View) -> Vec<u8> {
+        angled_at(view, Elapsed::seconds(0.0))
+    }
+
+    /// The same, at a moment in a movement - which only `Swaying` reads.
+    fn angled_at(view: View, elapsed: Elapsed) -> Vec<u8> {
         let theme = Theme::default();
         let palette = Palette::default();
         let look = Look {
             theme: &theme,
             view,
+            elapsed,
             palette: &palette,
             backdrop: true,
             caps: Some(Length(2.0)),
@@ -189,6 +204,46 @@ mod tests {
         )
         .pixels()
         .expect("a screen with area")
+    }
+
+    #[test]
+    fn only_the_swaying_field_is_a_different_picture_a_moment_later() {
+        // Motion of the picture rather than motion in it, which is the last of
+        // what #68 asked for - and the reason a scene carries the time at all.
+        // Every other angle is a setting: the same levels drawn a second later
+        // are the same bytes, and a surface that redrew them would be spending
+        // a frame to send what the terminal already has.
+        let quarter = Elapsed::seconds(SWAY_SECONDS / 4.0);
+        for still in [View::Flat, View::Raked, View::Turned, View::Corridor] {
+            assert_eq!(
+                angled_at(still, Elapsed::seconds(0.0)),
+                angled_at(still, quarter),
+                "{} moved, and nothing but the sway should",
+                still.label(),
+            );
+        }
+        assert_ne!(
+            angled_at(View::Swaying, Elapsed::seconds(0.0)),
+            angled_at(View::Swaying, quarter),
+            "the swaying field stood still",
+        );
+
+        // A full period brings it back where it started, so the motion is a
+        // cycle rather than a drift that eventually faces backwards.
+        assert_eq!(
+            angled_at(View::Swaying, Elapsed::seconds(0.0)),
+            angled_at(View::Swaying, Elapsed::seconds(SWAY_SECONDS)),
+            "a whole sway did not come back round",
+        );
+
+        // And it crosses the middle rather than swinging to one side: half a
+        // period is the mirror of the start, which is only true of a turn that
+        // passes through square-on.
+        assert_eq!(
+            angled_at(View::Swaying, Elapsed::seconds(0.0)),
+            angled_at(View::Swaying, Elapsed::seconds(SWAY_SECONDS / 2.0)),
+            "the sway does not pass back through the middle",
+        );
     }
 
     #[test]
@@ -447,6 +502,7 @@ mod tests {
         let look = Look {
             theme: &theme,
             view: View::Flat,
+            elapsed: Elapsed::seconds(0.0),
             palette: &palette,
             backdrop: false,
             caps: None,
@@ -530,6 +586,7 @@ mod tests {
         let look = Look {
             theme: &theme,
             view: View::Flat,
+            elapsed: Elapsed::seconds(0.0),
             palette: &palette,
             backdrop: false,
             caps: None,
@@ -571,6 +628,7 @@ mod tests {
         let look = Look {
             theme: &theme,
             view: View::Flat,
+            elapsed: Elapsed::seconds(0.0),
             palette: &palette,
             backdrop: false,
             caps: None,
@@ -658,6 +716,7 @@ mod against_the_glyphs {
         let look = Look {
             theme: &theme,
             view: View::Flat,
+            elapsed: Elapsed::seconds(0.0),
             palette: &palette,
             backdrop: false,
             caps: None,

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -271,8 +271,12 @@ pub struct App {
     /// Whether the first non-silent tap buffer has been seen.
     #[cfg(target_os = "macos")]
     tap_reported: bool,
-    /// When the analyser started, for the silent-tap warning below.
-    #[cfg(target_os = "macos")]
+    /// When the analyser started.
+    ///
+    /// Two readers, and neither is optional on one platform: the silent-tap
+    /// warning below is macOS-only, and a swaying view is not - it needs to
+    /// know how far through its cycle it is, on every surface that can draw
+    /// one.
     started: Instant,
     should_quit: bool,
     last_frame: Instant,
@@ -350,7 +354,6 @@ impl App {
             tap_scratch: Vec::new(),
             #[cfg(target_os = "macos")]
             tap_reported: false,
-            #[cfg(target_os = "macos")]
             started: Instant::now(),
             should_quit: false,
             last_frame: Instant::now(),
@@ -483,7 +486,7 @@ impl App {
         use crate::surface::frame::{Frame, Look};
         use crate::surface::overlay;
         use rav_core::geometry::Screen;
-        use rav_core::units::{CellSize, Cells, Elapsed, Length};
+        use rav_core::units::{CellSize, Cells, Length};
 
         // Only the analyser is drawn as pixels. The oscilloscope is still block
         // characters, so `space` has to hand the screen back rather than leave
@@ -519,10 +522,14 @@ impl App {
             // same picture, and a ladder on its own pitch would not be.
             ladder: Some((self.bar_style.skin(), cell.down(Cells(1)))),
             view: self.view,
-            // Measured from the clock rather than counted in frames: a sway
-            // paced by frames would cross faster on a terminal that repaints
-            // quickly, which is the mistake the ballistics already avoid.
-            elapsed: Elapsed::from_secs_f32(self.started.elapsed().as_secs_f32()),
+            // From the clock rather than counted in frames: a sway paced by
+            // frames would cross faster on a terminal that repaints quickly,
+            // which is the mistake the ballistics already avoid.
+            //
+            // Wrapped into one cycle in `f64` first - see `sway_phase`, which
+            // is where the reason is written down. Sending the raw uptime
+            // would work all day and then quietly stop moving.
+            elapsed: rav_appearance::scene::sway_phase(self.started.elapsed().as_secs_f64()),
         };
         // `coarse` and `fine` are the same cap on a cell grid - one position per
         // row is all a cell offers - so the difference has to be made here or

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -483,7 +483,7 @@ impl App {
         use crate::surface::frame::{Frame, Look};
         use crate::surface::overlay;
         use rav_core::geometry::Screen;
-        use rav_core::units::{CellSize, Cells, Length};
+        use rav_core::units::{CellSize, Cells, Elapsed, Length};
 
         // Only the analyser is drawn as pixels. The oscilloscope is still block
         // characters, so `space` has to hand the screen back rather than leave
@@ -519,6 +519,10 @@ impl App {
             // same picture, and a ladder on its own pitch would not be.
             ladder: Some((self.bar_style.skin(), cell.down(Cells(1)))),
             view: self.view,
+            // Measured from the clock rather than counted in frames: a sway
+            // paced by frames would cross faster on a terminal that repaints
+            // quickly, which is the mistake the ballistics already avoid.
+            elapsed: Elapsed::from_secs_f32(self.started.elapsed().as_secs_f32()),
         };
         // `coarse` and `fine` are the same cap on a cell grid - one position per
         // row is all a cell offers - so the difference has to be made here or
@@ -2375,7 +2379,7 @@ mod tests {
             because: "for the test",
         };
         assert_eq!(a.view, View::Flat, "rav does not open at an angle");
-        for expected in ["raked", "turned", "corridor", "flat"] {
+        for expected in ["raked", "turned", "corridor", "swaying", "flat"] {
             a.apply(Action::CycleView);
             assert_eq!(a.view.label(), expected);
             let row = a


### PR DESCRIPTION
The last bullet of #68: *"The whole field turning slowly, or leaning with the beat. Motion of the picture, not just motion in it."* `v` gains a fifth position after `corridor`, and it is the only one that is not the same picture twice.

**It sways rather than turning all the way round.** A field edge-on to the viewer has no area at all — #115 already has the test — so a full rotation would take the picture away twice a turn, which reads as a fault rather than as motion. A sine rather than a sawtooth, because a fold at each end reads as a jolt and this is the one view whose whole point is that it moves smoothly. Twelve seconds a cycle, between the same extremes `turned` holds still at.

Rendered at three points of the cycle: square-on as it crosses the middle, turned at the extreme, and back. It passes *through* flat twice a cycle rather than swinging to one side, which is only true of a turn centred on zero — asserted, not eyeballed.

**The time comes from the clock, not from a frame count.** A sway paced by frames would cross faster on a terminal that repaints quickly, which is exactly the mistake the ballistics already avoid — and the reason `Elapsed` takes a duration rather than reading a clock itself, since a core cannot have one.

**A scene carries the time now**, which is the part worth arguing about. It is the honest model rather than a convenience: a scene is what to draw *now*, and once anything moves, "now" is part of what a surface is being asked for. The alternative was to let the view compute its own angle from a clock it holds, which puts a clock in `rav-appearance` — a `no_std` crate that has just been made to prove it can build for a machine with no operating system.

**Nothing else started moving**, and there is a test for it: the same levels drawn a second later are the same bytes for flat, raked, turned and corridor. A surface redrawing those would be spending a frame to send what the terminal already has.

424 tests. README key row updated; `v` still refuses on block characters and on the oscilloscope.