### PR TITLE
fix: the crate ships the skin the binary embeds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,11 +48,11 @@ readme = "README.md"
 # crates.io allows at most five keywords, each at most 20 characters.
 keywords = ["winamp", "audio", "visualizer", "spectrum", "tui"]
 categories = ["multimedia::audio", "command-line-utilities", "visualization"]
-# `assets/` is for the README and the repository, and crates.io resolves a
-# README's relative paths against the repository rather than the package - so
-# excluding the whole directory costs nothing and keeps brand artwork out of
-# what people download to build the binary.
-exclude = ["assets/", ".github/", "devenv.nix", "devenv.yaml", "devenv.lock"]
+# Named file by file, never `assets/` as a directory: the built-in segment skin
+# lives there and is an `include_str!`, so excluding the directory produces a
+# package that does not compile. The demo is 2.4MB and is linked absolutely from
+# the README, which crates.io serves from the repository rather than the package.
+exclude = ["assets/demo.gif", ".github/", "devenv.nix", "devenv.yaml", "devenv.lock"]
 
 # Denied rather than warned: a warning in a `nix build` scrolls past in CI logs
 # and nobody sees it. `dead_code` is a member of `unused`, so this covers the

--- a/devenv.nix
+++ b/devenv.nix
@@ -445,7 +445,37 @@
       # the only task here that compiles for a second target.
       after = [ "test:unit" ];
     };
+    "test:package" = {
+      # A file the binary embeds must survive being packaged, or `cargo install`
+      # gets a crate that does not compile. Excluding `assets/` as a directory
+      # did exactly that to the built-in segment skin, and nothing caught it:
+      # the repository builds, the tests pass, and the file is only missing in
+      # the tarball nobody builds until release.
+      #
+      # crates.io is immutable and release-plz publishes in dependency order, so
+      # the failure lands after rav-core and rav-appearance are already up -
+      # two versions burned, and the number can never be reused.
+      #
+      # Paths are read out of the source rather than listed here, so an asset
+      # embedded later is covered without anyone remembering to add it.
+      exec = ''
+        set -eu
+        list=$(cargo package --quiet --list -p rav --allow-dirty)
+        status=0
+        for path in $(grep -rEho 'include_(str|bytes)!\("\.\./[^"]*"\)' src crates \
+          | sed -E 's/.*\("//; s/"\)$//; s|^(\.\./)+||' | sort -u); do
+          printf '%s\n' "$list" | grep -qxF "$path" && continue
+          echo "embedded but not packaged: $path" >&2
+          status=1
+        done
+        exit $status
+      '';
+      # Last, for the same ./target lock reason as test:portable.
+      after = [ "test:portable" ];
+    };
   };
 
-  enterTest = lib.mkForce "devenv tasks run test:fmt test:clippy test:nix test:unit test:portable";
+  # Named one by one, so a task added above is not in the suite until it is
+  # added here too - `devenv test` runs this line, not the task list.
+  enterTest = lib.mkForce "devenv tasks run test:fmt test:clippy test:nix test:unit test:portable test:package";
 }


### PR DESCRIPTION
`assets/` was excluded from the package as a whole directory, and the built-in segment skin lives there behind an `include_str!`. The published crate would not compile — `cargo install rav` fails on a file that is not in the tarball. The exclusion now names `assets/demo.gif`, the 2.4MB file it was written for.

No published version is affected. The skin landed in #131, after `1.0.0-beta.12` was cut, so the defect exists only on master — but release-plz publishes in dependency order, so `1.0.0-beta.13` would have failed at `rav` with `rav-core` and `rav-appearance` already on crates.io. Two immutable versions spent on a release that could not finish.

## Why nothing caught it

There are two independent inclusion lists, and #131 updated one:

| list | governs | where |
|---|---|---|
| crane's source filter | what `nix build` sees | `flake.nix`, `lib.hasInfix "/assets/skins/"` |
| cargo's `exclude` | what crates.io ships | `Cargo.toml` |

The CI job named **Package** is `nix build .#default`, so it passes on the first and never consults the second.

## Added

`test:package` reads every path embedded by `include_str!`/`include_bytes!` out of the source and checks it survives `cargo package`. The paths are not listed in the task, so an asset embedded later is covered without anyone remembering to add it.

`enterTest` names its tasks one at a time, so adding one to the task list does not put it in the suite. It is named there too.

## Verified

`devenv test` exits 1 with the old exclusion restored, naming the file, and 0 with the fix. `nix build` green.