### PR TITLE
feat: a skin can be a drawing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -364,6 +370,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "crossterm"
 version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -429,6 +444,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c87e182de0887fd5361989c677c4e8f5000cd9491d6d563161a8f3a5519fc7f"
 
 [[package]]
+name = "data-url"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be1e0bca6c3637f992fc1cc7cbc52a78c1ef6db076dbf1059c4323d6a2048376"
+
+[[package]]
 name = "dirs"
 version = "5.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -482,16 +503,50 @@ dependencies = [
 ]
 
 [[package]]
+name = "euclid"
+version = "0.22.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1a05365e3b1c6d1650318537c7460c6923f1abdd272ad6842baa2b509957a06"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
 
 [[package]]
+name = "fdeflate"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
+dependencies = [
+ "simd-adler32",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26b73573e6edcd2af0cdf47bd6cb58f0b3839491263c314eaad1ccf24430e1de"
+
+[[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
+
+[[package]]
+name = "float-cmp"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98de4bbd547a563b716d8dfa9aad1cb19bfab00f4fa09a6a4ed21dbcf44ce9c4"
 
 [[package]]
 name = "flume"
@@ -619,6 +674,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
+name = "imagesize"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65b27460c2c92b037f3f94c538ed9a3342f3fdf923606781629ccb35f82d042a"
+
+[[package]]
 name = "indexmap"
 version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -737,6 +798,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "kurbo"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b60dfc32f652b926df6192e55525b16d186c69d47876c3ead4da5cc9f8450e2"
+dependencies = [
+ "arrayvec",
+ "euclid",
+ "polycool",
+ "smallvec",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -838,6 +911,16 @@ name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
 
 [[package]]
 name = "mio"
@@ -1078,6 +1161,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
+name = "pico-args"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5be167a7af36ee22fe3115051bc51f6e6c7054c9348e28deb4f49bd6f705a315"
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1088,6 +1177,28 @@ name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+
+[[package]]
+name = "png"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61"
+dependencies = [
+ "bitflags 2.13.1",
+ "crc32fast",
+ "fdeflate",
+ "flate2",
+ "miniz_oxide",
+]
+
+[[package]]
+name = "polycool"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50596ddc09eb5ad5f75cacd40209568e66df71baf86e1499a0e99c4cff12a5a6"
+dependencies = [
+ "arrayvec",
+]
 
 [[package]]
 name = "ppv-lite86"
@@ -1248,6 +1359,7 @@ dependencies = [
  "rav-appearance",
  "rav-core",
  "realfft",
+ "resvg",
  "rustfft",
  "serde",
  "tiny-skia",
@@ -1255,6 +1367,7 @@ dependencies = [
  "toml",
  "tracing",
  "tracing-subscriber",
+ "usvg",
 ]
 
 [[package]]
@@ -1330,6 +1443,39 @@ name = "regex-syntax"
 version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
+
+[[package]]
+name = "resvg"
+version = "0.48.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67e3803f97b999e80cbf7c6ecdd07a8102204d92e1633cf48783720c521196bd"
+dependencies = [
+ "bytemuck",
+ "log",
+ "pico-args",
+ "rgb",
+ "svgtypes",
+ "tiny-skia",
+ "usvg",
+]
+
+[[package]]
+name = "rgb"
+version = "0.8.53"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b34b781b31e5d73e9fbc8689c70551fd1ade9a19e3e28cfec8580a79290cc4"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
+name = "roxmltree"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1964b10c76125c36f8afe190065a4bf9a87bf324842c05701330bba9f1cacbb"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "rustc-hash"
@@ -1508,6 +1654,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "simd-adler32"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a219298ac11a56ea9a6d2120044824d6f01aeb034955e7af7bc16858527deea"
+
+[[package]]
+name = "simplecss"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a9c6883ca9c3c7c90e888de77b7a5c849c779d25d74a1269b0218b14e8b136c"
+dependencies = [
+ "log",
+]
+
+[[package]]
+name = "siphasher"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1555,6 +1722,9 @@ name = "strict-num"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6637bab7722d379c8b41ba849228d680cc12d0a45ba1fa2b48f2a30577a06731"
+dependencies = [
+ "float-cmp",
+]
 
 [[package]]
 name = "strsim"
@@ -1582,6 +1752,16 @@ dependencies = [
  "quote",
  "rustversion",
  "syn 2.0.119",
+]
+
+[[package]]
+name = "svgtypes"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "695b5790b3131dafa99b3bbfd25a216edb3d216dad9ca208d4657bfb8f2abc3d"
+dependencies = [
+ "kurbo",
+ "siphasher",
 ]
 
 [[package]]
@@ -1659,6 +1839,7 @@ dependencies = [
  "bytemuck",
  "cfg-if",
  "log",
+ "png",
  "tiny-skia-path",
 ]
 
@@ -1877,6 +2058,25 @@ name = "unicode-width"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
+
+[[package]]
+name = "usvg"
+version = "0.48.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "977d0a4abdef933f424a99fe09f95576e089b90aebc6f016a3bc813762493e91"
+dependencies = [
+ "data-url",
+ "imagesize",
+ "kurbo",
+ "log",
+ "pico-args",
+ "roxmltree",
+ "simplecss",
+ "siphasher",
+ "strict-num",
+ "svgtypes",
+ "tiny-skia-path",
+]
 
 [[package]]
 name = "utf8parse"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -110,6 +110,8 @@ clap = { version = "4.5", features = ["derive"] }
 libc = "0.2"
 
 dirs = "5.0"
+resvg = { version = "0.48", default-features = false }
+usvg = { version = "0.48", default-features = false }
 
 [[bin]]
 name = "rav"

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Everything else is a keypress, and `h` shows the lot with their current values:
 | `q` / `Esc` | quit |
 | `Space` / `Tab` / `o` | switch analyser ↔ oscilloscope |
 | `t` | theme — rav, winamp, terminal, mono |
-| `b` | bar style — blocks, solid, thick, half, line, shade |
+| `b` | bar style — blocks, solid, thick, half, line, segment, shade |
 | `v` | viewing angle — flat, raked, turned, corridor, swaying; pixels only |
 | `p` | peak caps — fine, coarse, off |
 | `g` | grid behind the bars, on/off |

--- a/assets/skins/segment.svg
+++ b/assets/skins/segment.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" preserveAspectRatio="none">
+  <!-- One rung of the `segment` ladder: a lozenge with its ends cut off, the
+       shape a bar-graph LED has on a rack unit. Drawn as a mask, so only the
+       alpha matters and the fill is whatever the theme gives at that height -
+       see `render::sprite`.
+
+       A seam at the top and bottom, like every ladder rav draws, so a stack of
+       these reads as segments rather than as one bar. The corners are the part
+       no fraction of a rectangle can express, which is the whole reason this is
+       a drawing. -->
+  <path fill="#ffffff"
+        d="M 14 6
+           H 86
+           L 96 24
+           V 76
+           L 86 94
+           H 14
+           L 4 76
+           V 24
+           Z"/>
+</svg>

--- a/flake.nix
+++ b/flake.nix
@@ -19,16 +19,20 @@
           inherit (pkgs) lib stdenv;
           craneLib = crane.mkLib pkgs;
 
-          # src/visual/theme.rs pulls crates/rav-appearance/themes/*.toml in with
-          # have to survive filtering. crane's filter keeps every .toml today,
-          # which covers them incidentally rather than deliberately; the second
-          # clause states the requirement so a narrower filter upstream cannot
-          # quietly break the build.
+          # Two kinds of file are pulled in with `include_str!` and so have to
+          # survive filtering, and crane's filter keeps neither on purpose: the
+          # themes under crates/rav-appearance/themes/, which it happens to keep
+          # because they are `.toml`, and the skin artwork under assets/skins/,
+          # which it would drop outright. Both clauses state the requirement, so
+          # a narrower filter upstream cannot quietly break the build - and a
+          # missing skin is a build failure here and nowhere else, since `cargo
+          # build` reads the working tree and a flake only sees what git tracks.
           src = lib.cleanSourceWith {
             src = ./.;
             filter = path: type:
               (craneLib.filterCargoSources path type)
-              || (lib.hasInfix "/themes/" path);
+              || (lib.hasInfix "/themes/" path)
+              || (lib.hasInfix "/assets/skins/" path);
             name = "source";
           };
 

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -15,6 +15,7 @@ pub use rav_appearance::{ink, ramp, scene};
 pub use rav_core::{capability, geometry};
 
 pub mod raster;
+pub mod sprite;
 
 pub use capability::{Capabilities, Requirements, Shortfall};
 pub use geometry::{Anchor, BarLayout, Column, Rectangle, Screen};

--- a/src/render/raster.rs
+++ b/src/render/raster.rs
@@ -21,6 +21,20 @@ pub struct Canvas {
     pixmap: Pixmap,
     placing: Transform,
     antialias: bool,
+    /// A drawn rung, for a skin that is artwork rather than arithmetic.
+    ///
+    /// Held here rather than on the scene because a scene comes from
+    /// `rav-appearance`, which is `no_std` and cannot hold a rasterised
+    /// anything. The scene still says how many steps a ladder has and what
+    /// shape a rung is; this is the surface saying it also has a picture of
+    /// one. A surface without it draws exactly what it drew before.
+    artwork: Option<crate::render::sprite::Sprite>,
+    /// The whole ladder as one shape, and the geometry it was built for.
+    ///
+    /// Rebuilt when the screen or the rung changes and not otherwise: the grid
+    /// a bar climbs is fixed for as long as the window is, and only how much of
+    /// it is lit changes between frames.
+    ladder: Option<((u32, u32, u32), tiny_skia::Mask)>,
 }
 
 impl Canvas {
@@ -31,6 +45,8 @@ impl Canvas {
             pixmap,
             placing: Transform::IDENTITY,
             antialias: true,
+            artwork: None,
+            ladder: None,
         })
     }
 
@@ -51,6 +67,28 @@ impl Canvas {
 
     pub fn antialias(&mut self, on: bool) {
         self.antialias = on;
+    }
+
+    /// Draw the ladder's rungs from this picture instead of from its
+    /// fractions, for as long as the rungs are the size it was drawn for.
+    ///
+    /// Rasterised once per size by the caller, because a rung is a fixed size
+    /// for as long as the window is and parsing an SVG sixty times a second
+    /// would cost more than every bar rav draws put together.
+    pub fn wants_artwork(&mut self, svg: &'static str, across: u32, down: u32) {
+        // Already have it, at the size it is wanted: which is every frame but
+        // the first and the one after a resize. Parsing and rasterising the SVG
+        // is 0.44 ms, and the ladder it stamps is 8.6 - both of which the frame
+        // budget has no room for sixty times a second.
+        if self
+            .artwork
+            .as_ref()
+            .is_some_and(|had| had.is(svg) && had.fits(across, down))
+        {
+            return;
+        }
+        self.artwork = crate::render::sprite::Sprite::drawn(svg, across, down);
+        self.ladder = None;
     }
 
     /// Sized to hold a screen exactly.
@@ -165,6 +203,69 @@ impl Canvas {
             SkTransform::identity(),
             None,
         );
+    }
+
+    /// Paint a row of bars through the drawn ladder, if there is one to use.
+    ///
+    /// `false` when there is not, which is the caller's cue to draw the shape
+    /// the skin describes instead. The colour still comes from the ramp: the
+    /// drawing is taken as a mask, so it decides the shape and the theme decides
+    /// what colour that height is - which is the invariant every surface here
+    /// keeps, and the one thing a skin must not be able to override.
+    ///
+    /// Under a transform this declines. A clip is in the pixmap's own
+    /// coordinates and a leaning bar is not where its rectangle is, so the mask
+    /// and the fill would disagree - and half a bar shaped right is worse than a
+    /// whole one shaped plainly.
+    fn fill_through_ladder(
+        &mut self,
+        bars: &[Rectangle],
+        rung: Length,
+        ramp: &Ramp,
+        screen: &Screen,
+    ) -> bool {
+        if !self.placing.is_identity() || bars.is_empty() {
+            return false;
+        }
+        let (across, down) = (self.pixmap.width(), self.pixmap.height());
+        let wanted = (across, down, rung.get().to_bits());
+        if self.ladder.as_ref().is_none_or(|(had, _)| *had != wanted) {
+            let Some(artwork) = self.artwork.as_ref() else {
+                return false;
+            };
+            if !artwork.fits(bars[0].width().rounded_up(), rung.rounded_up()) {
+                return false;
+            }
+            let Some(mask) = artwork.ladder(across, down, bars, rung.get()) else {
+                return false;
+            };
+            self.ladder = Some((wanted, mask));
+        }
+        let Some((_, mask)) = &self.ladder else {
+            return false;
+        };
+
+        for stripe in ramp.stripes(screen.height()) {
+            let mut paint = Paint::default();
+            let colour = stripe.colour;
+            paint.set_color_rgba8(colour.red, colour.green, colour.blue, colour.alpha);
+            paint.anti_alias = self.antialias;
+            for bar in bars {
+                if let Some(part) = stripe.clip(*bar) {
+                    let Some(rect) = SkRect::from_xywh(
+                        part.left().get(),
+                        part.top().get(),
+                        part.width().get(),
+                        part.height().get(),
+                    ) else {
+                        continue;
+                    };
+                    self.pixmap
+                        .fill_rect(rect, &paint, SkTransform::identity(), Some(mask));
+                }
+            }
+        }
+        true
     }
 
     /// Paint one rectangle in whatever colour the ramp gives at each height.
@@ -442,6 +543,12 @@ fn draw_ladders(
 ) {
     if rung.get() <= 0.0 {
         canvas.fill_many_ramped_at(bars, ramp, screen, 1.0);
+        return;
+    }
+    // A drawn skin, if the surface has the picture and can use it. It declines
+    // for a size it was not drawn at and under any transform, and then the
+    // fractions below draw the ladder they always drew.
+    if canvas.fill_through_ladder(bars, rung, ramp, screen) {
         return;
     }
     let shape = skin.rung;

--- a/src/render/raster.rs
+++ b/src/render/raster.rs
@@ -11,6 +11,22 @@ use rav_core::transform::Transform;
 use rav_core::units::Length;
 use tiny_skia::{Paint, PathBuilder, Pixmap, Rect as SkRect, Transform as SkTransform};
 
+/// The geometry a stamped ladder was built for.
+///
+/// Everything the mask depends on and nothing that changes per frame, so it
+/// answers "is the one I have still the right one" exactly rather than nearly.
+#[derive(PartialEq)]
+struct Ladder {
+    across: u32,
+    down: u32,
+    /// The rung height, by its bits: a key is compared, never ordered, and
+    /// float equality on a value that came from the same arithmetic is what is
+    /// wanted here.
+    rung: u32,
+    /// Where each column starts and how wide it is.
+    columns: Vec<(u32, u32)>,
+}
+
 /// An RGBA buffer that geometry is drawn into.
 ///
 /// Owns a `tiny_skia::Pixmap` rather than exposing it, because the pixels leave
@@ -34,7 +50,7 @@ pub struct Canvas {
     /// Rebuilt when the screen or the rung changes and not otherwise: the grid
     /// a bar climbs is fixed for as long as the window is, and only how much of
     /// it is lit changes between frames.
-    ladder: Option<((u32, u32, u32), tiny_skia::Mask)>,
+    ladder: Option<(Ladder, tiny_skia::Mask)>,
 }
 
 impl Canvas {
@@ -228,7 +244,24 @@ impl Canvas {
             return false;
         }
         let (across, down) = (self.pixmap.width(), self.pixmap.height());
-        let wanted = (across, down, rung.get().to_bits());
+        // Keyed on where the columns actually are, not on the screen and the
+        // rung alone. `w` changes how many bands there are and `+` changes how
+        // wide they are, and either can leave the screen and the rung exactly as
+        // they were - so a key without the columns hands back a mask stamped for
+        // a different set of bars, and the ladder stops lining up with them.
+        //
+        // Their heights are deliberately not in it: those change sixty times a
+        // second and the mask does not depend on them, which is the whole reason
+        // it can be cached at all.
+        let wanted = Ladder {
+            across,
+            down,
+            rung: rung.get().to_bits(),
+            columns: bars
+                .iter()
+                .map(|bar| (bar.left().get().to_bits(), bar.width().get().to_bits()))
+                .collect(),
+        };
         if self.ladder.as_ref().is_none_or(|(had, _)| *had != wanted) {
             let Some(artwork) = self.artwork.as_ref() else {
                 return false;

--- a/src/render/sprite.rs
+++ b/src/render/sprite.rs
@@ -50,7 +50,10 @@ impl Sprite {
     /// `None` for artwork that will not parse or a rung with no area - a skin
     /// file someone is editing, or a terminal mid-resize. Both are a reason to
     /// draw the plain ladder, not to stop drawing.
-    pub fn drawn(svg: &str, across: u32, down: u32) -> Option<Self> {
+    /// `'static` because the identity check below is by address: every skin
+    /// here is an `include_str!`, and a borrowed buffer would give the same
+    /// pointer to two different drawings once it was reused.
+    pub fn drawn(svg: &'static str, across: u32, down: u32) -> Option<Self> {
         if across == 0 || down == 0 {
             return None;
         }
@@ -144,7 +147,7 @@ mod tests {
         <rect width="10" height="10" fill="#fff"/></svg>"##;
 
     /// How much of the rung the drawing covers, 0 to 1.
-    fn coverage(svg: &str, across: u32, down: u32) -> f32 {
+    fn coverage(svg: &'static str, across: u32, down: u32) -> f32 {
         let sprite = Sprite::drawn(svg, across, down).expect("it should draw");
         let one = Rectangle::new(
             Length(0.0),

--- a/src/render/sprite.rs
+++ b/src/render/sprite.rs
@@ -1,0 +1,211 @@
+//! A skin that is a drawing rather than a fraction of a rectangle.
+//!
+//! Every ladder rav has drawn so far is arithmetic: `▇` is the lower seven
+//! eighths of a rung, `━` a stroke across the middle. That is enough for the
+//! shapes a terminal already has, and it is the whole vocabulary a rectangle
+//! offers. A skin with a rounded end, a bevel or a notch cannot be written that
+//! way at all, and this is where those come from.
+//!
+//! # Why it is here and not in `rav-appearance`
+//!
+//! Parsing SVG needs an allocator, a filesystem-shaped API and about twenty
+//! crates. `rav-appearance` is `no_std` and has a check proving it builds for a
+//! machine with no operating system, so the artwork cannot live beside the model
+//! that describes it. The split is the honest one rather than a compromise: a
+//! skin still says *how many steps* it has and *what shape a rung is* in terms
+//! anything can read - a terminal picks a character, an LED strip picks a
+//! brightness - and a surface that can rasterise may additionally have a picture
+//! for it. One that cannot draws what it always drew.
+//!
+//! # The drawing gives shape, never colour
+//!
+//! The ramp still decides what colour a height is. That invariant is older than
+//! the pixel surface and is the reason a bar reddens as it rises rather than as
+//! it gets louder, so a skin is taken as a **mask**: its alpha is the shape, and
+//! the fill underneath is whatever the ramp gives at that height. An SVG whose
+//! own colours were used would be a skin overriding the theme, which is the one
+//! thing the appearance layer exists to prevent.
+//!
+//! # Rasterised once, not per frame
+//!
+//! A rung is a fixed size for as long as the window is, so the drawing is turned
+//! into pixels when that size changes and blitted after. Parsing and tessellating
+//! an SVG sixty times a second is the obvious trap and would cost more than
+//! every bar rav draws put together.
+
+use rav_core::geometry::Rectangle;
+use tiny_skia::{Mask, MaskType, Pixmap, PixmapPaint, Transform as SkTransform};
+
+/// One skin's artwork, rasterised for a rung of a particular size.
+pub struct Sprite {
+    art: Pixmap,
+    from: *const u8,
+    across: u32,
+    down: u32,
+}
+
+impl Sprite {
+    /// Parse an SVG and rasterise it to fill a rung of this size.
+    ///
+    /// `None` for artwork that will not parse or a rung with no area - a skin
+    /// file someone is editing, or a terminal mid-resize. Both are a reason to
+    /// draw the plain ladder, not to stop drawing.
+    pub fn drawn(svg: &str, across: u32, down: u32) -> Option<Self> {
+        if across == 0 || down == 0 {
+            return None;
+        }
+        // No fonts, no raster images, no system anything: a skin is shapes, and
+        // the alternative is dragging a font stack into a spectrum analyser.
+        let tree = usvg::Tree::from_str(svg, &usvg::Options::default()).ok()?;
+        let mut pixmap = Pixmap::new(across, down)?;
+        let size = tree.size();
+        // Stretched to the rung rather than fitted inside it. A rung is the unit
+        // the ladder is built from and its proportions come from the cell, which
+        // is the terminal's to choose - so a skin that insisted on its own
+        // aspect would leave gaps the theme never asked for.
+        let fill =
+            SkTransform::from_scale(across as f32 / size.width(), down as f32 / size.height());
+        resvg::render(&tree, fill, &mut pixmap.as_mut());
+        Some(Self {
+            art: pixmap,
+            // Which artwork this was drawn from, by address. Every skin here is
+            // an `include_str!`, so one `&'static str` per skin and comparing
+            // the pointer answers "is this still the same drawing" without
+            // comparing kilobytes of XML on every frame.
+            from: svg.as_ptr(),
+            across,
+            down,
+        })
+    }
+
+    /// Whether this was drawn for a rung of that size.
+    ///
+    /// The whole of the caching rule: a rung is a fixed size for as long as the
+    /// window is, so the answer is yes on every frame but the one after a
+    /// resize.
+    /// Whether this was drawn from that artwork.
+    pub fn is(&self, svg: &'static str) -> bool {
+        std::ptr::eq(self.from, svg.as_ptr())
+    }
+
+    pub fn fits(&self, across: u32, down: u32) -> bool {
+        self.across == across && self.down == down
+    }
+
+    /// A whole screen's worth of ladder, as one shape to fill through.
+    ///
+    /// Every rung position of every column, stamped up the full height rather
+    /// than up each bar - because a bar's height changes sixty times a second
+    /// and the *grid* it climbs does not. So this is built when the window
+    /// changes size and not again, and a frame clips it to whatever the bars
+    /// currently reach.
+    ///
+    /// One mask rather than one per rung: a clip is in the pixmap's own
+    /// coordinates, so a per-rung mask would be a screen-sized allocation
+    /// apiece - about nineteen hundred of them a frame at eighty bands.
+    pub fn ladder(&self, across: u32, down: u32, columns: &[Rectangle], rung: f32) -> Option<Mask> {
+        if rung <= 0.0 || across == 0 || down == 0 {
+            return None;
+        }
+        let mut stamped = Pixmap::new(across, down)?;
+        let paint = PixmapPaint::default();
+        for column in columns {
+            let left = column.left().get();
+            // From the floor up, which is the way a bar grows and therefore the
+            // way the seams have to line up.
+            let mut top = down as f32 - rung;
+            while top > -rung {
+                stamped.draw_pixmap(
+                    left as i32,
+                    top as i32,
+                    self.art.as_ref(),
+                    &paint,
+                    SkTransform::identity(),
+                    None,
+                );
+                top -= rung;
+            }
+        }
+        Some(Mask::from_pixmap(stamped.as_ref(), MaskType::Alpha))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rav_core::units::Length;
+
+    /// A circle inside its box, which no ladder of rectangles can be.
+    const DOT: &str = r##"<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 10 10">
+        <circle cx="5" cy="5" r="5" fill="#fff"/></svg>"##;
+
+    /// The whole box, for comparing against.
+    const SLAB: &str = r##"<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 10 10">
+        <rect width="10" height="10" fill="#fff"/></svg>"##;
+
+    /// How much of the rung the drawing covers, 0 to 1.
+    fn coverage(svg: &str, across: u32, down: u32) -> f32 {
+        let sprite = Sprite::drawn(svg, across, down).expect("it should draw");
+        let one = Rectangle::new(
+            Length(0.0),
+            Length(0.0),
+            Length(across as f32),
+            Length(down as f32),
+        );
+        let mask = sprite
+            .ladder(across, down, &[one], down as f32)
+            .expect("a ladder of one rung");
+        let covered: u32 = mask.data().iter().map(|&a| u32::from(a)).sum();
+        covered as f32 / (across * down * 255) as f32
+    }
+
+    #[test]
+    fn a_drawing_covers_what_it_draws_and_not_the_box_around_it() {
+        // The point of the exercise: a shape a rectangle cannot be. A circle
+        // inscribed in its box covers pi/4 of it - about 0.785 - and a slab
+        // covers all of it. If the mask were the bounding box, both would be 1.
+        let dot = coverage(DOT, 64, 64);
+        assert!(
+            (dot - 0.785).abs() < 0.01,
+            "a circle covered {dot} of its box, not about pi/4",
+        );
+        assert!(
+            (coverage(SLAB, 64, 64) - 1.0).abs() < 0.01,
+            "a slab is solid"
+        );
+    }
+
+    #[test]
+    fn a_drawing_is_stretched_to_whatever_a_rung_is() {
+        // A rung's proportions come from the terminal's cell, which is nobody's
+        // choice here. The same drawing has to fill a tall thin rung and a short
+        // wide one, so its coverage is the same fraction of either.
+        let tall = coverage(DOT, 16, 96);
+        let wide = coverage(DOT, 96, 16);
+        assert!(
+            (tall - wide).abs() < 0.02,
+            "the same drawing covered {tall} of a tall rung and {wide} of a wide one",
+        );
+    }
+
+    #[test]
+    fn artwork_that_will_not_parse_is_no_reason_to_stop_drawing() {
+        // A skin file someone is halfway through editing. The caller falls back
+        // to the plain ladder, which is a picture rather than an error.
+        assert!(Sprite::drawn("not an svg at all", 32, 32).is_none());
+        assert!(Sprite::drawn(SLAB, 0, 32).is_none(), "a rung with no width");
+        assert!(
+            Sprite::drawn(SLAB, 32, 0).is_none(),
+            "a rung with no height"
+        );
+    }
+
+    #[test]
+    fn a_sprite_knows_when_it_is_the_wrong_size() {
+        // The whole caching rule. Rasterising an SVG sixty times a second would
+        // cost more than every bar rav draws put together.
+        let sprite = Sprite::drawn(SLAB, 30, 60).unwrap();
+        assert!(sprite.fits(30, 60));
+        assert!(!sprite.fits(30, 61), "a resize has to redraw it");
+    }
+}

--- a/src/surface/frame.rs
+++ b/src/surface/frame.rs
@@ -44,6 +44,11 @@ pub struct Look<'a> {
     pub view: View,
     /// How long rav has been running, for the one angle that moves.
     pub elapsed: Elapsed,
+    /// The skin's artwork, for a skin that is a drawing.
+    ///
+    /// `None` for every ladder made of fractions, which is all of them but one
+    /// - and for a cell grid, which has no way to draw a picture and says so.
+    pub artwork: Option<&'static str>,
 }
 
 /// Everything a frame needs, held for as long as it takes to draw.
@@ -55,6 +60,7 @@ pub struct Frame {
     ladder: Option<(Skin, Length)>,
     view: View,
     elapsed: Elapsed,
+    artwork: Option<&'static str>,
     layout: BarLayout,
     screen: Screen,
 }
@@ -87,6 +93,7 @@ impl Frame {
             ladder: look.ladder,
             view: look.view,
             elapsed: look.elapsed,
+            artwork: look.artwork,
             layout,
             screen,
         }
@@ -98,7 +105,27 @@ impl Frame {
     /// [`super::pixels`], which never encodes them.
     pub fn pixels(&self) -> Option<Vec<u8>> {
         let mut canvas = Canvas::for_screen(&self.screen)?;
+        self.painted_onto(&mut canvas);
+        Some(canvas.to_rgba())
+    }
+
+    /// The same, onto a canvas the caller keeps.
+    ///
+    /// Which is what the render loop does, and the difference is not tidiness.
+    /// A canvas made fresh each frame throws away everything expensive it
+    /// learned: at 2400x1440 that is a 13.8 MB pixmap allocated and dropped
+    /// sixty times a second, and - for a skin that is a drawing - a whole
+    /// screen's worth of ladder stamped again from nothing, measured at
+    /// **8.6 ms** against a frame budget of 16.7. Handed the same canvas back,
+    /// it keeps both, and the drawn skin costs about what the block one does.
+    pub fn painted_onto(&self, canvas: &mut Canvas) {
         canvas.clear();
+        // A drawn skin, rasterised to whatever a rung is on this terminal. The
+        // canvas declines it at any other size and under any transform, so this
+        // is an offer rather than an instruction.
+        if let (Some(svg), Some((_, rung))) = (self.artwork, self.ladder) {
+            canvas.wants_artwork(svg, self.layout.bar_width().rounded_up(), rung.rounded_up());
+        }
         let styles = [Style {
             bars: &self.bars,
             grid: self.grid.as_ref(),
@@ -113,8 +140,7 @@ impl Frame {
             elapsed: self.elapsed,
             styles: &styles,
         }
-        .draw(&mut canvas);
-        Some(canvas.to_rgba())
+        .draw(canvas);
     }
 }
 
@@ -149,6 +175,7 @@ mod tests {
             theme: Box::leak(Box::new(Theme::default())),
             view: View::Flat,
             elapsed: Elapsed::seconds(0.0),
+            artwork: None,
             palette: Box::leak(Box::new(Palette::default())),
             backdrop: true,
             caps: None,
@@ -167,6 +194,7 @@ mod tests {
             theme: &theme,
             view: View::Flat,
             elapsed: Elapsed::seconds(0.0),
+            artwork: None,
             palette: &palette,
             backdrop,
             caps,
@@ -190,6 +218,7 @@ mod tests {
             theme: &theme,
             view,
             elapsed,
+            artwork: None,
             palette: &palette,
             backdrop: true,
             caps: Some(Length(2.0)),
@@ -204,6 +233,70 @@ mod tests {
         )
         .pixels()
         .expect("a screen with area")
+    }
+
+    /// The same frame with and without a drawn skin.
+    fn skinned(artwork: Option<&'static str>) -> Vec<u8> {
+        let theme = Theme::default();
+        let palette = Palette::default();
+        let look = Look {
+            theme: &theme,
+            view: View::Flat,
+            elapsed: Elapsed::seconds(0.0),
+            artwork,
+            palette: &palette,
+            backdrop: false,
+            caps: None,
+            ladder: Some((rav_appearance::skin::ladders::BLOCKS, Length(20.0))),
+        };
+        Frame::new(&[1.0], &[1.0], &look, layout(), screen())
+            .pixels()
+            .expect("a screen with area")
+    }
+
+    #[test]
+    fn a_drawn_skin_is_a_shape_the_fractions_cannot_make() {
+        // What twenty-one crates buy. A ladder of fractions is rectangles all
+        // the way up; a drawing can have a corner cut off, and this checks the
+        // corner is actually missing rather than the picture merely differing
+        // somewhere.
+        const CORNERS: &str = include_str!("../../assets/skins/segment.svg");
+        let plain = skinned(None);
+        let drawn = skinned(Some(CORNERS));
+        assert_ne!(plain, drawn, "the drawing changed nothing");
+
+        // The top-left corner of the bottom rung. A rectangle ladder fills it;
+        // the segment has that corner cut away, so it is bare.
+        let column: Column = layout().column(0);
+        let x = column.left().get() as u32 + 1;
+        let y = TALL as u32 - 2;
+        assert!(at(&plain, x, y).3 > 200, "a plain ladder fills its corner");
+        assert!(
+            at(&drawn, x, y).3 < 60,
+            "the drawn skin filled a corner it cuts away: {:?}",
+            at(&drawn, x, y),
+        );
+    }
+
+    #[test]
+    fn a_drawn_skin_still_takes_its_colour_from_the_theme() {
+        // The invariant that outranks the artwork: colour is a function of
+        // height, never of the skin. An SVG whose own fill reached the screen
+        // would be a skin overriding the theme, which is the one thing the
+        // appearance layer exists to prevent - and this drawing is white, so it
+        // would be obvious.
+        const CORNERS: &str = include_str!("../../assets/skins/segment.svg");
+        let drawn = skinned(Some(CORNERS));
+        let column: Column = layout().column(0);
+        let middle = column.left().get() as u32 + 10;
+
+        let low = at(&drawn, middle, TALL as u32 - 6);
+        let high = at(&drawn, middle, 6);
+        assert!(low.3 > 200 && high.3 > 200, "the bar is not solid there");
+        assert!(
+            low.1 > low.0 && high.0 > high.1,
+            "green at the bottom and red at the top: got {low:?} and {high:?}",
+        );
     }
 
     #[test]
@@ -511,6 +604,7 @@ mod tests {
             theme: &theme,
             view: View::Flat,
             elapsed: Elapsed::seconds(0.0),
+            artwork: None,
             palette: &palette,
             backdrop: false,
             caps: None,
@@ -595,6 +689,7 @@ mod tests {
             theme: &theme,
             view: View::Flat,
             elapsed: Elapsed::seconds(0.0),
+            artwork: None,
             palette: &palette,
             backdrop: false,
             caps: None,
@@ -637,6 +732,7 @@ mod tests {
             theme: &theme,
             view: View::Flat,
             elapsed: Elapsed::seconds(0.0),
+            artwork: None,
             palette: &palette,
             backdrop: false,
             caps: None,
@@ -725,6 +821,7 @@ mod against_the_glyphs {
             theme: &theme,
             view: View::Flat,
             elapsed: Elapsed::seconds(0.0),
+            artwork: None,
             palette: &palette,
             backdrop: false,
             caps: None,
@@ -758,6 +855,53 @@ mod against_the_glyphs {
                  eighths and this draws {in_eighths} - the two have parted \
                  company by more than the eighth a block character rounds to",
             );
+        }
+    }
+}
+
+#[cfg(test)]
+mod looking {
+    use super::*;
+
+    #[test]
+    fn write_the_segment_skin() {
+        let Ok(into) = std::env::var("RAV_LOOK") else {
+            return;
+        };
+        let (wide, tall) = (480.0f32, 240.0f32);
+        let screen = Screen::new(Length(wide), Length(tall));
+        let layout = BarLayout::new(Length(24.0), Length(8.0));
+        let theme = Theme::default();
+        let palette = Palette::default();
+        let levels: Vec<f32> = (0..16)
+            .map(|i| 0.25 + 0.6 * ((i as f32) * 0.7).sin().abs())
+            .collect();
+        let peaks: Vec<f32> = levels.iter().map(|l| (l + 0.12).min(1.0)).collect();
+        for (name, art) in [
+            ("blocks", None),
+            (
+                "segment",
+                Some(include_str!("../../assets/skins/segment.svg")),
+            ),
+        ] {
+            let look = Look {
+                theme: &theme,
+                view: View::Flat,
+                elapsed: Elapsed::seconds(0.0),
+                artwork: art,
+                palette: &palette,
+                backdrop: true,
+                caps: Some(Length(4.0)),
+                ladder: Some((rav_appearance::skin::ladders::BLOCKS, Length(24.0))),
+            };
+            let rgba = Frame::new(&levels, &peaks, &look, layout, screen)
+                .pixels()
+                .unwrap();
+            let size = tiny_skia::IntSize::from_wh(wide as u32, tall as u32).unwrap();
+            tiny_skia::Pixmap::from_vec(rgba, size)
+                .unwrap()
+                .save_png(format!("{into}/skin-{name}.png"))
+                .unwrap();
         }
     }
 }

--- a/src/surface/frame.rs
+++ b/src/surface/frame.rs
@@ -279,6 +279,51 @@ mod tests {
     }
 
     #[test]
+    fn a_drawn_ladder_follows_the_bars_when_there_are_a_different_number_of_them() {
+        // The ladder is stamped once and kept, because the grid a bar climbs
+        // does not change between frames. What does change is how many bars
+        // there are - `w` regroups the bands - and how wide they are, and
+        // neither touches the screen size or the rung height. A cache keyed on
+        // those alone hands back a ladder stamped for a different set of
+        // columns, and the shapes stop lining up with the bars they are meant
+        // to be.
+        const CORNERS: &str = include_str!("../../assets/skins/segment.svg");
+        let theme = Theme::default();
+        let palette = Palette::default();
+        let look = Look {
+            theme: &theme,
+            view: View::Flat,
+            elapsed: Elapsed::seconds(0.0),
+            artwork: Some(CORNERS),
+            palette: &palette,
+            backdrop: false,
+            caps: None,
+            ladder: Some((rav_appearance::skin::ladders::BLOCKS, Length(20.0))),
+        };
+        // One canvas, kept across both - as the render loop keeps it.
+        let mut canvas = Canvas::for_screen(&screen()).expect("a screen with area");
+        let paint = |canvas: &mut Canvas, bands: usize| {
+            let levels = vec![1.0; bands];
+            Frame::new(&levels, &levels, &look, layout(), screen()).painted_onto(canvas);
+            canvas.to_rgba()
+        };
+
+        let few = paint(&mut canvas, 2);
+        let many = paint(&mut canvas, 5);
+        assert_ne!(few, many, "more bands drew the same picture");
+
+        // The fifth column has to have ink in it, which it cannot if the mask
+        // is still the one stamped for two.
+        let fifth: Column = layout().column(4);
+        let x = fifth.left().get() as u32 + 10;
+        assert!(
+            at(&many, x, TALL as u32 - 6).3 > 200,
+            "the fifth bar was left unstamped: {:?}",
+            at(&many, x, TALL as u32 - 6),
+        );
+    }
+
+    #[test]
     fn a_drawn_skin_still_takes_its_colour_from_the_theme() {
         // The invariant that outranks the artwork: colour is a function of
         // height, never of the skin. An SVG whose own fill reached the screen

--- a/src/ui/analyzer.rs
+++ b/src/ui/analyzer.rs
@@ -36,9 +36,18 @@ pub enum BarStyle {
     Half,
     /// `━` - a thin rule, the airiest ladder.
     Line,
+    /// A drawn rung with its corners cut - the shape a bar-graph LED has on a
+    /// rack unit, and the first skin that is artwork rather than arithmetic.
+    ///
+    /// There is no character for it, so a cell grid draws the plain bar and
+    /// the help panel says so. See `render::sprite`.
+    Segment,
 }
 
 impl BarStyle {
+    /// How many there are, for anything that walks the cycle once.
+    pub const COUNT: usize = 7;
+
     pub fn next(self) -> Self {
         match self {
             BarStyle::Shade => BarStyle::Blocks,
@@ -46,7 +55,8 @@ impl BarStyle {
             BarStyle::Solid => BarStyle::Thick,
             BarStyle::Thick => BarStyle::Half,
             BarStyle::Half => BarStyle::Line,
-            BarStyle::Line => BarStyle::Shade,
+            BarStyle::Line => BarStyle::Segment,
+            BarStyle::Segment => BarStyle::Shade,
         }
     }
 
@@ -58,6 +68,7 @@ impl BarStyle {
             BarStyle::Thick => "thick",
             BarStyle::Half => "half",
             BarStyle::Line => "line",
+            BarStyle::Segment => "segment",
         }
     }
 
@@ -77,6 +88,9 @@ impl BarStyle {
             BarStyle::Thick => ladders::THICK,
             BarStyle::Half => ladders::HALF,
             BarStyle::Line => ladders::LINE,
+            // One shape clipped to the fill, because the drawing is the shape
+            // and there is no partial version of it to pick from.
+            BarStyle::Segment => rav_appearance::skin::PLAIN,
         }
     }
 
@@ -104,14 +118,31 @@ impl BarStyle {
     }
 
     /// Glyph for a fully lit row.
+    ///
+    /// `Segment` has none - it is a drawing, and a cell grid has no character
+    /// shaped like one - so it borrows the solid block. That is the honest
+    /// fall back: the same ladder rhythm, without the corners.
     fn glyph(self) -> &'static str {
         match self {
+            BarStyle::Segment => BLOCKS[8],
             BarStyle::Shade => "\u{2593}",
             BarStyle::Blocks => BLOCKS[8],
             BarStyle::Solid => "\u{2587}",
             BarStyle::Thick => "\u{2586}",
             BarStyle::Half => "\u{2584}",
             BarStyle::Line => "\u{2501}",
+        }
+    }
+
+    /// The drawing this style is made of, for a surface that can rasterise one.
+    ///
+    /// Embedded rather than read from disk: a skin nobody can lose is worth
+    /// more than one anybody can replace, and user skins are a directory this
+    /// does not have yet. `None` for every ladder made of fractions.
+    pub fn artwork(self) -> Option<&'static str> {
+        match self {
+            BarStyle::Segment => Some(include_str!("../../assets/skins/segment.svg")),
+            _ => None,
         }
     }
 
@@ -909,13 +940,15 @@ mod tests {
     fn every_bar_style_labels_itself_and_cycles() {
         let mut style = BarStyle::default();
         let mut seen = vec![style.label()];
-        for _ in 0..5 {
+        for _ in 0..6 {
             style = style.next();
             seen.push(style.label());
         }
         assert_eq!(
             seen,
-            vec!["blocks", "solid", "thick", "half", "line", "shade"]
+            vec![
+                "blocks", "solid", "thick", "half", "line", "segment", "shade"
+            ]
         );
         assert_eq!(style.next(), BarStyle::Blocks, "cycles back round");
     }

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -271,6 +271,8 @@ pub struct App {
     /// Whether the first non-silent tap buffer has been seen.
     #[cfg(target_os = "macos")]
     tap_reported: bool,
+    /// The pixel buffer, kept between frames - see `painted`.
+    canvas: Option<crate::render::Canvas>,
     /// When the analyser started.
     ///
     /// Two readers, and neither is optional on one platform: the silent-tap
@@ -354,6 +356,7 @@ impl App {
             tap_scratch: Vec::new(),
             #[cfg(target_os = "macos")]
             tap_reported: false,
+            canvas: None,
             started: Instant::now(),
             should_quit: false,
             last_frame: Instant::now(),
@@ -530,6 +533,7 @@ impl App {
             // is where the reason is written down. Sending the raw uptime
             // would work all day and then quietly stop moving.
             elapsed: rav_appearance::scene::sway_phase(self.started.elapsed().as_secs_f64()),
+            artwork: self.bar_style.artwork(),
         };
         // `coarse` and `fine` are the same cap on a cell grid - one position per
         // row is all a cell offers - so the difference has to be made here or
@@ -542,7 +546,27 @@ impl App {
                 .iter()
                 .map(|&peak| self.peaks.placed(peak, size.rows)),
         );
-        let drawn = Frame::new(self.ballistics.bars(), &caps, &look, layout, screen).pixels();
+        // Kept between frames rather than made fresh each time. At 2400x1440 a
+        // canvas is a 13.8 MB pixmap, and it also holds what a drawn skin costs
+        // to prepare - 8.6 ms of stamping that would otherwise be paid sixty
+        // times a second. Rebuilt when the terminal changes size, which is the
+        // only time any of it stops being true.
+        let canvas = match self.canvas.take() {
+            Some(had)
+                if had.width() == screen.width().rounded_up()
+                    && had.height() == screen.height().rounded_up() =>
+            {
+                Some(had)
+            }
+            _ => crate::render::Canvas::for_screen(&screen),
+        };
+        let drawn = canvas.map(|mut canvas| {
+            Frame::new(self.ballistics.bars(), &caps, &look, layout, screen)
+                .painted_onto(&mut canvas);
+            let pixels = canvas.to_rgba();
+            self.canvas = Some(canvas);
+            pixels
+        });
         self.cap_levels = caps;
         let Some(pixels) = drawn else {
             return Ok(false);
@@ -1568,9 +1592,11 @@ mod tests {
         assert!(readme.contains(&themes), "themes: expected {themes:?}");
 
         // Bar styles in the order `b` actually walks them, from the default.
+        // Counted from the cycle rather than written down, so a new style has
+        // to be documented rather than quietly appearing in the panel alone.
         let mut style = BarStyle::default();
         let mut styles = Vec::new();
-        for _ in 0..6 {
+        for _ in 0..BarStyle::COUNT {
             styles.push(style.label());
             style = style.next();
         }


### PR DESCRIPTION
The one thing the plan promised and never delivered — you were right to say so.

Every ladder rav draws is arithmetic: `▇` is the lower seven eighths of a rung, `━` a stroke across the middle. That is the whole vocabulary a rectangle offers. `b` gains **`segment`**: a rung with its corners cut off, the shape a bar-graph LED has on a rack unit, which no fraction can express.

**The drawing gives shape and never colour.** It is taken as a mask, so the theme still decides what colour a height is — the invariant that predates the pixel surface and is the reason a bar reddens as it rises rather than as it gets louder. The artwork is white; if its own fill reached the screen it would be obvious. `a_drawn_skin_still_takes_its_colour_from_the_theme` checks green at the bottom and red at the top, and `a_drawn_skin_is_a_shape_the_fractions_cannot_make` checks the cut corner is *bare* rather than merely different — it fails if the SVG is replaced with a solid block, which I verified.

**Where it lives, and why it is split.** `usvg` cannot go in `rav-appearance`: that crate is `no_std` and now has a CI check proving it builds for a machine with no operating system. So the model stays there — how many steps a ladder has, what shape a rung is, in terms a terminal or an LED strip can read — and the picture lives in `rav`, offered to a surface that can rasterise. A cell grid draws the solid block and the panel says so. That is the trade I flagged, taken deliberately.

**Two costs, both measured rather than assumed.**

The first version rasterised the SVG and stamped a screen of ladder *every frame*: **16.19 ms** against a 16.7 ms budget. Parsing is 0.44 ms of that and stamping is **8.6**, and both were thrown away because a canvas was built fresh each frame — which was also a **13.8 MB pixmap allocated and dropped sixty times a second**, on every skin, drawn or not. I had not noticed that. The render loop keeps its canvas now:

| | before | after |
|---|---|---|
| blocks | 5.54 ms | **4.75 ms** |
| segment | 16.19 ms | **8.30 ms** |

The second is **21 new crates**. `resvg` and `usvg` with default features off — no fonts, no raster image decoders, no system anything — and resvg 0.48 uses the tiny-skia rav already has, so there is one copy in the tree and the pixmaps interoperate rather than needing a conversion.

**`flake.nix` learns `assets/skins/`** in the same change, or the nix build loses the artwork and nothing else notices: a flake sees only what git tracks, and CI never builds it. `nix build .#default` verified here.

Not in this: user skins from a directory. The mechanism is the same; what it needs is a path, a watch and a licence story, and none of that changes what is here.