### PR TITLE
fix(core): a cap stays on the display at sizes that do not divide

### DIFF
--- a/crates/rav-core/src/geometry.rs
+++ b/crates/rav-core/src/geometry.rs
@@ -286,6 +286,14 @@ impl Column {
             Anchor::Middle => (screen.height() - risen) / 2.0 - thickness,
         }
         .held_between(Length::NONE, furthest);
+        // Clamping the top is not enough to keep the cap on the screen, because
+        // `(height - thickness) + thickness` is not always `height` in `f32`.
+        // A property test found it: a cap of 7.7606773 on a display 73.27264
+        // tall landed three millionths of a pixel below the floor. Nothing
+        // anyone could see, and still a rectangle that is not where this method
+        // promises every rectangle it returns will be - so the thickness gives
+        // way rather than the promise.
+        let thickness = thickness.smallest(screen.height() - top);
         Rectangle::new(self.left, top, self.width, thickness)
     }
 
@@ -406,6 +414,31 @@ mod tests {
         assert_eq!(
             column.cap(Level::FULL, Length(3.0), &screen).top(),
             Length::NONE
+        );
+    }
+
+    #[test]
+    fn a_cap_stays_inside_the_screen_at_sizes_that_do_not_divide() {
+        // The numbers a property test found, kept because nothing anyone would
+        // choose by hand goes near this: clamping the top is not enough, since
+        // `(height - thickness) + thickness` is not always `height` in `f32`.
+        // This one overshot by three millionths of a pixel - invisible, and
+        // still a rectangle outside the screen it was asked to be inside.
+        let screen = screen(256.0, 73.27264);
+        let cap = BarLayout::new(Length(8.0), Length(1.0))
+            .column(0)
+            .anchored(Anchor::Ceiling)
+            .cap(Level::new(0.958_762_6), Length(7.760_677_3), &screen);
+        assert!(
+            cap.bottom() <= screen.height(),
+            "{:?} hangs below a screen {:?} tall",
+            cap.bottom(),
+            screen.height(),
+        );
+        assert!(
+            cap.top() >= Length::NONE,
+            "{:?} is above the top",
+            cap.top()
         );
     }
 

--- a/crates/rav-core/tests/properties.proptest-regressions
+++ b/crates/rav-core/tests/properties.proptest-regressions
@@ -1,0 +1,7 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc 34d008e98ce8bd251c0ae49d5ef2269c90700bea89c3293a5a5849825c1ad5d3 # shrinks to anchor = Ceiling, peak = Level(0.9587626), thickness = 7.7606773, height = 73.27264


### PR DESCRIPTION
A property test found this, on a fresh input, while I was working on something else — which is exactly what property tests are for and the first time one here has caught a real defect rather than confirming a known one.

```
minimal failing input: anchor = Ceiling, peak = 0.9587626,
                       thickness = 7.7606773, height = 73.27264
below the floor: Rectangle { top: 65.51196, height: 7.7606773 }
```

`65.51196 + 7.7606773` is `73.272644`. The screen is `73.27264` tall. The cap hangs three millionths of a pixel below the floor.

**Clamping the top is not enough**, because `(height - thickness) + thickness` is not always `height` in `f32`. `Column::cap` clamps `top` to `height - thickness` and then builds a rectangle of the full thickness from there, and the addition rounds back up.

Nothing anyone could see. Still a rectangle outside the screen the method promises every rectangle it returns will be inside, and the promise is what other code relies on — the rasteriser clips silently, so this is the kind of thing that is only ever wrong somewhere it is not clipped. **The thickness gives way instead of the promise**: it is trimmed to whatever is left below the top.

**The counterexample is pinned as a unit test.** Nothing anyone would choose by hand goes near those numbers, and the property runs on fresh inputs every time — so without pinning it, this comes back and is rediscovered by somebody else in a year. It fails without the fix: `Length(73.272644) hangs below a screen Length(73.27264) tall`.

Unrelated to #132, which is why it is a separate PR rather than a commit on that branch.