### PR TITLE
docs: how to draw a skin

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,10 +46,9 @@ rav --surface glyphs  # auto, glyphs, kitty or window
 rav --skin bar.svg    # draw the bars from your own shape
 ```
 
-`--skin` takes an SVG and builds the bars from it - only its shape is used, so the
-theme still decides the colour — and it needs a terminal drawing pixels. It
-selects the `segment` bar style, since a skin nobody can see is
-indistinguishable from one that failed to load.
+`--skin` takes an SVG and builds the bars from it. Only the shape is used, so the
+theme still decides the colour, and it needs a terminal drawing pixels — see
+**[docs/skins.md](docs/skins.md)**.
 
 A terminal that can draw images gets **pixels**: a peak cap rides over the
 backdrop instead of erasing the cell it crosses, the bar ladder is even at any

--- a/docs/developing.md
+++ b/docs/developing.md
@@ -122,6 +122,7 @@ prevent.
 | `crates/rav-core/` | **`no_std`, no allocator.** The mechanics: `Level`, `Step`, `Fill`, `Length`, geometry, and what a display can show. Knows *how many* and *which one*, never what any of them look like |
 | `crates/rav-appearance/` | **`no_std`.** What a step looks like: inks, colours, ramps, the scene, and themes. Names no rasteriser, so one theme dresses a glyph grid, a window and an LED strip alike |
 | `crates/rav-appearance/themes/` | the bundled themes, TOML, turned into consts by that crate's `build.rs` — see [themes.md](themes.md) |
+| `assets/skins/` | the built-in skin artwork, embedded with `include_str!` — see [skins.md](skins.md) |
 | `src/audio/` | cpal capture, and the macOS CoreAudio process tap — see [audio.md](audio.md) |
 | `src/signal/` | FFT front end, bin-to-bar mapping, bar and cap ballistics |
 | `src/visual/` | reading a theme a *user* wrote, and asking the terminal for its palette — the halves that need a filesystem and a terminal |

--- a/docs/skins.md
+++ b/docs/skins.md
@@ -1,7 +1,7 @@
 # Drawing a skin
 
 A skin is one SVG: the shape of a single **rung**, the unit a bar is built from.
-rav stacks it up each bar and clips it to the level.
+rav stacks it up each bar and clips the stack to the level.
 
 ```
 rav --skin ./segment.svg

--- a/docs/skins.md
+++ b/docs/skins.md
@@ -1,0 +1,71 @@
+# Drawing a skin
+
+A skin is one SVG: the shape of a single **rung**, the unit a bar is built from.
+rav stacks it up each bar and clips it to the level.
+
+```
+rav --skin ./segment.svg
+```
+
+That selects the `segment` bar style, which is the one a drawing replaces. `b`
+cycles away to the ladders made of block characters and back.
+
+## Only the shape is used
+
+The drawing is a **mask**. Its alpha decides which pixels belong to a rung, and
+the theme decides what colour they are — so a bar still reddens as it rises, and
+a skin cannot override a theme. Colours inside the file are ignored; the shipped
+`assets/skins/segment.svg` is plain white for that reason.
+
+Draw in white, and think in coverage: solid where the rung is, transparent where
+it is not, partial for a soft edge.
+
+## Size and shape
+
+Use a `viewBox` and set `preserveAspectRatio="none"`. The drawing is stretched to
+fill one rung, whatever that is on the reader's terminal — a rung is one text
+cell tall and one bar wide, so it might be 24×60 device pixels or 10×20. A skin
+that insists on its own proportions would leave gaps the theme never asked for.
+
+```svg
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" preserveAspectRatio="none">
+  <path fill="#ffffff" d="M 14 6 H 86 L 96 24 V 76 L 86 94 H 14 L 4 76 V 24 Z"/>
+</svg>
+```
+
+Leave a gap at the top and bottom if you want a visible seam between rungs; fill
+edge to edge if you want a continuous bar. Both read as a ladder because the
+level clips the stack, not because of the artwork.
+
+## What is supported
+
+`usvg` parses the file with no font stack and no raster image support, so:
+
+| works | does not |
+|---|---|
+| paths, rectangles, circles, polygons | `<text>` — there are no fonts |
+| gradients and opacity, as coverage | embedded PNG or JPEG |
+| groups and transforms | external files of any kind |
+
+A file that will not parse is a startup error naming the path. A file that parses
+to nothing draws nothing, which looks like a bar that has gone missing rather
+than like a mistake — check it renders somewhere else first.
+
+## Where it does not apply
+
+The panel says so rather than leaving it a mystery. Press `h` and read the bar
+style row:
+
+| | |
+|---|---|
+| `segment` | the drawing is on screen |
+| `segment - needs pixels` | the terminal draws block characters, which have no way to carry a picture |
+| `segment - needs a flat view` | `v` has the field at an angle; a mask cannot follow a leaning bar, so the plain ladder is drawn instead |
+
+## Cost
+
+The file is parsed and rasterised once, and the whole ladder is stamped once per
+size — not per frame. Measured at 2400×1440 with eighty bands, a drawn skin costs
+8.3 ms a frame against 4.8 ms for the block ladder, inside a 16.7 ms budget.
+Complicated artwork costs no more per frame than simple artwork; it costs more
+once, when the window changes size.


### PR DESCRIPTION
Adds `docs/skins.md`. `--skin` shipped with a single line in the README, so writing a skin meant reading the source.

Covers what the file has to be, that only alpha is used and the theme still decides colour, why it needs `preserveAspectRatio="none"`, what `usvg` supports without a font stack, what the bar style row says when a drawing is not being drawn, and what it costs per frame.

Linked from the README and the module map in `docs/developing.md`.