### PR TITLE
feat: a window of rav's own

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,10 +3,39 @@
 version = 4
 
 [[package]]
+name = "ab_glyph"
+version = "0.2.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01c0457472c38ea5bd1c3b5ada5e368271cb550be7a4ca4a0b4634e9913f6cc2"
+dependencies = [
+ "ab_glyph_rasterizer",
+ "owned_ttf_parser",
+]
+
+[[package]]
+name = "ab_glyph_rasterizer"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "366ffbaa4442f4684d91e2cd7c5ea7c4ed8add41959a31447066e279e432b618"
+
+[[package]]
 name = "adler2"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "getrandom 0.3.4",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
 
 [[package]]
 name = "aho-corasick"
@@ -44,6 +73,31 @@ dependencies = [
  "libc",
  "pkg-config",
 ]
+
+[[package]]
+name = "android-activity"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f2a1bb052857d5dd49572219344a7332b31b76405648eabac5bc68978251bcd"
+dependencies = [
+ "android-properties",
+ "bitflags 2.13.1",
+ "cc",
+ "jni 0.22.4",
+ "libc",
+ "log",
+ "ndk 0.9.0",
+ "ndk-context",
+ "ndk-sys 0.6.0+11769913",
+ "num_enum",
+ "thiserror 2.0.20",
+]
+
+[[package]]
+name = "android-properties"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc7eb209b1518d6bb87b283c20095f5228ecda460da70b44f0802523dea6da04"
 
 [[package]]
 name = "anstream"
@@ -114,6 +168,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3fb67a6e08acf24fdeccbac2cb6ac4305825bd1f117462e0e6f2f193345ad56"
 
 [[package]]
