### PR TITLE
fix: each crate's assets are checked against its own tarball

### DIFF
--- a/devenv.nix
+++ b/devenv.nix
@@ -465,19 +465,29 @@
       # tidiness point. A path above a package root cannot be packaged at all,
       # which this reports rather than tolerates.
       exec = ''
-        set -eu
+        set -euo pipefail
         status=0
         embedded() {
-          # `|| true`: a package with no external assets is the normal case, and
-          # grep exits 1 on no match, which set -e would take as a failure.
-          grep -rEho 'include_(str|bytes)!\("\.\./[^"]*"\)' "$1" 2>/dev/null \
-            | sed -E 's/.*\("//; s/"\)$//; s|^(\.\./)+||' | sort -u || true
+          # grep exits 1 when a crate embeds nothing, which is the normal case,
+          # and 2 or more when the scan itself failed. `|| true` would collapse
+          # the two and report "nothing embedded" for a search that never ran -
+          # a check that passes by not looking is worse than no check.
+          set +e
+          found=$(grep -rEho 'include_(str|bytes)!\("\.\./[^"]*"\)' "$1")
+          code=$?
+          set -e
+          if [ $code -gt 1 ]; then
+            echo "scanning $1 failed: grep exited $code" >&2
+            return 1
+          fi
+          printf '%s' "$found" | sed -E 's/.*\("//; s/"\)$//; s|^(\.\./)+||' | sort -u
         }
         # `asset`, never `path`: zsh ties $path to $PATH, so a loop variable of
         # that name empties the search path for everything after it.
         check() {
           list=$(cargo package --quiet --list -p "$1" --allow-dirty)
-          for asset in $(embedded "$2"); do
+          assets=$(embedded "$2")
+          for asset in $assets; do
             printf '%s\n' "$list" | grep -qxF "$asset" && continue
             echo "$1 embeds $asset, which is not in its package" >&2
             status=1

--- a/devenv.nix
+++ b/devenv.nix
@@ -475,9 +475,21 @@
           set +e
           found=$(grep -rEho 'include_(str|bytes)!\("\.\./[^"]*"\)' "$1")
           code=$?
+          # Every call the pattern above cannot read is a failure rather than a
+          # skip: a path long enough for rustfmt to wrap the line, or a raw
+          # string, would otherwise drop out of the check without saying so.
+          # Requiring the open paren keeps doc comments out of the count - they
+          # name the macro without calling it.
+          called=$(grep -rEoh 'include_(str|bytes)!\(' "$1" | wc -l | tr -d ' ')
+          literal=$(grep -rEoh 'include_(str|bytes)!\("' "$1" | wc -l | tr -d ' ')
+          concat=$(grep -rEoh 'include_(str|bytes)!\(concat!' "$1" | wc -l | tr -d ' ')
           set -e
           if [ $code -gt 1 ]; then
             echo "scanning $1 failed: grep exited $code" >&2
+            return 1
+          fi
+          if [ "$called" -ne "$((literal + concat))" ]; then
+            echo "$1: an include_str!/include_bytes! call this check cannot read" >&2
             return 1
           fi
           printf '%s' "$found" | sed -E 's/.*\("//; s/"\)$//; s|^(\.\./)+||' | sort -u

--- a/devenv.nix
+++ b/devenv.nix
@@ -458,16 +458,34 @@
       #
       # Paths are read out of the source rather than listed here, so an asset
       # embedded later is covered without anyone remembering to add it.
+      #
+      # Each package is checked against its own tarball. rav shipping a file
+      # says nothing about whether rav-appearance ships it, and rav-appearance
+      # is published first - so the wrong tarball is the burn case, not a
+      # tidiness point. A path above a package root cannot be packaged at all,
+      # which this reports rather than tolerates.
       exec = ''
         set -eu
-        list=$(cargo package --quiet --list -p rav --allow-dirty)
         status=0
-        for path in $(grep -rEho 'include_(str|bytes)!\("\.\./[^"]*"\)' src crates \
-          | sed -E 's/.*\("//; s/"\)$//; s|^(\.\./)+||' | sort -u); do
-          printf '%s\n' "$list" | grep -qxF "$path" && continue
-          echo "embedded but not packaged: $path" >&2
-          status=1
-        done
+        embedded() {
+          # `|| true`: a package with no external assets is the normal case, and
+          # grep exits 1 on no match, which set -e would take as a failure.
+          grep -rEho 'include_(str|bytes)!\("\.\./[^"]*"\)' "$1" 2>/dev/null \
+            | sed -E 's/.*\("//; s/"\)$//; s|^(\.\./)+||' | sort -u || true
+        }
+        # `asset`, never `path`: zsh ties $path to $PATH, so a loop variable of
+        # that name empties the search path for everything after it.
+        check() {
+          list=$(cargo package --quiet --list -p "$1" --allow-dirty)
+          for asset in $(embedded "$2"); do
+            printf '%s\n' "$list" | grep -qxF "$asset" && continue
+            echo "$1 embeds $asset, which is not in its package" >&2
+            status=1
+          done
+        }
+        check rav src
+        check rav-core crates/rav-core/src
+        check rav-appearance crates/rav-appearance/src
         exit $status
       '';
       # Last, for the same ./target lock reason as test:portable.


### PR DESCRIPTION
`test:package`, added in #137, read the sources of all three crates but compared every path against `rav`'s package list. A file embedded by `rav-appearance` therefore passed on the strength of `rav` shipping it — and `rav-appearance` is published first, so that is the case that burns a version rather than a tidiness point.

Each package is now checked against its own list, and a path above a package root is reported rather than tolerated, since cargo cannot package one at all.

Also renames the loop variable to `asset`. zsh ties `$path` to `$PATH`, so iterating over `path` empties the search path for every command after it.

## Verified

An asset embedded in `rav-appearance` that only `rav` ships: the previous check exits 0, this one exits 1 with `rav-appearance embeds assets/skins/segment.svg, which is not in its package`. `devenv test` and `nix build` green.