### PR TITLE
fix: the demo tour walks every angle and comes back

### DIFF
--- a/devenv.nix
+++ b/devenv.nix
@@ -34,6 +34,10 @@
     gdb
     valgrind
     perf-tools
+
+    # record-demo reads the focused window and sends the tour's keys through
+    # this. macOS does both through osascript, which ships with the system.
+    xdotool
   ];
 
   # Development scripts
@@ -268,13 +272,23 @@
       # uyvy422 and chroma-subsamples the bars into a smear.
       GRAB=(-f avfoundation -capture_cursor 0 -pixel_format bgr0 -framerate "$FPS" -i "$SCREEN:none")
     else
-      if [ -z "$GEOMETRY" ] && command -v xdotool >/dev/null 2>&1; then
+      # Checked before the geometry, because the keys need it too. Reading the
+      # window is the part RAV_DEMO_GEOMETRY can stand in for; sending the tour
+      # is not - so without this, setting that variable on a machine with no
+      # xdotool records the full duration of a screen nobody ever pressed a key
+      # on, and nothing anywhere says so.
+      if ! command -v xdotool >/dev/null 2>&1; then
+        echo "❌ xdotool sends the tour's keys and is not on PATH."
+        echo "   It is in the devenv shell; outside it, install xdotool."
+        exit 1
+      fi
+      if [ -z "$GEOMETRY" ]; then
         GEOMETRY=$(xdotool getactivewindow getwindowgeometry --shell \
           | awk -F= '/^X=/{x=$2} /^Y=/{y=$2} /^WIDTH=/{w=$2} /^HEIGHT=/{h=$2} END{print w "x" h "+" x "+" y}')
       fi
       if [ -z "$GEOMETRY" ]; then
-        echo "❌ Set RAV_DEMO_GEOMETRY=941x249+X+Y (or install xdotool to read the"
-        echo "   focused window automatically)."
+        echo "❌ Could not read the focused window's geometry."
+        echo "   Set RAV_DEMO_GEOMETRY=941x249+X+Y."
         exit 1
       fi
     fi
@@ -293,6 +307,12 @@
     # Send one keypress to whatever window is focused - which is rav's, since the
     # countdown just asked for it. Both of these need the same permission the
     # geometry read above already used.
+    #
+    # Silent on failure, deliberately: the recording is running by now and
+    # anything printed here lands on the screen being filmed. What could go
+    # wrong is checked above instead, where saying so is still free - macOS by
+    # the geometry read, which needs the same Accessibility grant these do, and
+    # Linux by the xdotool check.
     send_key() {
       case "$(uname -s)" in
       Darwin)
@@ -303,7 +323,7 @@
         fi
         ;;
       *)
-        command -v xdotool >/dev/null 2>&1 && xdotool key --clearmodifiers "$1" || true
+        xdotool key --clearmodifiers "$1" >/dev/null 2>&1 || true
         ;;
       esac
     }

--- a/devenv.nix
+++ b/devenv.nix
@@ -189,11 +189,16 @@
     # press of each is what returns to the first, and leaving it out is how the
     # tour quietly stops ending where it began.
     #
+    # Four themes and five angles. `tests/the_demo_tour.rs` counts both against
+    # the enums, because a view added without a press here is invisible until
+    # someone looks closely at a finished GIF - which is how the fifth angle
+    # went missing.
+    #
     # The angles are the reason the terminal matters. `v` does nothing on block
     # characters and the panel says `needs pixels`, so a recording made in a
     # terminal that cannot draw images shows four seconds of a key not working.
     # Record in WezTerm, Ghostty or kitty.
-    TOUR="''${RAV_DEMO_TOUR:-3:t 3:t 3:t 3:t 2:v 2:v 2:v 2:v 1:space 4:space 1:h 4:h 2:-}"
+    TOUR="''${RAV_DEMO_TOUR:-3:t 3:t 3:t 3:t 2:v 2:v 2:v 2:v 2:v 1:space 4:space 1:h 4:h 2:-}"
     # Total duration is the sum of the tour's holds, so the two never drift.
     # SETTLE covers the second avfoundation spends opening the capture device -
     # without it the first key lands before filming starts and that segment is

