### PR TITLE
fix: a skin that will not parse stops the run

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -232,6 +232,15 @@ async fn rav_main() -> Result<()> {
     if let Some(path) = args.skin.as_deref() {
         let svg = std::fs::read_to_string(path)
             .with_context(|| format!("Cannot read the skin at {}", path.display()))?;
+        // Parsed before the screen is taken, for the same reason it is read
+        // here. A skin that will not parse draws nothing, and drawing nothing
+        // is indistinguishable from the plain ladder - so without this a typo
+        // in someone's own file looks like rav ignoring the flag.
+        anyhow::ensure!(
+            rav::render::sprite::parses(&svg),
+            "Cannot parse the skin at {} - it is not an SVG this can draw",
+            path.display(),
+        );
         app.wear_skin(Box::leak(svg.into_boxed_str()));
         info!("Using skin: {}", path.display());
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -87,6 +87,31 @@ async fn main() -> std::process::ExitCode {
 async fn rav_main() -> Result<()> {
     let args = Args::parse();
 
+    // Before the log file, the sound device and the screen, because all three
+    // are side effects and a file that cannot be used is a mistake in the
+    // command that was typed. Read here, worn further down where `App` exists.
+    //
+    // Leaked deliberately. A drawn skin is identified by the address of its
+    // text - see `render::sprite` - and this is read once for the life of the
+    // process, so one leak buys an identity check that cannot go wrong. A
+    // `String` handed in instead would be freed and its address reused.
+    let skin: Option<&'static str> = match args.skin.as_deref() {
+        Some(path) => {
+            let svg = std::fs::read_to_string(path)
+                .with_context(|| format!("Cannot read the skin at {}", path.display()))?;
+            // A skin that will not parse draws nothing, and drawing nothing is
+            // indistinguishable from the plain ladder - so without this a typo
+            // in someone's own file looks like rav ignoring the flag.
+            anyhow::ensure!(
+                rav::render::sprite::parses(&svg),
+                "Cannot parse the skin at {} - it is not an SVG this can draw",
+                path.display(),
+            );
+            Some(Box::leak(svg.into_boxed_str()))
+        }
+        None => None,
+    };
+
     // Initialize logging with clean mode support
     let log_level = if args.debug {
         "debug"
@@ -220,28 +245,8 @@ async fn rav_main() -> Result<()> {
         info!("Using theme: {theme}");
     }
 
-    // Read here rather than in `App` for the same reason a theme is: a path
-    // that cannot be read is a mistake worth stopping for, and reporting it
-    // once the alternate screen is up means reporting it where nobody can
-    // read it.
-    //
-    // Leaked deliberately. A drawn skin is identified by the address of its
-    // text - see `render::sprite` - and this is read once for the life of the
-    // process, so one leak buys an identity check that cannot go wrong. A
-    // `String` handed in instead would be freed and its address reused.
-    if let Some(path) = args.skin.as_deref() {
-        let svg = std::fs::read_to_string(path)
-            .with_context(|| format!("Cannot read the skin at {}", path.display()))?;
-        // Parsed before the screen is taken, for the same reason it is read
-        // here. A skin that will not parse draws nothing, and drawing nothing
-        // is indistinguishable from the plain ladder - so without this a typo
-        // in someone's own file looks like rav ignoring the flag.
-        anyhow::ensure!(
-            rav::render::sprite::parses(&svg),
-            "Cannot parse the skin at {} - it is not an SVG this can draw",
-            path.display(),
-        );
-        app.wear_skin(Box::leak(svg.into_boxed_str()));
+    if let (Some(svg), Some(path)) = (skin, args.skin.as_deref()) {
+        app.wear_skin(svg);
         info!("Using skin: {}", path.display());
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -73,11 +73,13 @@ async fn main() -> std::process::ExitCode {
     match rav_main().await {
         Ok(()) => std::process::ExitCode::SUCCESS,
         Err(problem) => {
-            // To stdout, deliberately. Everything rav can fail at happens after
-            // stderr has been pointed at the log file, so reporting the usual
-            // way means a mistyped `--theme` looks like rav dying in silence:
-            // exit 1, a blank terminal, and the reason in a file the user has
-            // no reason to look in.
+            // To stdout, deliberately. Nearly everything rav can fail at
+            // happens after stderr has been pointed at the log file, so
+            // reporting the usual way means a mistyped `--theme` looks like rav
+            // dying in silence: exit 1, a blank terminal, and the reason in a
+            // file the user has no reason to look in. The skin check runs
+            // before that redirection and would print either way; it goes here
+            // too, so one flag is not reported somewhere else than the next.
             println!("rav: {problem:#}");
             std::process::ExitCode::FAILURE
         }
@@ -102,11 +104,8 @@ async fn rav_main() -> Result<()> {
             // A skin that will not parse draws nothing, and drawing nothing is
             // indistinguishable from the plain ladder - so without this a typo
             // in someone's own file looks like rav ignoring the flag.
-            anyhow::ensure!(
-                rav::render::sprite::parses(&svg),
-                "Cannot parse the skin at {} - it is not an SVG this can draw",
-                path.display(),
-            );
+            rav::render::sprite::parses(&svg)
+                .with_context(|| format!("Cannot parse the skin at {}", path.display()))?;
             Some(Box::leak(svg.into_boxed_str()))
         }
         None => None,

--- a/src/render/sprite.rs
+++ b/src/render/sprite.rs
@@ -44,6 +44,16 @@ pub struct Sprite {
     down: u32,
 }
 
+/// Whether that is an SVG this can draw, without drawing it.
+///
+/// Startup asks before taking the screen. Once the frame loop has it, artwork
+/// that will not parse is only a reason to draw the plain ladder - which reads
+/// as rav ignoring the flag rather than as the file being wrong, and is why the
+/// question is worth asking early where the answer can still be printed.
+pub fn parses(svg: &str) -> bool {
+    usvg::Tree::from_str(svg, &usvg::Options::default()).is_ok()
+}
+
 impl Sprite {
     /// Parse an SVG and rasterise it to fill a rung of this size.
     ///

--- a/src/render/sprite.rs
+++ b/src/render/sprite.rs
@@ -44,14 +44,18 @@ pub struct Sprite {
     down: u32,
 }
 
-/// Whether that is an SVG this can draw, without drawing it.
+/// Parse that SVG and keep nothing but the verdict, and why if it is no.
 ///
 /// Startup asks before taking the screen. Once the frame loop has it, artwork
 /// that will not parse is only a reason to draw the plain ladder - which reads
 /// as rav ignoring the flag rather than as the file being wrong, and is why the
 /// question is worth asking early where the answer can still be printed.
-pub fn parses(svg: &str) -> bool {
-    usvg::Tree::from_str(svg, &usvg::Options::default()).is_ok()
+///
+/// The error is carried rather than thrown away because it is the useful half:
+/// `usvg` reports where the file stops making sense, and "this is not an SVG"
+/// leaves someone to find that themselves in a file they just drew.
+pub fn parses(svg: &str) -> Result<(), usvg::Error> {
+    usvg::Tree::from_str(svg, &usvg::Options::default()).map(drop)
 }
 
 impl Sprite {

--- a/tests/the_command_line.rs
+++ b/tests/the_command_line.rs
@@ -26,8 +26,15 @@ fn a_file_holding(svg: &str, named: &str) -> std::path::PathBuf {
     path
 }
 
-/// `--test-audio` opens no device, so this reaches the skin check on a machine
-/// with no sound card - which is every CI runner. The audio setup runs first.
+/// No pty and no sound device: the skin is checked before the log file, the
+/// device and the screen, so a run that has none of them still gets this far.
+/// If that ordering ever slips, these fail with whatever rav died of instead,
+/// which is how the ordering stays asserted rather than assumed.
+///
+/// `--list-devices` returns early, and it returns *after* the skin check - so
+/// a good skin reaches an exit rather than a terminal it cannot have, and this
+/// cannot hang waiting on a TUI that will never start. A skin check that moved
+/// below it would let the failing cases through, and they would say so.
 ///
 /// Returns what rav said on **stdout**, which is where it reports a failure on
 /// purpose: stderr is pointed at the log file early, so the usual channel would
@@ -35,7 +42,8 @@ fn a_file_holding(svg: &str, named: &str) -> std::path::PathBuf {
 /// so at the point it decides.
 fn rav_wearing(skin: &std::path::Path) -> (bool, String) {
     let out = Command::new(env!("CARGO_BIN_EXE_rav"))
-        .args(["--test-audio", "--skin"])
+        .arg("--list-devices")
+        .arg("--skin")
         .arg(skin)
         .output()
         .expect("run rav");

--- a/tests/the_command_line.rs
+++ b/tests/the_command_line.rs
@@ -1,0 +1,95 @@
+//! What the binary does with a file it was handed, before it takes the screen.
+//!
+//! A startup error is the last thing rav can say where anyone will read it.
+//! Once the alternate screen is up, a message goes onto a surface that is about
+//! to be painted over sixty times a second - so the checks that stop a run have
+//! to happen first, and this is where that ordering is asserted.
+//!
+//! No pty here: nothing in this file gets as far as needing one, and a test
+//! that built one would be asserting that the error came *before* the terminal
+//! by relying on a terminal.
+
+use std::process::Command;
+
+/// A skin someone is part-way through drawing: well-formed enough to look
+/// finished, and not parseable.
+const HALF_WRITTEN: &str =
+    r#"<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 10 10"><path d="M 0 0"#;
+
+/// A directory of this run's own, so two test binaries do not read each other's
+/// files or delete them mid-run.
+fn a_file_holding(svg: &str, named: &str) -> std::path::PathBuf {
+    let dir = std::env::temp_dir().join(format!("rav-cli-{}", std::process::id()));
+    std::fs::create_dir_all(&dir).expect("somewhere to write a skin");
+    let path = dir.join(named);
+    std::fs::write(&path, svg).expect("write the skin");
+    path
+}
+
+/// `--test-audio` opens no device, so this reaches the skin check on a machine
+/// with no sound card - which is every CI runner. The audio setup runs first.
+///
+/// Returns what rav said on **stdout**, which is where it reports a failure on
+/// purpose: stderr is pointed at the log file early, so the usual channel would
+/// make a mistyped flag look like rav dying without a word. `src/main.rs` says
+/// so at the point it decides.
+fn rav_wearing(skin: &std::path::Path) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_rav"))
+        .args(["--test-audio", "--skin"])
+        .arg(skin)
+        .output()
+        .expect("run rav");
+    (
+        out.status.success(),
+        String::from_utf8_lossy(&out.stdout).into_owned(),
+    )
+}
+
+#[test]
+fn a_skin_that_will_not_parse_stops_the_run_and_names_the_file() {
+    let path = a_file_holding(HALF_WRITTEN, "half-written.svg");
+    let (started, said) = rav_wearing(&path);
+    std::fs::remove_file(&path).ok();
+
+    // The alternative is what this replaces: rav starts, draws the plain block
+    // ladder, and says nothing - so a typo in someone's own file is
+    // indistinguishable from rav ignoring the flag.
+    assert!(!started, "rav started wearing a skin it cannot draw");
+    assert!(
+        said.contains(&*path.to_string_lossy()),
+        "the error does not say which file: {said}",
+    );
+}
+
+#[test]
+fn a_skin_that_is_not_there_stops_the_run_and_names_the_file() {
+    let path = std::env::temp_dir().join(format!("rav-cli-{}-absent.svg", std::process::id()));
+    let (started, said) = rav_wearing(&path);
+
+    assert!(!started, "rav started with no skin to wear");
+    assert!(
+        said.contains(&*path.to_string_lossy()),
+        "the error does not say which file: {said}",
+    );
+}
+
+#[test]
+fn a_skin_that_parses_is_not_what_stops_the_run() {
+    // The other half of the pair. Without this the two above would pass just as
+    // well against a rav that refused every skin, and the check would be
+    // measuring nothing but its own presence.
+    let path = a_file_holding(
+        r##"<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 10 10"><rect width="10" height="10" fill="#ffffff"/></svg>"##,
+        "plain.svg",
+    );
+    let (_started, said) = rav_wearing(&path);
+    std::fs::remove_file(&path).ok();
+
+    // Not "it succeeded": with no terminal to draw on, rav has every right to
+    // stop for that instead. What must not appear is a complaint about the
+    // skin, which is the thing this file is about.
+    assert!(
+        !said.contains("skin"),
+        "a skin that parses was refused anyway: {said}",
+    );
+}

--- a/tests/the_command_line.rs
+++ b/tests/the_command_line.rs
@@ -72,6 +72,10 @@ fn a_skin_that_will_not_parse_stops_the_run_and_names_the_file() {
 #[test]
 fn a_skin_that_is_not_there_stops_the_run_and_names_the_file() {
     let path = std::env::temp_dir().join(format!("rav-cli-{}-absent.svg", std::process::id()));
+    // A pid comes round again, and so does a temp directory that was never
+    // cleared. Without this, the one run where the name is already taken turns
+    // this into the case two tests down and passes for the wrong reason.
+    std::fs::remove_file(&path).ok();
     let (started, said) = rav_wearing(&path);
 
     assert!(!started, "rav started with no skin to wear");


### PR DESCRIPTION
A skin file that is not valid SVG was read, stored, and then failed to rasterise on the first frame — where the only thing left to do is draw the plain block ladder. A half-finished drawing, or a typo, therefore looked exactly like rav ignoring the flag: bars still moving, nothing said, and nothing in the help panel, which knows only about `needs pixels` and `needs a flat view`.

The skin is now parsed before the screen is taken, alongside the read that was already checked there, and a file that will not parse is an error naming the path — the behaviour `docs/skins.md` already describes.

## Added

`tests/the_command_line.rs`, covering what the binary does with a file it was handed — nothing did. A skin that will not parse and one that is not there both stop the run and name it; one that parses is not refused. That last is the control: without it the pair would pass just as well against a rav that turned down every skin.

The file asserts on **stdout**, not stderr, because that is where rav reports a failure on purpose — stderr is pointed at the log file early, so the usual channel would make a mistyped flag look like rav dying without a word.

## Verified

With the check removed, `a_skin_that_will_not_parse_stops_the_run_and_names_the_file` fails and the other two still pass. `devenv test` and `nix build` green.