### PR TITLE
docs(audio): what flume actually does on the callback, having read it

### DIFF
--- a/crates/rav-core/tests/properties.proptest-regressions
+++ b/crates/rav-core/tests/properties.proptest-regressions
@@ -1,0 +1,7 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc 34d008e98ce8bd251c0ae49d5ef2269c90700bea89c3293a5a5849825c1ad5d3 # shrinks to anchor = Ceiling, peak = Level(0.9587626), thickness = 7.7606773, height = 73.27264

--- a/crates/rav-core/tests/properties.proptest-regressions
+++ b/crates/rav-core/tests/properties.proptest-regressions
@@ -1,7 +1,0 @@
-# Seeds for failure cases proptest has generated in the past. It is
-# automatically read and these particular cases re-run before any
-# novel cases are generated.
-#
-# It is recommended to check this file in to source control so that
-# everyone who runs the test benefits from these saved cases.
-cc 34d008e98ce8bd251c0ae49d5ef2269c90700bea89c3293a5a5849825c1ad5d3 # shrinks to anchor = Ceiling, peak = Level(0.9587626), thickness = 7.7606773, height = 73.27264

--- a/src/audio/mod.rs
+++ b/src/audio/mod.rs
@@ -32,8 +32,26 @@
 //! - **Nothing waits.** Every send is a `try_send`, and the tap's callback takes
 //!   a `try_lock` it is allowed to lose.
 //!
-//! The one thing left on that thread is `flume` itself, which takes a brief
-//! internal lock. Closing that would mean a lock-free ring, and a dependency.
+//! # What is left, and why it stays
+//!
+//! `flume` itself. `try_send` takes a `std::sync::Mutex` and holds it for one
+//! `VecDeque::push_back` - read rather than assumed, and worth being exact
+//! about, because the alarming version is behind a feature rav does not enable:
+//! with `spin` on, flume's lock spins and then **sleeps** on the caller, which
+//! on this thread would be indefensible. Without it the lock is an ordinary
+//! mutex the consumer holds only long enough to pop.
+//!
+//! So the residual risk is a bounded one: if the consumer is preempted holding
+//! that lock, the callback waits for it. Small, and real.
+//!
+//! Closing it means a lock-free ring, and a ring cannot be awaited - the render
+//! loop selects on this channel, which is what makes rav event-driven rather
+//! than timer-driven. Something would still have to wake the loop, and every
+//! candidate for that takes a lock somewhere too. So the trade is a new
+//! dependency and a restructured event loop against a mutex held for a pointer
+//! push, and it is not worth it today. Written down rather than left implicit,
+//! because "no locks on the audio thread" is a rule this file otherwise keeps
+//! absolutely, and the exception should be one someone chose.
 //!
 //! [`synthetic`] is exempt and says so: it paces itself on a thread of its own,
 //! answers to nobody, and allocating there costs nothing.


### PR DESCRIPTION
The module note said flume "takes a brief internal lock" and left the question open. Reading it settles the question — and corrects the scarier half of my own guess, which is the part worth reporting.

**The version worth worrying about is behind a feature rav does not enable.** With `spin` on, flume’s lock spins ten times and then **`thread::sleep`s** on the caller, escalating to about a millisecond. On a realtime audio callback that would be indefensible. rav takes the default features — `async`, `select`, `eventual-fairness` — so `wait_lock` is `Mutex::lock()`, held for one `VecDeque::push_back`, and the consumer holds it only long enough to pop.

I had been about to report the sleeping version as fact. It is not fact here.

**What is actually left is a bounded risk rather than a hazard**: a callback waiting on a consumer that was preempted mid-pop.

**And it stays.** Closing it means a lock-free ring, and a ring cannot be awaited — the render loop *selects* on this channel, which is what makes rav event-driven rather than timer-driven. Something would still have to wake the loop, and every candidate for that takes a lock somewhere too, which the macOS tap already says out loud about `notify_one`. So the trade is a new dependency and a restructured event loop against a mutex held for a pointer push.

The note says all of that now. "No locks on the audio thread" is a rule that file otherwise keeps absolutely, and the exception should be one somebody chose rather than one nobody noticed.

That closes the second of the two questions that were waiting on you. Nothing behavioural.