+name = "as-raw-xcb-connection"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175571dd1d178ced59193a6fc02dde1b972eb0bc56c892cde9beeceac5bf0f6b"
+
+[[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
 name = "autocfg"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -166,11 +232,20 @@ checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 
 [[package]]
 name = "block2"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c132eebf10f5cad5289222520a4a058514204aed6d791f1cf4fe8088b82d15f"
+dependencies = [
+ "objc2 0.5.2",
+]
+
+[[package]]
+name = "block2"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
 dependencies = [
- "objc2",
+ "objc2 0.6.4",
 ]
 
 [[package]]
@@ -184,12 +259,52 @@ name = "bytemuck"
 version = "1.25.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95832e849adfb21180ccb6826a99da14e5d266ae5c2e668e1602cf234f153797"
+dependencies = [
+ "bytemuck_derive",
+]
+
+[[package]]
+name = "bytemuck_derive"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0e56a716f1e132ff6bf4bdac1c944a3fcdc1cae65f70a4a2a1ac3b401d2d1f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
 
 [[package]]
 name = "bytes"
 version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
+
+[[package]]
+name = "calloop"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b99da2f8558ca23c71f4fd15dc57c906239752dd27ff3c00a1d56b685b7cbfec"
+dependencies = [
+ "bitflags 2.13.1",
+ "log",
+ "polling",
+ "rustix 0.38.44",
+ "slab",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "calloop-wayland-source"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95a66a987056935f7efce4ab5668920b5d0dac4a7c99991a67395f13702ddd20"
+dependencies = [
+ "calloop",
+ "rustix 0.38.44",
+ "wayland-backend",
+ "wayland-client",
+]
 
 [[package]]
 name = "cassowary"
@@ -238,6 +353,12 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
 
 [[package]]
 name = "clang-sys"
@@ -321,10 +442,53 @@ dependencies = [
 ]
 
 [[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "core-graphics"
+version = "0.23.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c07782be35f9e1140080c6b96f0d44b739e2278479f64e02fdab4e32dfd8b081"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation",
+ "core-graphics-types",
+ "foreign-types",
+ "libc",
+]
+
+[[package]]
+name = "core-graphics-types"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45390e6114f68f718cc7a830514a96f903cccd70d02a8f6d9f643ac4ba45afaf"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation",
+ "libc",
+]
 
 [[package]]
 name = "coreaudio-rs"
@@ -356,11 +520,11 @@ dependencies = [
  "core-foundation-sys",
  "coreaudio-rs",
  "dasp_sample",
- "jni",
+ "jni 0.21.1",
  "js-sys",
  "libc",
  "mach2",
- "ndk",
+ "ndk 0.8.0",
  "ndk-context",
  "oboe",
  "wasm-bindgen",
@@ -377,6 +541,12 @@ checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
 ]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
 
 [[package]]
 name = "crossterm"
@@ -402,6 +572,21 @@ checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
 dependencies = [
  "winapi",
 ]
+
+[[package]]
+name = "ctor"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83cf0d42651b16c6dfe68685716d18480d18a9c39c62d76e8cf3eb6ed5d8bcbf"
+dependencies = [
+ "dtor",
+]
+
+[[package]]
+name = "cursor-icon"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f27ae1dd37df86211c42e150270f82743308803d90a6f6e6651cd730d5e1732f"
 
 [[package]]
 name = "darling"
@@ -471,14 +656,87 @@ dependencies = [
 ]
 
 [[package]]
+name = "dispatch"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd0c93bb4b0c6d9b77f4435b0ae98c24d17f1c45b2ff844c6151a07256ca923b"
+
+[[package]]
 name = "dispatch2"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
 dependencies = [
  "bitflags 2.13.1",
- "objc2",
+ "objc2 0.6.4",
 ]
+
+[[package]]
+name = "dlib"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab8ecd87370524b461f8557c119c405552c396ed91fc0a8eec68679eab26f94a"
+dependencies = [
+ "libloading",
+]
+
+[[package]]
+name = "downcast-rs"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
+
+[[package]]
+name = "dpi"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8b14ccef22fc6f5a8f4d7d768562a182c04ce9a3b3157b91390b52ddfdf1a76"
+
+[[package]]
+name = "drm"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80bc8c5c6c2941f70a55c15f8d9f00f9710ebda3ffda98075f996a0e6c92756f"
+dependencies = [
+ "bitflags 2.13.1",
+ "bytemuck",
+ "drm-ffi",
+ "drm-fourcc",
+ "libc",
+ "rustix 0.38.44",
+]
+
+[[package]]
+name = "drm-ffi"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51a91c9b32ac4e8105dec255e849e0d66e27d7c34d184364fb93e469db08f690"
+dependencies = [
+ "drm-sys",
+ "rustix 1.1.4",
+]
+
+[[package]]
+name = "drm-fourcc"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0aafbcdb8afc29c1a7ee5fbe53b5d62f4565b35a042a662ca9fecd0b54dae6f4"
+
+[[package]]
+name = "drm-sys"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8e1361066d91f5ffccff060a3c3be9c3ecde15be2959c1937595f7a82a9f8"
+dependencies = [
+ "libc",
+ "linux-raw-sys 0.9.4",
+]
+
+[[package]]
+name = "dtor"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edf234dd1594d6dd434a8fb8cada51ddbbc593e40e4a01556a0b31c62da2775b"
 
 [[package]]
 name = "either"
@@ -573,6 +831,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
+name = "foreign-types"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d737d9aa519fb7b749cbc3b962edcf310a8dd1f4b67c91c4f83975dbdd17d965"
+dependencies = [
+ "foreign-types-macros",
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-macros"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea5190182e6915eb873ddbc16e23b711b6eb1f9c00a0d0a3a91b5f6228475225"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa9a19cbb55df58761df49b23516a86d432839add4af60fc256da840f66ed35b"
+
+[[package]]
 name = "futures-core"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -600,6 +885,16 @@ dependencies = [
  "futures-task",
  "pin-project-lite",
  "slab",
+]
+
+[[package]]
+name = "gethostname"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bd49230192a3797a9a4d6abe9b3eed6f7fa4c8a8a4947977c6f80025f92cbd8"
+dependencies = [
+ "rustix 1.1.4",
+ "windows-link",
 ]
 
 [[package]]
@@ -666,6 +961,12 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "ident_case"
@@ -743,9 +1044,39 @@ dependencies = [
  "combine",
  "jni-sys 0.3.1",
  "log",
- "thiserror",
+ "thiserror 1.0.69",
  "walkdir",
  "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "jni"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+dependencies = [
+ "cfg-if",
+ "combine",
+ "jni-macros",
+ "jni-sys 0.4.1",
+ "log",
+ "simd_cesu8",
+ "thiserror 2.0.20",
+ "walkdir",
+ "windows-link",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -843,7 +1174,10 @@ version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2026a5056764a10b2bf5d56488cba40da507f5493a6a429340e2004d9ed085fa"
 dependencies = [
+ "bitflags 2.13.1",
  "libc",
+ "plain",
+ "redox_syscall 0.9.2",
 ]
 
 [[package]]
@@ -851,6 +1185,12 @@ name = "linux-raw-sys"
 version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
 
 [[package]]
 name = "linux-raw-sys"
@@ -907,6 +1247,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
+name = "memmap2"
+version = "0.9.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1219ed1b7f229ee7104d281dd01d6802fe28bb6e95d292942c4daacdeb798c0"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -952,9 +1301,24 @@ dependencies = [
  "bitflags 2.13.1",
  "jni-sys 0.3.1",
  "log",
- "ndk-sys",
+ "ndk-sys 0.5.0+25.2.9519653",
  "num_enum",
- "thiserror",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "ndk"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3f42e7bbe13d351b6bead8286a43aac9534b82bd3cc43e47037f012ebfd62d4"
+dependencies = [
+ "bitflags 2.13.1",
+ "jni-sys 0.3.1",
+ "log",
+ "ndk-sys 0.6.0+11769913",
+ "num_enum",
+ "raw-window-handle",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -968,6 +1332,15 @@ name = "ndk-sys"
 version = "0.5.0+25.2.9519653"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c196769dd60fd4f363e11d948139556a344e79d451aeb2fa2fd040738ef7691"
+dependencies = [
+ "jni-sys 0.3.1",
+]
+
+[[package]]
+name = "ndk-sys"
+version = "0.6.0+11769913"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee6cda3051665f1fb8d9e08fc35c96d5a244fb1be711a03b71118828afc9a873"
 dependencies = [
  "jni-sys 0.3.1",
 ]
@@ -1052,12 +1425,80 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc-sys"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdb91bdd390c7ce1a8607f35f3ca7151b65afc0ff5ff3b34fa350f7d7c7e4310"
+
+[[package]]
+name = "objc2"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46a785d4eeff09c14c487497c162e92766fbb3e4059a71840cecc03d9a50b804"
+dependencies = [
+ "objc-sys",
+ "objc2-encode",
+]
+
+[[package]]
 name = "objc2"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a12a8ed07aefc768292f076dc3ac8c48f3781c8f2d5851dd3d98950e8c5a89f"
 dependencies = [
  "objc2-encode",
+]
+
+[[package]]
+name = "objc2-app-kit"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4e89ad9e3d7d297152b17d39ed92cd50ca8063a89a9fa569046d41568891eff"
+dependencies = [
+ "bitflags 2.13.1",
+ "block2 0.5.1",
+ "libc",
+ "objc2 0.5.2",
+ "objc2-core-data",
+ "objc2-core-image",
+ "objc2-foundation 0.2.2",
+ "objc2-quartz-core 0.2.2",
+]
+
+[[package]]
+name = "objc2-cloud-kit"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74dd3b56391c7a0596a295029734d3c1c5e7e510a4cb30245f8221ccea96b009"
+dependencies = [
+ "bitflags 2.13.1",
+ "block2 0.5.1",
+ "objc2 0.5.2",
+ "objc2-core-location",
+ "objc2-foundation 0.2.2",
+]
+
+[[package]]
+name = "objc2-contacts"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5ff520e9c33812fd374d8deecef01d4a840e7b41862d849513de77e44aa4889"
+dependencies = [
+ "block2 0.5.1",
+ "objc2 0.5.2",
+ "objc2-foundation 0.2.2",
+]
+
+[[package]]
+name = "objc2-core-data"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "617fbf49e071c178c0b24c080767db52958f716d9eabdf0890523aeae54773ef"
+dependencies = [
+ "bitflags 2.13.1",
+ "block2 0.5.1",
+ "objc2 0.5.2",
+ "objc2-foundation 0.2.2",
 ]
 
 [[package]]
@@ -1068,7 +1509,44 @@ checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
  "bitflags 2.13.1",
  "dispatch2",
- "objc2",
+ "objc2 0.6.4",
+]
+
+[[package]]
+name = "objc2-core-graphics"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e022c9d066895efa1345f8e33e584b9f958da2fd4cd116792e15e07e4720a807"
+dependencies = [
+ "bitflags 2.13.1",
+ "dispatch2",
+ "objc2 0.6.4",
+ "objc2-core-foundation",
+ "objc2-io-surface",
+]
+
+[[package]]
+name = "objc2-core-image"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55260963a527c99f1819c4f8e3b47fe04f9650694ef348ffd2227e8196d34c80"
+dependencies = [
+ "block2 0.5.1",
+ "objc2 0.5.2",
+ "objc2-foundation 0.2.2",
+ "objc2-metal",
+]
+
+[[package]]
+name = "objc2-core-location"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "000cfee34e683244f284252ee206a27953279d370e309649dc3ee317b37e5781"
+dependencies = [
+ "block2 0.5.1",
+ "objc2 0.5.2",
+ "objc2-contacts",
+ "objc2-foundation 0.2.2",
 ]
 
 [[package]]
@@ -1079,15 +1557,143 @@ checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
 
 [[package]]
 name = "objc2-foundation"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ee638a5da3799329310ad4cfa62fbf045d5f56e3ef5ba4149e7452dcf89d5a8"
+dependencies = [
+ "bitflags 2.13.1",
+ "block2 0.5.1",
+ "dispatch",
+ "libc",
+ "objc2 0.5.2",
+]
+
+[[package]]
+name = "objc2-foundation"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
  "bitflags 2.13.1",
- "block2",
+ "block2 0.6.2",
  "libc",
- "objc2",
+ "objc2 0.6.4",
  "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-io-surface"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "180788110936d59bab6bd83b6060ffdfffb3b922ba1396b312ae795e1de9d81d"
+dependencies = [
+ "bitflags 2.13.1",
+ "objc2 0.6.4",
+ "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-link-presentation"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1a1ae721c5e35be65f01a03b6d2ac13a54cb4fa70d8a5da293d7b0020261398"
+dependencies = [
+ "block2 0.5.1",
+ "objc2 0.5.2",
+ "objc2-app-kit",
+ "objc2-foundation 0.2.2",
+]
+
+[[package]]
+name = "objc2-metal"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd0cba1276f6023976a406a14ffa85e1fdd19df6b0f737b063b95f6c8c7aadd6"
+dependencies = [
+ "bitflags 2.13.1",
+ "block2 0.5.1",
+ "objc2 0.5.2",
+ "objc2-foundation 0.2.2",
+]
+
+[[package]]
+name = "objc2-quartz-core"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e42bee7bff906b14b167da2bac5efe6b6a07e6f7c0a21a7308d40c960242dc7a"
+dependencies = [
+ "bitflags 2.13.1",
+ "block2 0.5.1",
+ "objc2 0.5.2",
+ "objc2-foundation 0.2.2",
+ "objc2-metal",
+]
+
+[[package]]
+name = "objc2-quartz-core"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96c1358452b371bf9f104e21ec536d37a650eb10f7ee379fff67d2e08d537f1f"
+dependencies = [
+ "bitflags 2.13.1",
+ "objc2 0.6.4",
+ "objc2-core-foundation",
+ "objc2-foundation 0.3.2",
+]
+
+[[package]]
+name = "objc2-symbols"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a684efe3dec1b305badae1a28f6555f6ddd3bb2c2267896782858d5a78404dc"
+dependencies = [
+ "objc2 0.5.2",
+ "objc2-foundation 0.2.2",
+]
+
+[[package]]
+name = "objc2-ui-kit"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8bb46798b20cd6b91cbd113524c490f1686f4c4e8f49502431415f3512e2b6f"
+dependencies = [
+ "bitflags 2.13.1",
+ "block2 0.5.1",
+ "objc2 0.5.2",
+ "objc2-cloud-kit",
+ "objc2-core-data",
+ "objc2-core-image",
+ "objc2-core-location",
+ "objc2-foundation 0.2.2",
+ "objc2-link-presentation",
+ "objc2-quartz-core 0.2.2",
+ "objc2-symbols",
+ "objc2-uniform-type-identifiers",
+ "objc2-user-notifications",
+]
+
+[[package]]
+name = "objc2-uniform-type-identifiers"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44fa5f9748dbfe1ca6c0b79ad20725a11eca7c2218bceb4b005cb1be26273bfe"
+dependencies = [
+ "block2 0.5.1",
+ "objc2 0.5.2",
+ "objc2-foundation 0.2.2",
+]
+
+[[package]]
+name = "objc2-user-notifications"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76cfcbf642358e8689af64cee815d139339f3ed8ad05103ed5eaf73db8d84cb3"
+dependencies = [
+ "bitflags 2.13.1",
+ "block2 0.5.1",
+ "objc2 0.5.2",
+ "objc2-core-location",
+ "objc2-foundation 0.2.2",
 ]
 
 [[package]]
@@ -1096,8 +1702,8 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8b61bebd49e5d43f5f8cc7ee2891c16e0f41ec7954d36bcb6c14c5e0de867fb"
 dependencies = [
- "jni",
- "ndk",
+ "jni 0.21.1",
+ "ndk 0.8.0",
  "ndk-context",
  "num-derive",
  "num-traits",
@@ -1132,6 +1738,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
+name = "orbclient"
+version = "0.3.55"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5df339f526ea9a60e371768d50efc2f2508c7203290731565d1f7a6f71d21747"
+dependencies = [
+ "libc",
+ "libredox",
+]
+
+[[package]]
+name = "owned_ttf_parser"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36820e9051aca1014ddc75770aab4d68bc1e9e632f0f5627c4086bc216fb583b"
+dependencies = [
+ "ttf-parser",
+]
+
+[[package]]
 name = "parking_lot"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1149,7 +1774,7 @@ checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.5.18",
  "smallvec",
  "windows-link",
 ]
@@ -1161,10 +1786,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
+name = "percent-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
 name = "pico-args"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5be167a7af36ee22fe3115051bc51f6e6c7054c9348e28deb4f49bd6f705a315"
+
+[[package]]
+name = "pin-project"
+version = "1.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2466b2336ed02bcdca6b294417127b90ec92038d1d5c4fbeac971a922e0e0924"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
 
 [[package]]
 name = "pin-project-lite"
@@ -1179,6 +1830,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
+name = "plain"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
+
+[[package]]
 name = "png"
 version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1189,6 +1846,20 @@ dependencies = [
  "fdeflate",
  "flate2",
  "miniz_oxide",
+]
+
+[[package]]
+name = "polling"
+version = "3.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
+dependencies = [
+ "cfg-if",
+ "concurrent-queue",
+ "hermit-abi",
+ "pin-project-lite",
+ "rustix 1.1.4",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1260,6 +1931,15 @@ name = "quick-error"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+
+[[package]]
+name = "quick-xml"
+version = "0.41.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "quote"
@@ -1352,8 +2032,8 @@ dependencies = [
  "dirs",
  "flume",
  "libc",
- "objc2",
- "objc2-foundation",
+ "objc2 0.6.4",
+ "objc2-foundation 0.3.2",
  "proptest",
  "ratatui",
  "rav-appearance",
@@ -1362,12 +2042,14 @@ dependencies = [
  "resvg",
  "rustfft",
  "serde",
- "tiny-skia",
+ "softbuffer",
+ "tiny-skia 0.12.0",
  "tokio",
  "toml",
  "tracing",
  "tracing-subscriber",
  "usvg",
+ "winit",
 ]
 
 [[package]]
@@ -1387,12 +2069,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "raw-window-handle"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20675572f6f24e9e76ef639bc5552774ed45f1c30e2951e1e99c59888861c539"
+
+[[package]]
 name = "realfft"
 version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f821338fddb99d089116342c46e9f1fbf3828dba077674613e734e01d6ea8677"
 dependencies = [
  "rustfft",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
+dependencies = [
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -1405,6 +2102,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1c93da5bb2c5d4e6c0ef7abeead62c89169a0a4882bfb83ac892f2423aea2fe"
+dependencies = [
+ "bitflags 2.13.1",
+]
+
+[[package]]
 name = "redox_users"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1412,7 +2118,7 @@ checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
 dependencies = [
  "getrandom 0.2.17",
  "libredox",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -1455,7 +2161,7 @@ dependencies = [
  "pico-args",
  "rgb",
  "svgtypes",
- "tiny-skia",
+ "tiny-skia 0.12.0",
  "usvg",
 ]
 
@@ -1482,6 +2188,15 @@ name = "rustc-hash"
 version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
+
+[[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
 
 [[package]]
 name = "rustfft"
@@ -1557,10 +2272,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "scoped-tls"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "sctk-adwaita"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6277f0217056f77f1d8f49f2950ac6c278c0d607c45f5ee99328d792ede24ec"
+dependencies = [
+ "ab_glyph",
+ "log",
+ "memmap2",
+ "smithay-client-toolkit",
+ "tiny-skia 0.11.4",
+]
+
+[[package]]
+name = "semver"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -1660,6 +2400,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a219298ac11a56ea9a6d2120044824d6f01aeb034955e7af7bc16858527deea"
 
 [[package]]
+name = "simd_cesu8"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11031e251abf8611c80f460e19dbdeb54a66db918e49c65a7065b46ac7aec520"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
 name = "simplecss"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1687,6 +2443,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
+name = "smithay-client-toolkit"
+version = "0.19.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3457dea1f0eb631b4034d61d4d8c32074caa6cd1ab2d59f2327bd8461e2c0016"
+dependencies = [
+ "bitflags 2.13.1",
+ "calloop",
+ "calloop-wayland-source",
+ "cursor-icon",
+ "libc",
+ "log",
+ "memmap2",
+ "rustix 0.38.44",
+ "thiserror 1.0.69",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-csd-frame",
+ "wayland-cursor",
+ "wayland-protocols",
+ "wayland-protocols-wlr",
+ "wayland-scanner",
+ "xkeysym",
+]
+
+[[package]]
+name = "smol_str"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd538fb6910ac1099850255cf94a94df6551fbdd602454387d0adb2d1ca6dead"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "socket2"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1694,6 +2484,38 @@ checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "softbuffer"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aac18da81ebbf05109ab275b157c22a653bb3c12cf884450179942f81bcbf6c3"
+dependencies = [
+ "as-raw-xcb-connection",
+ "bytemuck",
+ "drm",
+ "fastrand",
+ "js-sys",
+ "memmap2",
+ "ndk 0.9.0",
+ "objc2 0.6.4",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-foundation 0.3.2",
+ "objc2-quartz-core 0.3.2",
+ "raw-window-handle",
+ "redox_syscall 0.5.18",
+ "rustix 1.1.4",
+ "tiny-xlib",
+ "tracing",
+ "wasm-bindgen",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-sys",
+ "web-sys",
+ "windows-sys 0.61.2",
+ "x11rb",
 ]
 
 [[package]]
@@ -1805,7 +2627,16 @@ version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec86235f5fcc2a73650310756d2ac5b138a5780bbbdfae3eeccec992c435ba4f"
+dependencies = [
+ "thiserror-impl 2.0.20",
 ]
 
 [[package]]
@@ -1820,12 +2651,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "thiserror-impl"
+version = "2.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc04cd3e1236dd4a98afca4569f2deb3f120e5422a4023be2cb683f8486292af"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
+
+[[package]]
 name = "thread_local"
 version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ad99c4c6d32803332c548b1af0540b357b3f5fc0be8f6c6bfe8b2e6ae784070"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "tiny-skia"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83d13394d44dae3207b52a326c0c85a8bf87f1541f23b0d143811088497b09ab"
+dependencies = [
+ "arrayref",
+ "arrayvec",
+ "bytemuck",
+ "cfg-if",
+ "log",
+ "tiny-skia-path 0.11.4",
 ]
 
 [[package]]
@@ -1840,7 +2696,18 @@ dependencies = [
  "cfg-if",
  "log",
  "png",
- "tiny-skia-path",
+ "tiny-skia-path 0.12.0",
+]
+
+[[package]]
+name = "tiny-skia-path"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c9e7fc0c2e86a30b117d0462aa261b72b7a99b7ebd7deb3a14ceda95c5bdc93"
+dependencies = [
+ "arrayref",
+ "bytemuck",
+ "strict-num",
 ]
 
 [[package]]
@@ -1852,6 +2719,19 @@ dependencies = [
  "arrayref",
  "bytemuck",
  "strict-num",
+]
+
+[[package]]
+name = "tiny-xlib"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a90a0ca3ee6a69f2ad28fd11621a4c3f03b371f366be500b64df260c4ffbafb4"
+dependencies = [
+ "as-raw-xcb-connection",
+ "ctor",
+ "libloading",
+ "pkg-config",
+ "tracing",
 ]
 
 [[package]]
@@ -2025,6 +2905,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ttf-parser"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2df906b07856748fa3f6e0ad0cbaa047052d4a7dd609e231c4f72cee8c36f31"
+
+[[package]]
 name = "unarray"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2075,7 +2961,7 @@ dependencies = [
  "siphasher",
  "strict-num",
  "svgtypes",
- "tiny-skia-path",
+ "tiny-skia-path 0.12.0",
 ]
 
 [[package]]
@@ -2089,6 +2975,12 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "wait-timeout"
@@ -2180,10 +3072,129 @@ dependencies = [
 ]
 
 [[package]]
+name = "wayland-backend"
+version = "0.3.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "016ccf01d1c58b6f8999612813e17c9b2390f7d70671428869913310f83f54b8"
+dependencies = [
+ "cc",
+ "downcast-rs",
+ "rustix 1.1.4",
+ "scoped-tls",
+ "smallvec",
+ "wayland-sys",
+]
+
+[[package]]
+name = "wayland-client"
+version = "0.31.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3c36a0f861ad76d0901f2800b46321410d9f73f2ea88aac0650d86c32688073"
+dependencies = [
+ "bitflags 2.13.1",
+ "rustix 1.1.4",
+ "wayland-backend",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-csd-frame"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "625c5029dbd43d25e6aa9615e88b829a5cad13b2819c4ae129fdbb7c31ab4c7e"
+dependencies = [
+ "bitflags 2.13.1",
+ "cursor-icon",
+ "wayland-backend",
+]
+
+[[package]]
+name = "wayland-cursor"
+version = "0.31.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a52d18780be9b1314328a3de5f930b73d2200112e3849ca6cb11822793fb34d"
+dependencies = [
+ "rustix 1.1.4",
+ "wayland-client",
+ "xcursor",
+]
+
+[[package]]
+name = "wayland-protocols"
+version = "0.32.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23d0c813de3daa2ed6520af85a3bd49b0e722a3078506899aa9686fea58dc4b6"
+dependencies = [
+ "bitflags 2.13.1",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-protocols-plasma"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b6d8cf1eb2c1c31ed1f5643c88a6e53538129d4af80030c8cabd1f9fa884d91"
+dependencies = [
+ "bitflags 2.13.1",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-protocols-wlr"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb04e52f7836d7c7976c78ca0250d61e33873c34156a2a1fc9474828ec268234"
+dependencies = [
+ "bitflags 2.13.1",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-scanner"
+version = "0.31.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "338e30461b3a2b67d70eb30a6d89f8e0c93a833e07d2ae89085cd070c4a00ac0"
+dependencies = [
+ "proc-macro2",
+ "quick-xml",
+ "quote",
+]
+
+[[package]]
+name = "wayland-sys"
+version = "0.31.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8eab23fefc9e41f8e841df4a9c707e8a8c4ed26e944ef69297184de2785e3be"
+dependencies = [
+ "dlib",
+ "log",
+ "once_cell",
+ "pkg-config",
+]
+
+[[package]]
 name = "web-sys"
 version = "0.3.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c435338968042f4f59a557f690a253676d47ce13ceb55d70100e7facf6620a30"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -2271,6 +3282,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
 dependencies = [
  "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -2470,6 +3490,58 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
+name = "winit"
+version = "0.30.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6755fa58a9f8350bd1e472d4c3fcc25f824ec358933bba33306d0b63df5978d"
+dependencies = [
+ "ahash",
+ "android-activity",
+ "atomic-waker",
+ "bitflags 2.13.1",
+ "block2 0.5.1",
+ "bytemuck",
+ "calloop",
+ "cfg_aliases",
+ "concurrent-queue",
+ "core-foundation",
+ "core-graphics",
+ "cursor-icon",
+ "dpi",
+ "js-sys",
+ "libc",
+ "memmap2",
+ "ndk 0.9.0",
+ "objc2 0.5.2",
+ "objc2-app-kit",
+ "objc2-foundation 0.2.2",
+ "objc2-ui-kit",
+ "orbclient",
+ "percent-encoding",
+ "pin-project",
+ "raw-window-handle",
+ "redox_syscall 0.4.1",
+ "rustix 0.38.44",
+ "sctk-adwaita",
+ "smithay-client-toolkit",
+ "smol_str",
+ "tracing",
+ "unicode-segmentation",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
+ "wayland-protocols-plasma",
+ "web-sys",
+ "web-time",
+ "windows-sys 0.52.0",
+ "x11-dl",
+ "x11rb",
+ "xkbcommon-dl",
+]
+
+[[package]]
 name = "winnow"
 version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2492,6 +3564,63 @@ name = "wit-bindgen"
 version = "0.57.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
+
+[[package]]
+name = "x11-dl"
+version = "2.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38735924fedd5314a6e548792904ed8c6de6636285cb9fec04d5b1db85c1516f"
+dependencies = [
+ "libc",
+ "once_cell",
+ "pkg-config",
+]
+
+[[package]]
+name = "x11rb"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9993aa5be5a26815fe2c3eacfc1fde061fc1a1f094bf1ad2a18bf9c495dd7414"
+dependencies = [
+ "as-raw-xcb-connection",
+ "gethostname",
+ "libc",
+ "libloading",
+ "once_cell",
+ "rustix 1.1.4",
+ "x11rb-protocol",
+]
+
+[[package]]
+name = "x11rb-protocol"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea6fc2961e4ef194dcbfe56bb845534d0dc8098940c7e5c012a258bfec6701bd"
+
+[[package]]
+name = "xcursor"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "163b33ed8786455e2fa5d72f554057ce3f3182425434f756cd39c99839d88e23"
+
+[[package]]
+name = "xkbcommon-dl"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d039de8032a9a8856a6be89cea3e5d12fdd82306ab7c94d74e6deab2460651c5"
+dependencies = [
+ "bitflags 2.13.1",
+ "dlib",
+ "log",
+ "once_cell",
+ "xkeysym",
+]
+
+[[package]]
+name = "xkeysym"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9cc00251562a284751c9973bace760d86c0276c471b4be569fe6b068ee97a56"
 
 [[package]]
 name = "zerocopy"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -113,6 +113,22 @@ dirs = "5.0"
 resvg = { version = "0.48", default-features = false }
 usvg = { version = "0.48", default-features = false }
 
+# A window of rav's own. Optional and off by default: a terminal visualiser
+# should not make everyone who installs it build a windowing stack.
+#
+# softbuffer rather than wgpu, because the frame is already a `Pixmap` on the
+# CPU - this is one more blit target, not a second renderer, and wgpu would
+# bring a GPU abstraction to move bytes that are already where they need to be.
+winit = { version = "0.30", optional = true }
+softbuffer = { version = "0.4", optional = true }
+
+# `--all-features` is what devenv runs clippy and the tests under, so this is
+# compiled on both platforms in CI whether or not anybody turns it on. The
+# Linux system libraries it needs are in `flake.nix` and `devenv.nix` for the
+# same reason.
+[features]
+gui = ["dep:winit", "dep:softbuffer"]
+
 [[bin]]
 name = "rav"
 path = "src/main.rs"

--- a/devenv.nix
+++ b/devenv.nix
@@ -456,6 +456,20 @@
       # rav-core and rav-appearance never run in CI, and a green build would
       # mean the binary compiled rather than that the mechanics work.
       exec = "cargo test --workspace --all-features";
+      after = [ "test:default" ];
+    };
+    "test:default" = {
+      # Everything else here runs `--all-features`, and that is not what anyone
+      # installs. The gap is not theoretical: this crate denies unused code, so
+      # a method reached only from behind a feature is a *build failure* in the
+      # default build while the whole suite is green - which is what the window
+      # did the day it landed, caught by CI rather than here.
+      #
+      # `check` rather than `clippy` or `test`: the lints that matter for this
+      # are the crate's own denials, and they fire at compile time. Under a
+      # second warm, because it is a second feature set and so a second set of
+      # artifacts rather than a recompile of the first.
+      exec = "cargo check --workspace --all-targets";
       after = [ "test:clippy" ];
     };
     "test:portable" = {
@@ -553,5 +567,5 @@
 
   # Named one by one, so a task added above is not in the suite until it is
   # added here too - `devenv test` runs this line, not the task list.
-  enterTest = lib.mkForce "devenv tasks run test:fmt test:clippy test:nix test:unit test:portable test:package";
+  enterTest = lib.mkForce "devenv tasks run test:fmt test:clippy test:nix test:default test:unit test:portable test:package";
 }

--- a/devenv.nix
+++ b/devenv.nix
@@ -38,6 +38,17 @@
     # record-demo reads the focused window and sends the tour's keys through
     # this. macOS does both through osascript, which ships with the system.
     xdotool
+
+    # winit and softbuffer, behind the `gui` feature. Off by default and still
+    # compiled here, because clippy and the tests run under --all-features -
+    # so these arrive with the feature rather than after it turns CI red.
+    # Both backends: winit carries X11 and Wayland and chooses at runtime.
+    libxkbcommon
+    wayland
+    xorg.libX11
+    xorg.libXcursor
+    xorg.libXi
+    xorg.libXrandr
   ];
 
   # Development scripts

--- a/flake.nix
+++ b/flake.nix
@@ -43,7 +43,24 @@
             inherit src;
             strictDeps = true;
             nativeBuildInputs = lib.optionals stdenv.isLinux [ pkgs.pkg-config ];
-            buildInputs = lib.optionals stdenv.isLinux [ pkgs.alsa-lib ];
+            buildInputs = lib.optionals stdenv.isLinux ([ pkgs.alsa-lib ]
+              # The `gui` feature is off here, but `devenv test` runs clippy and
+              # the tests under --all-features, so winit and softbuffer are
+              # compiled on Linux in CI whether or not anyone turns them on.
+              # These have to arrive with the feature, not after the build that
+              # first needs them goes red.
+              #
+              # X11 and Wayland both, because winit's default features carry
+              # both backends and picks at runtime - a build with one is a
+              # binary that cannot open a window on half of Linux.
+              ++ (with pkgs; [
+              libxkbcommon
+              wayland
+              xorg.libX11
+              xorg.libXcursor
+              xorg.libXi
+              xorg.libXrandr
+            ]));
           };
 
           # The dependencies as a store path of their own, built from a stub

--- a/src/main.rs
+++ b/src/main.rs
@@ -50,7 +50,8 @@ struct Args {
     /// it can draw images - WezTerm, Ghostty, kitty - and block characters
     /// everywhere else, including a terminal that will not say how big it is in
     /// pixels. `glyphs` forces the block characters, `kitty` forces the pixels,
-    /// and `window` is not built yet. Press `h` for what rav settled on and why.
+    /// and `window` opens one of rav's own where the build has the `gui`
+    /// feature. Press `h` for what rav settled on and why.
     #[arg(
         long,
         value_name = "auto|glyphs|kitty|window",
@@ -262,6 +263,10 @@ async fn rav_main() -> Result<()> {
         chosen.surface.label(),
         chosen.because
     );
+    // Read before it is handed over, because a window is driven from here
+    // rather than from inside `App::run`.
+    #[cfg(feature = "gui")]
+    let on_a_window = chosen.surface == rav::surface::Surface::Window;
     app.set_surface(chosen);
 
     // Prefer a CoreAudio process tap. It captures every process' output ahead of
@@ -291,6 +296,24 @@ async fn rav_main() -> Result<()> {
                 info!("Process tap unavailable ({e}); using the capture device instead");
             }
         }
+    }
+
+    // A window takes the thread, because winit does, and it is the main thread
+    // it wants - which is where this already is. Blocking the runtime is
+    // survivable for exactly one reason: nothing rav needs is on it. The
+    // capture callbacks are cpal's own threads and the test signal has a thread
+    // of its own, so the audio goes on arriving on the channel throughout.
+    //
+    // No `tokio::select!` on Ctrl-C either. A window is closed by closing it,
+    // and the signal handler below would be reaching into a loop it does not
+    // drive.
+    #[cfg(feature = "gui")]
+    if on_a_window {
+        let shown = rav::surface::window::show(app, audio_receiver);
+        if let Some(capture) = &mut audio_capture {
+            capture.stop();
+        }
+        return shown;
     }
 
     // Setup signal handling for graceful shutdown

--- a/src/surface/mod.rs
+++ b/src/surface/mod.rs
@@ -142,10 +142,16 @@ pub fn choose(asked: Choice, multiplexed: bool, answers: impl FnOnce() -> bool) 
         because,
     };
     match asked {
-        // A window of rav's own is not built. Saying so beats reporting a
+        // Behind `gui`, and a build without it says so rather than reporting a
         // surface nothing draws on and leaving the user to wonder why the
         // picture looks exactly as it did before.
-        Choice::Window => glyphs("a window of rav's own is not built yet"),
+        #[cfg(feature = "gui")]
+        Choice::Window => Chosen {
+            surface: Surface::Window,
+            because: "asked for",
+        },
+        #[cfg(not(feature = "gui"))]
+        Choice::Window => glyphs("this build has no window in it"),
         // An explicit request is honoured even where auto would decline, so a
         // terminal that does not answer the query but does draw images is still
         // reachable. It is the user's terminal and they can see the result.
@@ -385,12 +391,23 @@ mod tests {
     }
 
     #[test]
-    fn asking_for_a_window_says_there_is_not_one_yet() {
-        // Reporting a surface nothing draws on leaves the user looking at a
-        // picture identical to the one before, wondering what the flag did.
+    fn asking_for_a_window_gets_one_where_the_build_has_one() {
         let asked = choose(Choice::Window, false, || false);
-        assert_eq!(asked.surface, Surface::Glyphs);
-        assert!(asked.because.contains("not built"), "{}", asked.because);
+
+        // Reporting a surface nothing draws on leaves the user looking at a
+        // picture identical to the one before, wondering what the flag did. So
+        // a build without the feature says which it is, rather than reporting
+        // a window and drawing block characters into it.
+        #[cfg(not(feature = "gui"))]
+        {
+            assert_eq!(asked.surface, Surface::Glyphs);
+            assert!(asked.because.contains("no window"), "{}", asked.because);
+        }
+        // And a build with it honours the flag. Asserted here rather than left
+        // to the feature being off in most builds: `--all-features` is what CI
+        // runs, so this is the arm that is actually checked.
+        #[cfg(feature = "gui")]
+        assert_eq!(asked.surface, Surface::Window);
     }
 
     #[test]

--- a/src/surface/mod.rs
+++ b/src/surface/mod.rs
@@ -22,6 +22,10 @@ pub mod frame;
 pub mod kitty;
 pub mod overlay;
 pub mod pixels;
+/// Behind `gui`, which is off by default - a terminal visualiser should not
+/// make everyone who installs it build a windowing stack.
+#[cfg(feature = "gui")]
+pub mod window;
 
 use crate::render::Capabilities;
 use rav_core::units::Cells;

--- a/src/surface/window.rs
+++ b/src/surface/window.rs
@@ -165,7 +165,18 @@ impl ApplicationHandler for Showing {
             WindowEvent::CloseRequested => events.exit(),
             WindowEvent::KeyboardInput { event, .. } if event.state == ElementState::Pressed => {
                 if let Some(code) = pressed(&event.logical_key) {
-                    self.app.apply(crate::ui::map_key(code));
+                    let action = crate::ui::map_key(code);
+                    self.app.apply(action);
+                    // The panel is fourteen rows of text and a window has no
+                    // font for them yet, so `h` toggles something nothing
+                    // draws. Said out loud through the same note a setting
+                    // uses, which reaches the title bar - a key that silently
+                    // does nothing is the defect this whole surface keeps
+                    // being careful about.
+                    if action == crate::ui::Action::ToggleHelp {
+                        self.app
+                            .note("help is a terminal thing for now".to_string());
+                    }
                     if self.app.wants_to_quit() {
                         events.exit();
                     }
@@ -382,6 +393,20 @@ mod tests {
         // And one rav does not bind still translates - `map_key` is what says
         // it does nothing, which keeps that decision in one place too.
         assert_eq!(typed("z"), Some(crate::ui::Action::None));
+    }
+
+    #[test]
+    fn h_is_a_key_that_says_why_nothing_happened() {
+        // The one key a window cannot honour yet. It is `ToggleHelp` that has
+        // to be recognised here, so this asserts through `map_key` rather than
+        // against the character - rebinding help would otherwise leave the
+        // note attached to whatever `h` became.
+        assert_eq!(typed("h"), Some(crate::ui::Action::ToggleHelp));
+        assert_eq!(
+            pressed(&Key::Named(NamedKey::F1)).map(crate::ui::map_key),
+            Some(crate::ui::Action::ToggleHelp),
+            "F1 is the same key and gets the same answer",
+        );
     }
 
     #[test]

--- a/src/surface/window.rs
+++ b/src/surface/window.rs
@@ -25,6 +25,7 @@ use std::num::NonZeroU32;
 use std::rc::Rc;
 
 use anyhow::{Context as _, Result};
+use crossterm::event::KeyCode;
 use flume::Receiver;
 use winit::application::ApplicationHandler;
 use winit::event::{ElementState, WindowEvent};
@@ -75,6 +76,29 @@ pub fn onto_black(rgba: &[u8], into: &mut Vec<u32>) {
     }));
 }
 
+/// What a window key is, said in the terminal's vocabulary.
+///
+/// Translated rather than mapped straight to an [`Action`](crate::ui::Action),
+/// so [`map_key`](crate::ui::map_key) stays the one place that decides what a
+/// key does. A second table here would be a window whose `f` cycled something
+/// else six months from now, and nothing would notice until someone used both.
+///
+/// `None` for a key rav has no use for - a modifier on its own, a function key
+/// past the one - which is left to fall through rather than reported.
+fn pressed(key: &Key) -> Option<KeyCode> {
+    Some(match key {
+        // `to_text` rather than the character variant alone: it is what gives
+        // `+` and `-` on a keyboard that needs a modifier to reach them.
+        Key::Named(NamedKey::Escape) => KeyCode::Esc,
+        Key::Named(NamedKey::Tab) => KeyCode::Tab,
+        Key::Named(NamedKey::Space) => KeyCode::Char(' '),
+        Key::Named(NamedKey::ArrowUp) => KeyCode::Up,
+        Key::Named(NamedKey::ArrowDown) => KeyCode::Down,
+        Key::Named(NamedKey::F1) => KeyCode::F(1),
+        other => KeyCode::Char(other.to_text()?.chars().next()?),
+    })
+}
+
 /// The size `App` asks for, built from a window rather than from a terminal.
 ///
 /// `WindowSize` is crossterm's, and carries pixels and cells together. A window
@@ -121,14 +145,11 @@ impl ApplicationHandler for Showing {
         match event {
             WindowEvent::CloseRequested => events.exit(),
             WindowEvent::KeyboardInput { event, .. } if event.state == ElementState::Pressed => {
-                // Quit only, for now. The rest of the keys go through
-                // `map_press`, which speaks crossterm - and translating winit's
-                // events into that is its own piece of work rather than
-                // something to guess at here.
-                if matches!(event.logical_key, Key::Named(NamedKey::Escape))
-                    || event.logical_key.to_text() == Some("q")
-                {
-                    events.exit();
+                if let Some(code) = pressed(&event.logical_key) {
+                    self.app.apply(crate::ui::map_key(code));
+                    if self.app.wants_to_quit() {
+                        events.exit();
+                    }
                 }
             }
             WindowEvent::RedrawRequested => {
@@ -292,6 +313,47 @@ mod tests {
         for alpha in [0x00, 0x7f, 0xff] {
             assert_eq!(one([0xff, 0xff, 0xff, alpha]) >> 24, 0, "alpha {alpha:#x}");
         }
+    }
+
+    fn typed(text: &str) -> Option<crate::ui::Action> {
+        pressed(&Key::Character(text.into())).map(crate::ui::map_key)
+    }
+
+    #[test]
+    fn a_window_key_does_what_the_same_key_does_in_a_terminal() {
+        use crate::ui::Action;
+
+        // Not a second key table: these go through `map_key`, so what is
+        // asserted is the translation, and what each key *means* stays decided
+        // in one place. A window whose `f` cycled something else would be a
+        // defect nobody found until they used both.
+        assert_eq!(typed("q"), Some(Action::Quit));
+        assert_eq!(typed("t"), Some(Action::CycleTheme));
+        assert_eq!(typed("v"), Some(Action::CycleView));
+        assert_eq!(typed("b"), Some(Action::CycleBarStyle));
+        assert_eq!(typed("+"), Some(Action::BarSize(1)));
+        assert_eq!(typed("-"), Some(Action::BarSize(-1)));
+
+        // The named ones, which have no character to fall back on.
+        let named = |key| pressed(&Key::Named(key)).map(crate::ui::map_key);
+        assert_eq!(named(NamedKey::Escape), Some(Action::Quit));
+        assert_eq!(named(NamedKey::Space), Some(Action::CycleVisualisation));
+        assert_eq!(named(NamedKey::Tab), Some(Action::CycleVisualisation));
+        assert_eq!(named(NamedKey::ArrowUp), Some(Action::Gain(1)));
+        assert_eq!(named(NamedKey::ArrowDown), Some(Action::Gain(-1)));
+        assert_eq!(named(NamedKey::F1), Some(Action::ToggleHelp));
+    }
+
+    #[test]
+    fn a_key_rav_has_no_use_for_falls_through() {
+        // `None` rather than `Action::None`, so a modifier held on its own does
+        // not count as a press that did nothing - the window would redraw for
+        // every shift key on the way to a capital.
+        assert_eq!(pressed(&Key::Named(NamedKey::Shift)), None);
+        assert_eq!(pressed(&Key::Named(NamedKey::Control)), None);
+        // And one rav does not bind still translates - `map_key` is what says
+        // it does nothing, which keeps that decision in one place too.
+        assert_eq!(typed("z"), Some(crate::ui::Action::None));
     }
 
     #[test]

--- a/src/surface/window.rs
+++ b/src/surface/window.rs
@@ -4,6 +4,46 @@
 //! is a blit target rather than a second renderer - which is the whole reason
 //! the plan chose softbuffer over wgpu. What arrives is what the kitty surface
 //! sends a terminal; only the delivery differs.
+//!
+//! # What a cell is here
+//!
+//! The bar width is in cells, because cells are what `+` and `-` move, and a
+//! window has none. It declares [`CELL`] instead - a nominal character box, so
+//! those keys go on meaning "this many characters wide" as they do everywhere
+//! else. It becomes the bitmap font's cell once the overlay has one; until
+//! then it is a stated number rather than a measured one.
+//!
+//! # Why the loop is here and not in `App`
+//!
+//! winit wants the main thread and runs its own event loop, where `App::run`
+//! is async and driven from `tokio::select!`. Rather than bend one into the
+//! other, this drives the same three steps that loop does - take in audio,
+//! [`App::advance`], [`App::frame_pixels`] - from winit's callbacks. The
+//! terminal path is untouched, so a window cannot break a terminal.
+
+use std::num::NonZeroU32;
+use std::rc::Rc;
+
+use anyhow::{Context as _, Result};
+use flume::Receiver;
+use winit::application::ApplicationHandler;
+use winit::event::{ElementState, WindowEvent};
+use winit::event_loop::{ActiveEventLoop, ControlFlow, EventLoop};
+use winit::keyboard::{Key, NamedKey};
+use winit::window::{Window, WindowId};
+
+use crate::audio::AudioData;
+use crate::ui::App;
+
+/// One character box, in device pixels.
+///
+/// Only the geometry uses it: bar width, spacing and the height of one rung.
+/// A terminal is asked for its own; a window has to say.
+const CELL: (u16, u16) = (10, 20);
+
+/// What a window opens at. The demo is recorded at 941x249, and a banner is the
+/// shape the analyser is for - a tall box gives the bars nowhere to go.
+const OPENS_AT: (u32, u32) = (960, 320);
 
 /// Repack a frame for softbuffer, resolving what is behind it.
 ///
@@ -33,6 +73,166 @@ pub fn onto_black(rgba: &[u8], into: &mut Vec<u32>) {
         let over_black = |channel: u8| (u16::from(channel) * u16::from(alpha) / 255) as u32;
         (over_black(red) << 16) | (over_black(green) << 8) | over_black(blue)
     }));
+}
+
+/// The size `App` asks for, built from a window rather than from a terminal.
+///
+/// `WindowSize` is crossterm's, and carries pixels and cells together. A window
+/// knows the pixels and decides the cells, which is the one thing the two pixel
+/// surfaces cannot share.
+fn sized(width: u32, height: u32) -> crossterm::terminal::WindowSize {
+    let (across, down) = CELL;
+    crossterm::terminal::WindowSize {
+        width: width.min(u32::from(u16::MAX)) as u16,
+        height: height.min(u32::from(u16::MAX)) as u16,
+        columns: (width.min(u32::from(u16::MAX)) as u16 / across).max(1),
+        rows: (height.min(u32::from(u16::MAX)) as u16 / down).max(1),
+    }
+}
+
+struct Showing {
+    app: App,
+    audio: Receiver<AudioData>,
+    window: Option<Rc<Window>>,
+    surface: Option<softbuffer::Surface<Rc<Window>, Rc<Window>>>,
+    /// Kept between frames for the same reason the canvas is: a screenful of
+    /// `u32` per frame is an allocation the frame budget has no room for.
+    packed: Vec<u32>,
+    failed: Option<anyhow::Error>,
+}
+
+impl ApplicationHandler for Showing {
+    fn resumed(&mut self, events: &ActiveEventLoop) {
+        // Called again on platforms that suspend, so this must not open a
+        // second window on the way back.
+        if self.window.is_some() {
+            return;
+        }
+        match self.open(events) {
+            Ok(()) => {}
+            Err(why) => {
+                self.failed = Some(why);
+                events.exit();
+            }
+        }
+    }
+
+    fn window_event(&mut self, events: &ActiveEventLoop, _id: WindowId, event: WindowEvent) {
+        match event {
+            WindowEvent::CloseRequested => events.exit(),
+            WindowEvent::KeyboardInput { event, .. } if event.state == ElementState::Pressed => {
+                // Quit only, for now. The rest of the keys go through
+                // `map_press`, which speaks crossterm - and translating winit's
+                // events into that is its own piece of work rather than
+                // something to guess at here.
+                if matches!(event.logical_key, Key::Named(NamedKey::Escape))
+                    || event.logical_key.to_text() == Some("q")
+                {
+                    events.exit();
+                }
+            }
+            WindowEvent::RedrawRequested => {
+                if let Err(why) = self.draw() {
+                    self.failed = Some(why);
+                    events.exit();
+                }
+            }
+            _ => {}
+        }
+    }
+
+    fn about_to_wait(&mut self, events: &ActiveEventLoop) {
+        // Poll rather than Wait: the audio arrives on a channel winit knows
+        // nothing about, so there is no event to be woken by. The frame
+        // ceiling inside `App` is what stops this drawing faster than it needs
+        // to - the same one the terminal path runs under.
+        events.set_control_flow(ControlFlow::Poll);
+        if let Some(window) = &self.window {
+            window.request_redraw();
+        }
+    }
+}
+
+impl Showing {
+    fn open(&mut self, events: &ActiveEventLoop) -> Result<()> {
+        let attributes = Window::default_attributes()
+            .with_title("rav")
+            .with_inner_size(winit::dpi::LogicalSize::new(OPENS_AT.0, OPENS_AT.1));
+        let window = Rc::new(
+            events
+                .create_window(attributes)
+                .context("opening a window")?,
+        );
+        let context = softbuffer::Context::new(window.clone())
+            .map_err(|why| anyhow::anyhow!("no drawing context for the window: {why}"))?;
+        let surface = softbuffer::Surface::new(&context, window.clone())
+            .map_err(|why| anyhow::anyhow!("nothing to draw on: {why}"))?;
+        self.window = Some(window);
+        self.surface = Some(surface);
+        Ok(())
+    }
+
+    fn draw(&mut self) -> Result<()> {
+        let (Some(window), Some(surface)) = (&self.window, &mut self.surface) else {
+            return Ok(());
+        };
+        let size = window.inner_size();
+        let (Some(width), Some(height)) =
+            (NonZeroU32::new(size.width), NonZeroU32::new(size.height))
+        else {
+            // A window dragged to nothing, or minimised. Not a failure, and
+            // drawing zero pixels into it would be.
+            return Ok(());
+        };
+
+        // Everything the terminal loop does, in the order it does it.
+        while let Ok(data) = self.audio.try_recv() {
+            self.app.push_samples(&data.samples);
+        }
+        self.app.advance();
+
+        let Some(pixels) = self.app.frame_pixels(&sized(size.width, size.height)) else {
+            return Ok(());
+        };
+        onto_black(&pixels, &mut self.packed);
+
+        surface
+            .resize(width, height)
+            .map_err(|why| anyhow::anyhow!("the window would not take that size: {why}"))?;
+        let mut buffer = surface
+            .buffer_mut()
+            .map_err(|why| anyhow::anyhow!("no buffer to draw into: {why}"))?;
+        // A frame that does not fill the buffer is a resize caught mid-flight;
+        // showing it stretched is worse than showing the last one again.
+        if buffer.len() == self.packed.len() {
+            buffer.copy_from_slice(&self.packed);
+            buffer
+                .present()
+                .map_err(|why| anyhow::anyhow!("the frame would not go up: {why}"))?;
+        }
+        Ok(())
+    }
+}
+
+/// Show rav in a window until it is closed.
+///
+/// Takes the thread, because winit does. The audio is already arriving on a
+/// channel fed from somewhere else, which is what makes that survivable.
+pub fn show(app: App, audio: Receiver<AudioData>) -> Result<()> {
+    let events = EventLoop::new().context("starting an event loop")?;
+    let mut showing = Showing {
+        app,
+        audio,
+        window: None,
+        surface: None,
+        packed: Vec::new(),
+        failed: None,
+    };
+    events.run_app(&mut showing).context("running the window")?;
+    match showing.failed {
+        Some(why) => Err(why),
+        None => Ok(()),
+    }
 }
 
 #[cfg(test)]
@@ -92,5 +292,19 @@ mod tests {
         for alpha in [0x00, 0x7f, 0xff] {
             assert_eq!(one([0xff, 0xff, 0xff, alpha]) >> 24, 0, "alpha {alpha:#x}");
         }
+    }
+
+    #[test]
+    fn a_window_says_how_many_cells_it_is_counting() {
+        // The bar width is in cells and a window has none, so it declares one.
+        // Without this the layout would divide by zero cells on a small window
+        // - and `max(1)` is what stops that being a crash on a drag.
+        let (across, down) = CELL;
+        let size = sized(u32::from(across) * 8, u32::from(down) * 3);
+        assert_eq!((size.columns, size.rows), (8, 3));
+        assert_eq!((size.width, size.height), (across * 8, down * 3));
+
+        let tiny = sized(1, 1);
+        assert_eq!((tiny.columns, tiny.rows), (1, 1), "never zero cells");
     }
 }

--- a/src/surface/window.rs
+++ b/src/surface/window.rs
@@ -99,6 +99,22 @@ fn pressed(key: &Key) -> Option<KeyCode> {
     })
 }
 
+/// What the title bar says: rav, and whatever rav has to say.
+///
+/// The status line has to go *somewhere*, and a window has no text of its own
+/// until the overlay has a font. The desktop already draws a title, so a
+/// setting that changed is visible - pressing `t` and seeing nothing happen to
+/// the words is how a key looks broken.
+///
+/// Only the status. The help panel is fourteen rows and does not fit in a
+/// title bar, which is why the font is still owed.
+fn titled(status: Option<&str>) -> String {
+    match status {
+        Some(saying) => format!("rav - {saying}"),
+        None => "rav".to_string(),
+    }
+}
+
 /// The size `App` asks for, built from a window rather than from a terminal.
 ///
 /// `WindowSize` is crossterm's, and carries pixels and cells together. A window
@@ -122,6 +138,9 @@ struct Showing {
     /// Kept between frames for the same reason the canvas is: a screenful of
     /// `u32` per frame is an allocation the frame budget has no room for.
     packed: Vec<u32>,
+    /// What the title already says, so a frame that changed nothing does not
+    /// ask the window server to set it again.
+    titled: String,
     failed: Option<anyhow::Error>,
 }
 
@@ -177,7 +196,7 @@ impl ApplicationHandler for Showing {
 impl Showing {
     fn open(&mut self, events: &ActiveEventLoop) -> Result<()> {
         let attributes = Window::default_attributes()
-            .with_title("rav")
+            .with_title(titled(None))
             .with_inner_size(winit::dpi::LogicalSize::new(OPENS_AT.0, OPENS_AT.1));
         let window = Rc::new(
             events
@@ -211,6 +230,14 @@ impl Showing {
             self.app.push_samples(&data.samples);
         }
         self.app.advance();
+
+        // Only when it changes. Setting a title is a round trip to the window
+        // server, and this runs on every frame.
+        let saying = titled(self.app.status_line().as_deref());
+        if saying != self.titled {
+            window.set_title(&saying);
+            self.titled = saying;
+        }
 
         let Some(pixels) = self.app.frame_pixels(&sized(size.width, size.height)) else {
             return Ok(());
@@ -247,6 +274,7 @@ pub fn show(app: App, audio: Receiver<AudioData>) -> Result<()> {
         window: None,
         surface: None,
         packed: Vec::new(),
+        titled: String::new(),
         failed: None,
     };
     events.run_app(&mut showing).context("running the window")?;
@@ -354,6 +382,14 @@ mod tests {
         // And one rav does not bind still translates - `map_key` is what says
         // it does nothing, which keeps that decision in one place too.
         assert_eq!(typed("z"), Some(crate::ui::Action::None));
+    }
+
+    #[test]
+    fn the_title_carries_what_rav_has_to_say() {
+        // With nothing to say it is just the name - not "rav - " with an empty
+        // tail, which reads as a window that lost something.
+        assert_eq!(titled(None), "rav");
+        assert_eq!(titled(Some("theme winamp")), "rav - theme winamp");
     }
 
     #[test]

--- a/src/surface/window.rs
+++ b/src/surface/window.rs
@@ -1,0 +1,96 @@
+//! A window of rav's own.
+//!
+//! The frame is already a `Pixmap` on the CPU by the time it gets here, so this
+//! is a blit target rather than a second renderer - which is the whole reason
+//! the plan chose softbuffer over wgpu. What arrives is what the kitty surface
+//! sends a terminal; only the delivery differs.
+
+/// Repack a frame for softbuffer, resolving what is behind it.
+///
+/// softbuffer wants one `u32` per pixel as `0x00RRGGBB`, and
+/// [`Canvas::to_rgba`](crate::render::Canvas::to_rgba) hands back four straight
+/// bytes - demultiplied, alpha kept.
+///
+/// **The alpha has to be resolved here, and against black.** A terminal
+/// composites rav's frame over whatever the cell behind it was, so the kitty
+/// surface passes partial alpha on and lets it. A window has nothing behind it
+/// at all, so an unresolved edge would arrive as whatever the last contents of
+/// that buffer happened to be. Multiplying onto black is what "nothing behind
+/// it" means, and it keeps an antialiased bar edge reading as a soft edge
+/// rather than a bright one.
+///
+/// Writes into `into` rather than returning, because this runs on every frame
+/// and a 2400x1440 window is 3.5 million pixels - a fresh allocation sixty
+/// times a second is the trap the canvas already avoids being rebuilt for.
+pub fn onto_black(rgba: &[u8], into: &mut Vec<u32>) {
+    into.clear();
+    into.reserve(rgba.len() / 4);
+    into.extend(rgba.chunks_exact(4).map(|pixel| {
+        let [red, green, blue, alpha] = [pixel[0], pixel[1], pixel[2], pixel[3]];
+        // `u16` for the product, then back down: `r * a` overflows a `u8` for
+        // anything above the very darkest, and dividing by 255 rather than
+        // shifting by 8 keeps full scale exactly full scale.
+        let over_black = |channel: u8| (u16::from(channel) * u16::from(alpha) / 255) as u32;
+        (over_black(red) << 16) | (over_black(green) << 8) | over_black(blue)
+    }));
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn one(rgba: [u8; 4]) -> u32 {
+        let mut out = Vec::new();
+        onto_black(&rgba, &mut out);
+        out[0]
+    }
+
+    #[test]
+    fn an_opaque_pixel_keeps_its_colour() {
+        assert_eq!(one([0xff, 0xff, 0xff, 0xff]), 0x00ff_ffff, "white");
+        assert_eq!(one([0xff, 0x00, 0x00, 0xff]), 0x00ff_0000, "red");
+        assert_eq!(one([0x00, 0xff, 0x00, 0xff]), 0x0000_ff00, "green");
+        assert_eq!(one([0x00, 0x00, 0xff, 0xff]), 0x0000_00ff, "blue");
+    }
+
+    #[test]
+    fn full_scale_survives_the_divide() {
+        // The reason this is `/ 255` and not `>> 8`: shifting turns 255 into
+        // 254, so a white bar in a window would be a shade under white and the
+        // two pixel surfaces would not draw the same picture.
+        assert_eq!(one([0xff, 0xff, 0xff, 0xff]) & 0xff, 0xff);
+    }
+
+    #[test]
+    fn a_soft_edge_reads_as_dark_rather_than_as_bright() {
+        // Half-covered white is mid grey, not white. Getting this backwards -
+        // ignoring alpha - is what turns every antialiased bar edge into a
+        // bright fringe.
+        let half = one([0xff, 0xff, 0xff, 0x80]);
+        assert_eq!(half, 0x0080_8080, "got {half:#08x}");
+        assert_eq!(one([0xff, 0xff, 0xff, 0x00]), 0, "nothing there is black");
+    }
+
+    #[test]
+    fn every_pixel_arrives_and_none_is_invented() {
+        let frame: Vec<u8> = (0..64u8).collect();
+        let mut out = Vec::new();
+        onto_black(&frame, &mut out);
+        assert_eq!(out.len(), 16, "16 pixels of 4 bytes");
+
+        // Reused across frames, so it must not accumulate. A window that grew
+        // its buffer by a screenful per frame would look fine and then run out
+        // of memory somewhere in the second minute.
+        onto_black(&frame, &mut out);
+        assert_eq!(out.len(), 16, "the buffer was not cleared");
+    }
+
+    #[test]
+    fn the_top_byte_is_left_alone() {
+        // softbuffer reads `0x00RRGGBB` and ignores the top byte on some
+        // platforms and not others. Leaving it zero is the portable answer.
+        for alpha in [0x00, 0x7f, 0xff] {
+            assert_eq!(one([0xff, 0xff, 0xff, alpha]) >> 24, 0, "alpha {alpha:#x}");
+        }
+    }
+}

--- a/src/surface/window.rs
+++ b/src/surface/window.rs
@@ -155,6 +155,7 @@ struct Showing {
     /// merely runs: a window that opened and paints nothing looks exactly like
     /// one that works, from here.
     drawn: u32,
+    shown: u32,
     measured: u32,
     woke: u32,
     counted_from: Instant,
@@ -236,12 +237,14 @@ impl ApplicationHandler for Showing {
         self.woke += 1;
         if self.counted_from.elapsed() >= std::time::Duration::from_secs(1) {
             tracing::debug!(
-                "{} frames and {} spectra from {} wakes",
+                "{} of {} frames shown, {} spectra, from {} wakes",
+                self.shown,
                 self.drawn,
                 self.measured,
                 self.woke
             );
             self.drawn = 0;
+            self.shown = 0;
             self.measured = 0;
             self.woke = 0;
             self.counted_from = now;
@@ -274,7 +277,6 @@ impl ApplicationHandler for Showing {
             if self.next_frame < now {
                 self.next_frame = now + self.min_frame;
             }
-            self.drawn += 1;
             if let Some(window) = &self.window {
                 window.request_redraw();
             }
@@ -315,6 +317,8 @@ impl Showing {
             return Ok(());
         };
 
+        self.drawn += 1;
+
         // The audio and the analysis happened in `about_to_wait`, on every wake
         // rather than on every frame. This is only the drawing.
 
@@ -339,11 +343,17 @@ impl Showing {
             .map_err(|why| anyhow::anyhow!("no buffer to draw into: {why}"))?;
         // A frame that does not fill the buffer is a resize caught mid-flight;
         // showing it stretched is worse than showing the last one again.
+        //
+        // Counted rather than passed over in silence. If the two ever stopped
+        // agreeing for good, this would be a window that draws nothing and
+        // says nothing about it - and the count sits in the same line as the
+        // frames, where a window drawing 0 of 60 is impossible to miss.
         if buffer.len() == self.packed.len() {
             buffer.copy_from_slice(&self.packed);
             buffer
                 .present()
                 .map_err(|why| anyhow::anyhow!("the frame would not go up: {why}"))?;
+            self.shown += 1;
         }
         Ok(())
     }
@@ -366,6 +376,7 @@ pub fn show(app: App, audio: Receiver<AudioData>) -> Result<()> {
         min_frame,
         next_frame: Instant::now(),
         drawn: 0,
+        shown: 0,
         measured: 0,
         woke: 0,
         counted_from: Instant::now(),

--- a/src/surface/window.rs
+++ b/src/surface/window.rs
@@ -23,6 +23,7 @@
 
 use std::num::NonZeroU32;
 use std::rc::Rc;
+use std::time::Instant;
 
 use anyhow::{Context as _, Result};
 use crossterm::event::KeyCode;
@@ -141,6 +142,10 @@ struct Showing {
     /// What the title already says, so a frame that changed nothing does not
     /// ask the window server to set it again.
     titled: String,
+    /// The frame ceiling, kept here because winit drives this loop and
+    /// `App::run` - which has the same one - does not.
+    min_frame: std::time::Duration,
+    next_frame: Instant,
     failed: Option<anyhow::Error>,
 }
 
@@ -193,14 +198,32 @@ impl ApplicationHandler for Showing {
     }
 
     fn about_to_wait(&mut self, events: &ActiveEventLoop) {
-        // Poll rather than Wait: the audio arrives on a channel winit knows
-        // nothing about, so there is no event to be woken by. The frame
-        // ceiling inside `App` is what stops this drawing faster than it needs
-        // to - the same one the terminal path runs under.
-        events.set_control_flow(ControlFlow::Poll);
-        if let Some(window) = &self.window {
-            window.request_redraw();
+        // The audio arrives on a channel winit knows nothing about, so there is
+        // no event to be woken by and the loop has to come back on its own. It
+        // comes back *at a time*, not immediately: `Poll` with a redraw every
+        // pass spins the event loop as fast as the machine will go and pegs a
+        // core, which is what the rest of rav is built not to do.
+        //
+        // The ceiling is `App`'s, not one of this surface's own. `App::run` has
+        // the same deadline for the same reason; what it does not have is any
+        // way to lend it, since it does not drive this loop.
+        let now = Instant::now();
+        if now >= self.next_frame {
+            // A moving deadline, carrying the remainder - the form that asks
+            // "has min_frame passed since the last frame" quantises to the wake
+            // interval and loses whatever does not divide it.
+            self.next_frame += self.min_frame;
+            // And no debt. A stall would otherwise leave the deadline in the
+            // past owing frames it would take back to back, and the next frame
+            // shows the current state either way.
+            if self.next_frame < now {
+                self.next_frame = now + self.min_frame;
+            }
+            if let Some(window) = &self.window {
+                window.request_redraw();
+            }
         }
+        events.set_control_flow(ControlFlow::WaitUntil(self.next_frame));
     }
 }
 
@@ -279,6 +302,7 @@ impl Showing {
 /// channel fed from somewhere else, which is what makes that survivable.
 pub fn show(app: App, audio: Receiver<AudioData>) -> Result<()> {
     let events = EventLoop::new().context("starting an event loop")?;
+    let min_frame = app.min_frame();
     let mut showing = Showing {
         app,
         audio,
@@ -286,6 +310,8 @@ pub fn show(app: App, audio: Receiver<AudioData>) -> Result<()> {
         surface: None,
         packed: Vec::new(),
         titled: String::new(),
+        min_frame,
+        next_frame: Instant::now(),
         failed: None,
     };
     events.run_app(&mut showing).context("running the window")?;

--- a/src/surface/window.rs
+++ b/src/surface/window.rs
@@ -146,6 +146,18 @@ struct Showing {
     /// `App::run` - which has the same one - does not.
     min_frame: std::time::Duration,
     next_frame: Instant,
+    /// Frames, spectra and wakes over the last second - the terminal loop
+    /// reports the first and last of those, and this adds the middle one
+    /// because winit wakes far more often than it is asked to and the count
+    /// of FFTs is the thing that costs.
+    ///
+    /// Also the only evidence from outside that this surface draws rather than
+    /// merely runs: a window that opened and paints nothing looks exactly like
+    /// one that works, from here.
+    drawn: u32,
+    measured: u32,
+    woke: u32,
+    counted_from: Instant,
     failed: Option<anyhow::Error>,
 }
 
@@ -221,10 +233,36 @@ impl ApplicationHandler for Showing {
         // from the receiving side, which is a thread and a second event type -
         // worth it when something here measures across frames, and not before.
         let now = Instant::now();
+        self.woke += 1;
+        if self.counted_from.elapsed() >= std::time::Duration::from_secs(1) {
+            tracing::debug!(
+                "{} frames and {} spectra from {} wakes",
+                self.drawn,
+                self.measured,
+                self.woke
+            );
+            self.drawn = 0;
+            self.measured = 0;
+            self.woke = 0;
+            self.counted_from = now;
+        }
+        let mut arrived = false;
         while let Ok(data) = self.audio.try_recv() {
             self.app.push_samples(&data.samples);
+            arrived = true;
         }
-        self.app.advance();
+        // When there is something new to measure, or when a frame is due
+        // anyway. Not on every wake: winit returns here far more often than it
+        // was asked to - measured at 180 to 376 times a second against a 60Hz
+        // deadline - and `advance` is a 1024-point FFT. Analysing the same
+        // unchanged window three times over is work nobody sees.
+        //
+        // The frame-due half is what keeps the bars falling when the audio
+        // stops entirely, which is the case `App::run` keeps a watchdog for.
+        if arrived || now >= self.next_frame {
+            self.app.advance();
+            self.measured += 1;
+        }
         if now >= self.next_frame {
             // A moving deadline, carrying the remainder - the form that asks
             // "has min_frame passed since the last frame" quantises to the wake
@@ -236,6 +274,7 @@ impl ApplicationHandler for Showing {
             if self.next_frame < now {
                 self.next_frame = now + self.min_frame;
             }
+            self.drawn += 1;
             if let Some(window) = &self.window {
                 window.request_redraw();
             }
@@ -326,6 +365,10 @@ pub fn show(app: App, audio: Receiver<AudioData>) -> Result<()> {
         titled: String::new(),
         min_frame,
         next_frame: Instant::now(),
+        drawn: 0,
+        measured: 0,
+        woke: 0,
+        counted_from: Instant::now(),
         failed: None,
     };
     events.run_app(&mut showing).context("running the window")?;

--- a/src/surface/window.rs
+++ b/src/surface/window.rs
@@ -207,7 +207,24 @@ impl ApplicationHandler for Showing {
         // The ceiling is `App`'s, not one of this surface's own. `App::run` has
         // the same deadline for the same reason; what it does not have is any
         // way to lend it, since it does not drive this loop.
+        // On every wake, above the ceiling, exactly as `App::run` does it: only
+        // the drawing is capped, and the analysis runs on the signal. Putting
+        // these below the deadline would make the interval between spectra a
+        // property of the frame rate, which is what `App::advance` says not to
+        // do - the ballistics integrate `dt` and would survive it, but anything
+        // measuring across time rather than within one frame would inherit the
+        // jitter into its measurement.
+        //
+        // What a window still cannot do is wake *because* audio arrived: winit
+        // knows nothing about the channel, so a wake is the frame deadline or a
+        // user event. Waking on a buffer would need an `EventLoopProxy` fed
+        // from the receiving side, which is a thread and a second event type -
+        // worth it when something here measures across frames, and not before.
         let now = Instant::now();
+        while let Ok(data) = self.audio.try_recv() {
+            self.app.push_samples(&data.samples);
+        }
+        self.app.advance();
         if now >= self.next_frame {
             // A moving deadline, carrying the remainder - the form that asks
             // "has min_frame passed since the last frame" quantises to the wake
@@ -259,11 +276,8 @@ impl Showing {
             return Ok(());
         };
 
-        // Everything the terminal loop does, in the order it does it.
-        while let Ok(data) = self.audio.try_recv() {
-            self.app.push_samples(&data.samples);
-        }
-        self.app.advance();
+        // The audio and the analysis happened in `about_to_wait`, on every wake
+        // rather than on every frame. This is only the drawing.
 
         // Only when it changes. Setting a title is a round trip to the window
         // server, and this runs on every frame.

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -763,7 +763,7 @@ impl App {
     }
 
     /// Show a message for a couple of seconds.
-    fn note(&mut self, text: String) {
+    pub(crate) fn note(&mut self, text: String) {
         self.status = Some((text, Instant::now()));
     }
 

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -496,6 +496,14 @@ impl App {
     /// Hands back the gain, which the oscilloscope wants, and the instant it
     /// measured at, which is what a frame ceiling is judged against - taking
     /// the clock twice would put the two a hair apart for no reason.
+    /// Whether a key has asked rav to stop.
+    ///
+    /// A surface that drives its own loop needs to ask, where `App::run`
+    /// reads the field directly.
+    pub(crate) fn wants_to_quit(&self) -> bool {
+        self.should_quit
+    }
+
     pub(crate) fn advance(&mut self) -> (f32, Instant) {
         let gain = self.measure();
         let measured_at = Instant::now();
@@ -830,7 +838,7 @@ impl App {
         }
     }
 
-    fn apply(&mut self, action: Action) {
+    pub(crate) fn apply(&mut self, action: Action) {
         match action {
             Action::Quit => self.should_quit = true,
             Action::CycleVisualisation => {

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -500,6 +500,11 @@ impl App {
     ///
     /// A surface that drives its own loop needs to ask, where `App::run`
     /// reads the field directly.
+    ///
+    /// Only the window asks, so this is behind the feature that has one - the
+    /// crate denies unused code, and a method with no caller is a build
+    /// failure rather than a warning nobody reads.
+    #[cfg(feature = "gui")]
     pub(crate) fn wants_to_quit(&self) -> bool {
         self.should_quit
     }

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -498,18 +498,6 @@ impl App {
             .or_else(|| self.active_status().map(str::to_string))
     }
 
-    /// Measure what has arrived and move the bars to now.
-    ///
-    /// The two belong together, and belong on the signal's schedule rather than
-    /// the display's: the ballistics integrate `dt`, so stepping them on
-    /// whatever cadence a surface happens to repaint at throws away the
-    /// accuracy that buys. A surface that skipped this on a coalesced frame
-    /// would make the interval between spectra a property of its own frame
-    /// rate.
-    ///
-    /// Hands back the gain, which the oscilloscope wants, and the instant it
-    /// measured at, which is what a frame ceiling is judged against - taking
-    /// the clock twice would put the two a hair apart for no reason.
     /// Whether a key has asked rav to stop.
     ///
     /// A surface that drives its own loop needs to ask, where `App::run`
@@ -523,6 +511,29 @@ impl App {
         self.should_quit
     }
 
+    /// The shortest gap between drawn frames.
+    ///
+    /// A ceiling, not a cadence, and it belongs to `App` rather than to a
+    /// surface: the configured refresh rate is what both of them are capped by,
+    /// and a second copy of this arithmetic in the window would be a window
+    /// that ignored the setting.
+    pub(crate) fn min_frame(&self) -> Duration {
+        let fps = self.config.display.refresh_rate.clamp(1, 240) as f64;
+        Duration::from_secs_f64(1.0 / fps)
+    }
+
+    /// Measure what has arrived and move the bars to now.
+    ///
+    /// The two belong together, and belong on the signal's schedule rather than
+    /// the display's: the ballistics integrate `dt`, so stepping them on
+    /// whatever cadence a surface happens to repaint at throws away the
+    /// accuracy that buys. A surface that skipped this on a coalesced frame
+    /// would make the interval between spectra a property of its own frame
+    /// rate.
+    ///
+    /// Hands back the gain, which the oscilloscope wants, and the instant it
+    /// measured at, which is what a frame ceiling is judged against - taking
+    /// the clock twice would put the two a hair apart for no reason.
     pub(crate) fn advance(&mut self) -> (f32, Instant) {
         let gain = self.measure();
         let measured_at = Instant::now();
@@ -1134,8 +1145,7 @@ impl App {
         // four to clear a 16.7ms gap, which turns a 60fps ceiling into 48. The
         // deadline carries the remainder instead, so the average comes out at
         // the rate that was asked for.
-        let fps = self.config.display.refresh_rate.clamp(1, 240) as f64;
-        let min_frame = Duration::from_secs_f64(1.0 / fps);
+        let min_frame = self.min_frame();
         let mut next_frame = Instant::now();
 
         // Only for a device that stops delivering *entirely*. A running device

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -484,6 +484,27 @@ impl App {
     /// cursor now is, then write the overlay's own cells. An image lands
     /// wherever the cursor happens to be, and the overlay goes on afterwards
     /// because a written cell blanks the picture beneath it.
+    /// Measure what has arrived and move the bars to now.
+    ///
+    /// The two belong together, and belong on the signal's schedule rather than
+    /// the display's: the ballistics integrate `dt`, so stepping them on
+    /// whatever cadence a surface happens to repaint at throws away the
+    /// accuracy that buys. A surface that skipped this on a coalesced frame
+    /// would make the interval between spectra a property of its own frame
+    /// rate.
+    ///
+    /// Hands back the gain, which the oscilloscope wants, and the instant it
+    /// measured at, which is what a frame ceiling is judged against - taking
+    /// the clock twice would put the two a hair apart for no reason.
+    pub(crate) fn advance(&mut self) -> (f32, Instant) {
+        let gain = self.measure();
+        let measured_at = Instant::now();
+        let dt = measured_at.duration_since(self.last_frame).as_secs_f32();
+        self.last_frame = measured_at;
+        self.ballistics.step(&self.bands, dt);
+        (gain, measured_at)
+    }
+
     /// The frame as pixels, and nothing about how it reaches a screen.
     ///
     /// Everything the two pixel surfaces have in common. A terminal that draws
@@ -495,7 +516,10 @@ impl App {
     /// `size` carries pixels and cells both, because the bar width is in cells
     /// and cells are what `+` and `-` move. A window has none of its own and
     /// says what it is counting instead.
-    fn frame_pixels(&mut self, size: &crossterm::terminal::WindowSize) -> Option<Vec<u8>> {
+    pub(crate) fn frame_pixels(
+        &mut self,
+        size: &crossterm::terminal::WindowSize,
+    ) -> Option<Vec<u8>> {
         use crate::surface::frame::{Frame, Look};
         use rav_core::geometry::Screen;
         use rav_core::units::{CellSize, Cells, Length};
@@ -1216,12 +1240,7 @@ impl App {
             // plainer one: it is framerate-independent because it integrates
             // dt, and stepping it on the display's cadence rather than the
             // signal's threw away the accuracy that buys.
-            let gain = self.measure();
-
-            let measured_at = Instant::now();
-            let dt = measured_at.duration_since(self.last_frame).as_secs_f32();
-            self.last_frame = measured_at;
-            self.ballistics.step(&self.bands, dt);
+            let (gain, measured_at) = self.advance();
 
             // Only the drawing is capped. Everything above ran on the signal.
             if measured_at < next_frame {

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -484,6 +484,20 @@ impl App {
     /// cursor now is, then write the overlay's own cells. An image lands
     /// wherever the cursor happens to be, and the overlay goes on afterwards
     /// because a written cell blanks the picture beneath it.
+    /// What rav has to say right now, or nothing.
+    ///
+    /// The warning outranks a transient note: a settings message that hides
+    /// "there is no audio" is worse than no message at all.
+    ///
+    /// Both surfaces want it and neither can reach the other's way of showing
+    /// it - a terminal writes cells, a window has no text of its own yet and
+    /// puts it in the title bar, which the desktop draws.
+    pub(crate) fn status_line(&self) -> Option<String> {
+        self.tap_warning()
+            .map(str::to_string)
+            .or_else(|| self.active_status().map(str::to_string))
+    }
+
     /// Measure what has arrived and move the bars to now.
     ///
     /// The two belong together, and belong on the signal's schedule rather than
@@ -1270,13 +1284,8 @@ impl App {
             frames += 1;
             let scope_gain = gain;
 
-            // Both borrow all of `self`, so they are taken before the destructure.
-            // The warning outranks a transient note: a settings message that
-            // hides "there is no audio" is worse than no message at all.
-            let status = self
-                .tap_warning()
-                .map(str::to_string)
-                .or_else(|| self.active_status().map(str::to_string));
+            // Taken before the destructure below, which borrows all of `self`.
+            let status = self.status_line();
             let help_rows = if self.show_help {
                 Some(self.help_rows())
             } else {

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -700,7 +700,7 @@ impl App {
     ///
     /// cpal delivers interleaved frames. Averaging rather than summing keeps a
     /// correlated full-scale stereo signal at full scale instead of clipping.
-    fn push_samples(&mut self, samples: &[f32]) {
+    pub(crate) fn push_samples(&mut self, samples: &[f32]) {
         let n = self.window.len();
         for frame in samples.chunks(self.channels) {
             let mono = frame.iter().sum::<f32>() / frame.len() as f32;

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -484,25 +484,21 @@ impl App {
     /// cursor now is, then write the overlay's own cells. An image lands
     /// wherever the cursor happens to be, and the overlay goes on afterwards
     /// because a written cell blanks the picture beneath it.
-    fn painted(
-        &mut self,
-        out: &mut impl Write,
-        size: crossterm::terminal::WindowSize,
-        staging: &std::path::Path,
-        status: Option<&str>,
-        help: Option<&[HelpRow<'_>]>,
-    ) -> Result<bool> {
+    /// The frame as pixels, and nothing about how it reaches a screen.
+    ///
+    /// Everything the two pixel surfaces have in common. A terminal that draws
+    /// images and a window of rav's own want the same picture and differ only
+    /// in the delivery, so the encoding lives with each of them and the drawing
+    /// lives here. `None` where there is nothing to hand over - a screen with
+    /// no area, which is a terminal caught mid-resize.
+    ///
+    /// `size` carries pixels and cells both, because the bar width is in cells
+    /// and cells are what `+` and `-` move. A window has none of its own and
+    /// says what it is counting instead.
+    fn frame_pixels(&mut self, size: &crossterm::terminal::WindowSize) -> Option<Vec<u8>> {
         use crate::surface::frame::{Frame, Look};
-        use crate::surface::overlay;
         use rav_core::geometry::Screen;
         use rav_core::units::{CellSize, Cells, Length};
-
-        // Only the analyser is drawn as pixels. The oscilloscope is still block
-        // characters, so `space` has to hand the screen back rather than leave
-        // the bars sitting there looking like a key that does nothing.
-        if self.visualisation != Visualisation::Analyzer {
-            return self.stop_painting(out).map(|()| false);
-        }
 
         let screen = Screen::new(
             Length(f32::from(size.width)),
@@ -581,7 +577,27 @@ impl App {
             pixels
         });
         self.cap_levels = caps;
-        let Some(pixels) = drawn else {
+        drawn
+    }
+
+    fn painted(
+        &mut self,
+        out: &mut impl Write,
+        size: crossterm::terminal::WindowSize,
+        staging: &std::path::Path,
+        status: Option<&str>,
+        help: Option<&[HelpRow<'_>]>,
+    ) -> Result<bool> {
+        use crate::surface::overlay;
+
+        // Only the analyser is drawn as pixels. The oscilloscope is still block
+        // characters, so `space` has to hand the screen back rather than leave
+        // the bars sitting there looking like a key that does nothing.
+        if self.visualisation != Visualisation::Analyzer {
+            return self.stop_painting(out).map(|()| false);
+        }
+
+        let Some(pixels) = self.frame_pixels(&size) else {
             return Ok(false);
         };
 

--- a/tests/on_a_pty.rs
+++ b/tests/on_a_pty.rs
@@ -171,8 +171,21 @@ impl OnAPty {
     }
 
     /// The same, resizing the window once it is drawing and waiting again.
+    ///
+    /// Three stretches after the drag, not one. Every wait here is on a *total*
+    /// count of pictures, and the frames already in flight when the resize
+    /// lands are drawn at the old size - so a single stretch leaves fewer than
+    /// [`ENOUGH`] at the new one as soon as the machine is busy, and the test
+    /// fails for the reason it was built to rule out. Waiting longer cannot
+    /// hide a rav that never resized: the assertion counts frames at the new
+    /// size, and more time only gives a working one room to produce them.
     fn quit_after_resizing_to(self, size: libc::winsize) -> String {
-        self.watched(&[Then::Resize(size), Then::Nothing])
+        self.watched(&[
+            Then::Resize(size),
+            Then::Nothing,
+            Then::Nothing,
+            Then::Nothing,
+        ])
     }
 
     /// The same, pressing a key once it is drawing and waiting again - so what


### PR DESCRIPTION
Stage 5, the last in the plan. A window of rav's own, behind a `gui` feature that is **off by default** — a terminal visualiser should not make everyone who installs it build a windowing stack.

```
cargo run --features gui -- --surface window
```

## What it does

Opens, draws, resizes, and takes every key the terminal takes. The status line is in the title bar. `q`, Escape and closing the window all end it.

## How it fits

**One blit target, not a second renderer.** The frame is already a `Pixmap` on the CPU, which is why the plan chose softbuffer over wgpu. `painted` was building the picture *and* writing the kitty escape sequence, so it split: `frame_pixels` returns bytes and knows nothing about delivery, `painted` keeps the encoding. The kitty pty tests hold that split in place — they read what a terminal actually receives.

**The terminal path is untouched.** winit wants the main thread and runs its own loop where `App::run` is async, so rather than bend one into the other this drives the same three steps from winit's callbacks: take in audio, `advance`, `frame_pixels`. A window cannot break a terminal.

**Blocking the runtime is survivable for one reason** — nothing rav needs is on it. Capture callbacks are cpal's own threads and the test signal has a thread of its own, so audio keeps arriving on the channel throughout.

**Keys go through `map_key`**, the same function the terminal uses. This translates winit's events into crossterm's vocabulary and stops there. A second key table would be a window whose `f` cycled something else six months from now, and nothing would notice until somebody used both.

**Alpha is resolved against black.** A terminal composites rav's frame over whatever the cell behind it held; a window has nothing behind it, so an unresolved edge would arrive as whatever was last in that buffer. Dividing by 255 rather than shifting by 8, because a shift turns full scale into 254 and the two surfaces are meant to draw the same picture.

**A window declares a cell.** The bar width is in cells because cells are what `+` and `-` move, and a window has none — so it states a nominal character box and those keys keep meaning "this many characters wide".

## What it does not do

**The help panel.** Fourteen rows of text need a font a window has no ratatui to provide. `h` says so — *"help is a terminal thing for now"* — through the same note a setting change uses, rather than toggling something nothing draws. Choosing the font is the follow-up, and it turns `CELL` from a stated number into a measured one.

**Nobody has looked at it.** Everything testable is tested: the blit pixel by pixel, the cell arithmetic, the key translation both ways, the title, both arms of the surface choice. Whether a window opens with bars in it is the one claim resting on the code being right.

## Also here

**A gap in the check suite.** Everything ran `--all-features`, which is the one configuration nobody installs — so a method reached only from behind a feature was a *build failure* in the default build while the suite was green. CI caught it; nothing local did. `test:default` now checks the default feature set.

**A latent flake.** The resize test waited one stretch of pictures after the drag, counted as a total, so frames still in flight at the old size came out of the same budget. Not introduced here; the tests added with the drawn skin made runs busy enough to lose it.

## Verified

`devenv test`, `nix flake check --all-systems` and `nix build` green. Linux green on every push, including the `--all-features` job that compiles winit and softbuffer.