### PR TITLE
feat: a skin you drew yourself

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,13 @@ rav --list-devices    # what rav can capture from
 rav -d "<name>"       # capture from a named device
 rav --clean           # log almost nothing
 rav --surface glyphs  # auto, glyphs, kitty or window
+rav --skin bar.svg    # draw the bars from your own shape
 ```
+
+`--skin` takes an SVG and builds the bars from it - only its shape is used, so the
+theme still decides the colour — and it needs a terminal drawing pixels. It
+selects the `segment` bar style, since a skin nobody can see is
+indistinguishable from one that failed to load.
 
 A terminal that can draw images gets **pixels**: a peak cap rides over the
 backdrop instead of erasing the cell it crosses, the bar ladder is even at any

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-use anyhow::Result;
+use anyhow::{Context, Result};
 use clap::Parser;
 use tracing::info;
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
@@ -39,6 +39,12 @@ struct Args {
     /// Theme: `rav`, `winamp`, `terminal`, `mono`, or a name/path of a theme file
     #[arg(long, value_name = "NAME|PATH")]
     theme: Option<String>,
+
+    /// An SVG to draw a bar's rungs from, in place of the built-in `segment`.
+    /// Only its shape is used - the theme still decides the colour. Implies
+    /// that style at startup, and needs a terminal drawing pixels
+    #[arg(long, value_name = "PATH")]
+    skin: Option<std::path::PathBuf>,
 
     /// Which surface to draw on. `auto` draws pixels wherever the terminal says
     /// it can draw images - WezTerm, Ghostty, kitty - and block characters
@@ -212,6 +218,22 @@ async fn rav_main() -> Result<()> {
     if let Some(theme) = args.theme.as_deref() {
         app.set_theme(rav::visual::theme::load(theme)?);
         info!("Using theme: {theme}");
+    }
+
+    // Read here rather than in `App` for the same reason a theme is: a path
+    // that cannot be read is a mistake worth stopping for, and reporting it
+    // once the alternate screen is up means reporting it where nobody can
+    // read it.
+    //
+    // Leaked deliberately. A drawn skin is identified by the address of its
+    // text - see `render::sprite` - and this is read once for the life of the
+    // process, so one leak buys an identity check that cannot go wrong. A
+    // `String` handed in instead would be freed and its address reused.
+    if let Some(path) = args.skin.as_deref() {
+        let svg = std::fs::read_to_string(path)
+            .with_context(|| format!("Cannot read the skin at {}", path.display()))?;
+        app.wear_skin(Box::leak(svg.into_boxed_str()));
+        info!("Using skin: {}", path.display());
     }
 
     // Here, and not inside `App`, because asking the terminal has to happen

--- a/src/main.rs
+++ b/src/main.rs
@@ -41,8 +41,8 @@ struct Args {
     theme: Option<String>,
 
     /// An SVG to draw a bar's rungs from, in place of the built-in `segment`.
-    /// Only its shape is used - the theme still decides the colour. Implies
-    /// that style at startup, and needs a terminal drawing pixels
+    /// Only its shape is used, so the theme still decides the colour. Selects
+    /// that bar style at startup, and needs a terminal that draws pixels.
     #[arg(long, value_name = "PATH")]
     skin: Option<std::path::PathBuf>,
 

--- a/src/render/raster.rs
+++ b/src/render/raster.rs
@@ -91,7 +91,17 @@ impl Canvas {
     /// Rasterised once per size by the caller, because a rung is a fixed size
     /// for as long as the window is and parsing an SVG sixty times a second
     /// would cost more than every bar rav draws put together.
-    pub fn wants_artwork(&mut self, svg: &'static str, across: u32, down: u32) {
+    pub fn wants_artwork(&mut self, svg: Option<&'static str>, across: u32, down: u32) {
+        let Some(svg) = svg else {
+            // Said out loud rather than left implicit. A canvas keeps its
+            // stamped ladder between frames, so a style that has stopped
+            // wanting one would otherwise go on being shaped by the mask the
+            // last style left behind - and `b` would be labels over one
+            // picture again, which is the defect the ladders exist to fix.
+            self.artwork = None;
+            self.ladder = None;
+            return;
+        };
         // Already have it, at the size it is wanted: which is every frame but
         // the first and the one after a resize. Parsing and rasterising the SVG
         // is 0.44 ms, and the ladder it stamps is 8.6 - both of which the frame
@@ -240,7 +250,9 @@ impl Canvas {
         ramp: &Ramp,
         screen: &Screen,
     ) -> bool {
-        if !self.placing.is_identity() || bars.is_empty() {
+        // No drawing, no drawn ladder - even if one is still stamped from the
+        // style before this one.
+        if self.artwork.is_none() || !self.placing.is_identity() || bars.is_empty() {
             return false;
         }
         let (across, down) = (self.pixmap.width(), self.pixmap.height());

--- a/src/surface/frame.rs
+++ b/src/surface/frame.rs
@@ -120,12 +120,18 @@ impl Frame {
     /// it keeps both, and the drawn skin costs about what the block one does.
     pub fn painted_onto(&self, canvas: &mut Canvas) {
         canvas.clear();
-        // A drawn skin, rasterised to whatever a rung is on this terminal. The
-        // canvas declines it at any other size and under any transform, so this
-        // is an offer rather than an instruction.
-        if let (Some(svg), Some((_, rung))) = (self.artwork, self.ladder) {
-            canvas.wants_artwork(svg, self.layout.bar_width().rounded_up(), rung.rounded_up());
-        }
+        // An offer rather than an instruction: the canvas declines a drawing at
+        // any size but the one it was rasterised for, and under any transform.
+        //
+        // Told every frame, including that there is none. A canvas keeps its
+        // stamped ladder between frames, so a style that has stopped wanting
+        // one has to say so, or the mask it left behind goes on shaping bars
+        // that are not made of it.
+        canvas.wants_artwork(
+            self.artwork,
+            self.layout.bar_width().rounded_up(),
+            self.ladder.map_or(0, |(_, rung)| rung.rounded_up()),
+        );
         let styles = [Style {
             bars: &self.bars,
             grid: self.grid.as_ref(),
@@ -275,6 +281,45 @@ mod tests {
             at(&drawn, x, y).3 < 60,
             "the drawn skin filled a corner it cuts away: {:?}",
             at(&drawn, x, y),
+        );
+    }
+
+    #[test]
+    fn a_style_that_stopped_wanting_a_drawing_stops_being_shaped_by_one() {
+        // The canvas keeps its stamped ladder between frames, which is what
+        // makes a drawn skin affordable - and what makes this the mistake to
+        // guard. Wear a skin, cycle to a style that has no artwork, and the
+        // mask left behind would go on cutting the corners off a block ladder:
+        // `b` back to being labels over one picture, which is the whole defect
+        // the ladders were built to fix.
+        const CORNERS: &str = include_str!("../../assets/skins/segment.svg");
+        let theme = Theme::default();
+        let palette = Palette::default();
+        let paint = |canvas: &mut Canvas, artwork: Option<&'static str>| {
+            let look = Look {
+                theme: &theme,
+                view: View::Flat,
+                elapsed: Elapsed::seconds(0.0),
+                artwork,
+                palette: &palette,
+                backdrop: false,
+                caps: None,
+                ladder: Some((rav_appearance::skin::ladders::BLOCKS, Length(20.0))),
+            };
+            Frame::new(&[1.0], &[1.0], &look, layout(), screen()).painted_onto(canvas);
+            canvas.to_rgba()
+        };
+
+        // One canvas throughout, as the render loop keeps it.
+        let mut canvas = Canvas::for_screen(&screen()).expect("a screen with area");
+        let plain_first = paint(&mut canvas, None);
+        let drawn = paint(&mut canvas, Some(CORNERS));
+        let plain_again = paint(&mut canvas, None);
+
+        assert_ne!(plain_first, drawn, "the drawing changed nothing");
+        assert_eq!(
+            plain_first, plain_again,
+            "the ladder kept the shape of a skin the style no longer wants",
         );
     }
 

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -250,6 +250,11 @@ pub struct App {
     bar_style: BarStyle,
     /// The angle the field is bolted at. Pixels only - see `Action::CycleView`.
     view: View,
+    /// A drawing to build the bars from, if one was given on the command line.
+    ///
+    /// Replaces the artwork the `segment` style carries. `None` is the built-in
+    /// one, which is what every run that did not ask uses.
+    skin: Option<&'static str>,
     show_help: bool,
     /// Briefly shown after a settings key, so a change is visible without a
     /// permanent status bar cluttering the display.
@@ -347,6 +352,7 @@ impl App {
             // answers to that question agree only until one of them moves.
             bar_style: BarStyle::from_skin(preset.skin).unwrap_or_default(),
             view: View::default(),
+            skin: None,
             show_help: false,
             status: None,
             source: None,
@@ -533,7 +539,7 @@ impl App {
             // is where the reason is written down. Sending the raw uptime
             // would work all day and then quietly stop moving.
             elapsed: rav_appearance::scene::sway_phase(self.started.elapsed().as_secs_f64()),
-            artwork: self.bar_style.artwork(),
+            artwork: self.skin.or_else(|| self.bar_style.artwork()),
         };
         // `coarse` and `fine` are the same cap on a cell grid - one position per
         // row is all a cell offers - so the difference has to be made here or
@@ -685,6 +691,16 @@ impl App {
     /// Show a message for a couple of seconds.
     fn note(&mut self, text: String) {
         self.status = Some((text, Instant::now()));
+    }
+
+    /// Draw the bars from this drawing rather than the built-in one.
+    ///
+    /// Opens on the style that uses it, because a skin nobody can see is
+    /// indistinguishable from a skin that failed to load - and `b` walks away
+    /// from it and back like any other.
+    pub fn wear_skin(&mut self, svg: &'static str) {
+        self.skin = Some(svg);
+        self.bar_style = BarStyle::Segment;
     }
 
     /// Whether a viewing angle would change anything.
@@ -2422,6 +2438,35 @@ mod tests {
                 .expect("no viewing angle row");
             assert_eq!(row.value.as_deref(), Some(expected));
         }
+    }
+
+    #[test]
+    fn a_skin_from_a_file_replaces_the_built_in_one_and_shows_itself() {
+        // A skin nobody can see is indistinguishable from one that failed to
+        // load, so wearing it also selects the style that draws it. `b` walks
+        // away from there and back like any other.
+        const MINE: &str = "<svg/>";
+        let mut a = app();
+        assert_ne!(a.bar_style, BarStyle::Segment, "not where it opens");
+
+        a.wear_skin(MINE);
+        assert_eq!(a.bar_style, BarStyle::Segment, "it chose another style");
+        assert_eq!(a.skin, Some(MINE));
+
+        // And it outranks the built-in artwork rather than sitting beside it:
+        // the drawing a user handed over is the one they expect to see.
+        assert!(
+            std::ptr::eq(
+                a.skin.or_else(|| a.bar_style.artwork()).unwrap().as_ptr(),
+                MINE.as_ptr()
+            ),
+            "the built-in drawing won",
+        );
+
+        // Cycling away leaves the skin in hand, so coming back shows it again
+        // rather than reverting to the built-in.
+        a.apply(Action::CycleBarStyle);
+        assert_eq!(a.skin, Some(MINE), "cycling threw the skin away");
     }
 
     #[test]

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -539,7 +539,14 @@ impl App {
             // is where the reason is written down. Sending the raw uptime
             // would work all day and then quietly stop moving.
             elapsed: rav_appearance::scene::sway_phase(self.started.elapsed().as_secs_f64()),
-            artwork: self.skin.or_else(|| self.bar_style.artwork()),
+            // Only the style that draws one gets one, and a skin from the
+            // command line stands in for that style's built-in artwork rather
+            // than for every style's. Offered unconditionally otherwise, `b`
+            // would go back to being six labels over one picture.
+            artwork: self
+                .bar_style
+                .artwork()
+                .map(|built_in| self.skin.unwrap_or(built_in)),
         };
         // `coarse` and `fine` are the same cap on a cell grid - one position per
         // row is all a cell offers - so the difference has to be made here or


### PR DESCRIPTION
Adds `--skin <PATH>`: an SVG the bars are drawn from, in place of the built-in `segment` artwork. Only the shape is used — the theme still decides colour. Selecting it also selects the `segment` bar style. A path that cannot be read stops rav, as an unknown theme does.

Fixes a skin being offered to every bar style rather than to the one with artwork, which made `b` a set of labels over one picture. The canvas is now told each frame whether a drawing is wanted, so a stamped ladder is not reused by a style that no longer has one.

The skin text is leaked: a drawn skin is identified by the address of its bytes, which is what keeps the ladder from being restamped every frame.