--- a/tests/the_demo_tour.rs
+++ b/tests/the_demo_tour.rs
@@ -1,0 +1,77 @@
+//! The demo tour walks every theme and every angle, and comes back.
+//!
+//! `record-demo` drives the GIF on the front page by sending keys on a timer,
+//! and the tour is a string in `devenv.nix`. One press per theme and one per
+//! angle, because the last press of each is what returns to the first - so a
+//! setting added to rav without a press added here leaves the recording ending
+//! somewhere other than it started, and the GIF stops looping cleanly.
+//!
+//! That is not hypothetical: the fifth viewing angle arrived after the tour was
+//! written and the tour went on pressing `v` four times. The plan predicted
+//! this exact coupling before either existed. Nothing else checks it, because
+//! the failure is only visible to someone watching a finished recording.
+
+use rav_appearance::scene::View;
+use rav_appearance::theme::Theme;
+
+/// The tour as `record-demo` defaults it, or `None` where `devenv.nix` is not
+/// beside us - a crate unpacked from the registry has the tests and not the
+/// development environment, and that is not a failure.
+fn default_tour() -> Option<String> {
+    let nix = std::fs::read_to_string("devenv.nix").ok()?;
+    let line = nix.lines().find(|line| line.contains("RAV_DEMO_TOUR:-"))?;
+    let after = line.split("RAV_DEMO_TOUR:-").nth(1)?;
+    Some(after.split('}').next()?.to_string())
+}
+
+/// How many times the tour sends that key.
+fn presses_of(tour: &str, key: char) -> usize {
+    tour.split_whitespace()
+        .filter_map(|step| step.split(':').nth(1))
+        .filter(|sent| sent.chars().eq(std::iter::once(key)))
+        .count()
+}
+
+#[test]
+fn one_press_per_viewing_angle() {
+    let Some(tour) = default_tour() else {
+        return;
+    };
+    let mut angles = 1;
+    let mut view = View::default().next();
+    while view != View::default() {
+        angles += 1;
+        view = view.next();
+    }
+
+    // Where the tour actually leaves the field, by pressing `v` as it does.
+    // Naming it is the whole value of the message: "four presses, five angles"
+    // is arithmetic, and "it ends on swaying" is the thing to go and look at.
+    let pressed = presses_of(&tour, 'v');
+    let ends_on = (0..pressed).fold(View::default(), |view, _| view.next());
+
+    assert_eq!(
+        pressed,
+        angles,
+        "the tour presses `v` {pressed} times for {angles} angles, so the \
+         recording ends on {} rather than back at {}\ntour: {tour}",
+        ends_on.label(),
+        View::default().label(),
+    );
+}
+
+#[test]
+fn one_press_per_built_in_theme() {
+    let Some(tour) = default_tour() else {
+        return;
+    };
+    let themes = Theme::built_in_names().count();
+
+    assert_eq!(
+        presses_of(&tour, 't'),
+        themes,
+        "the tour presses `t` {} times for {themes} themes, so the recording \
+         does not end on the theme it opened with\ntour: {tour}",
+        presses_of(&tour, 't'),
+    );
+}

--- a/tests/the_demo_tour.rs
+++ b/tests/the_demo_tour.rs
@@ -17,11 +17,33 @@ use rav_appearance::theme::Theme;
 /// The tour as `record-demo` defaults it, or `None` where `devenv.nix` is not
 /// beside us - a crate unpacked from the registry has the tests and not the
 /// development environment, and that is not a failure.
+///
+/// Absent and unreadable are told apart on purpose. A file that is there and
+/// does not parse means `record-demo` has been rewritten, and returning `None`
+/// for it would leave both of these skipping in the one repository that has the
+/// script - green, and guarding nothing. That is the failure they exist to
+/// catch in the recording, so they had better not be it themselves.
 fn default_tour() -> Option<String> {
     let nix = std::fs::read_to_string("devenv.nix").ok()?;
-    let line = nix.lines().find(|line| line.contains("RAV_DEMO_TOUR:-"))?;
-    let after = line.split("RAV_DEMO_TOUR:-").nth(1)?;
-    Some(after.split('}').next()?.to_string())
+    let line = nix
+        .lines()
+        .find(|line| line.contains("RAV_DEMO_TOUR:-"))
+        .expect("devenv.nix is here but names no RAV_DEMO_TOUR - has record-demo moved?");
+    let after = line
+        .split("RAV_DEMO_TOUR:-")
+        .nth(1)
+        .expect("RAV_DEMO_TOUR is named but has no default after `:-`");
+    let tour = after
+        .split('}')
+        .next()
+        .expect("the default is never closed")
+        .trim()
+        .to_string();
+    assert!(
+        tour.split_whitespace().all(|step| step.contains(':')),
+        "the tour is not `seconds:key` steps any more: {tour}",
+    );
+    Some(tour)
 }
 
 /// How many times the tour sends that key.


### PR DESCRIPTION
`record-demo` drives the GIF on the front page by sending keys on a timer. It pressed `v` four times for **five** viewing angles, so the tour left the field on `swaying` and the recording stopped looping from the frame it opened on — the last press of each key is what returns to the first. The fifth angle landed in #130, after the tour was written in #129.

The tour now runs 36 seconds rather than 34. Duration is summed from the tour itself, so that needed no separate change.

## Added

`tests/the_demo_tour.rs` counts the presses against the `View` and `Theme` enums. Nothing checked this coupling, and the failure is only visible to someone watching a finished GIF closely enough to see where it stops — which is why it survived a release. The plan's blast-radius table called out this exact coupling before either side of it existed.

The tests skip where `devenv.nix` is not beside them: a crate unpacked from the registry carries `tests/` and not the development environment, and that is not a failure.

## Verified

With the fifth press removed the angle test fails with `the tour presses \`v\` 4 times for 5 angles, so the recording ends on swaying rather than back at flat`, and the theme test still passes. `devenv test` green.

Worth knowing before re-recording the demo: this is the tour that will run.