### PR TITLE
fix: the log says which run wrote a line

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -51,8 +51,9 @@ near zero means the source is silent rather than absent.
 
 Read it from the bottom. The file is appended to, so it holds every run since
 you last deleted it, and two ravs going at once interleave their lines.
-`🚀 RAV Audio Visualizer starting up` marks where a run begins and carries that
-run's **pid**, which is what tells two of them apart:
+`🚀 RAV Audio Visualizer starting up...` marks where a run begins, and the
+**pid** after it is what tells two of them apart — so that is the prefix to
+search for, and the number on the end is the answer:
 
 ```
 🚀 RAV Audio Visualizer starting up... (pid 41337)

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -50,9 +50,17 @@ it says which rav chose. Neither line at all means nothing is arriving; a peak
 near zero means the source is silent rather than absent.
 
 Read it from the bottom. The file is appended to, so it holds every run since
-you last deleted it — and if two ravs are going at once their lines interleave
-with nothing to tell them apart. `🚀 RAV Audio Visualizer starting up` marks
-where the newest run begins.
+you last deleted it, and two ravs going at once interleave their lines.
+`🚀 RAV Audio Visualizer starting up` marks where a run begins and carries that
+run's **pid**, which is what tells two of them apart:
+
+```
+🚀 RAV Audio Visualizer starting up... (pid 41337)
+```
+
+`ps` will say whether that pid is still going. A run you thought had finished
+and has not is the reason to check: its lines go on arriving under yours, and
+they look exactly like yours.
 
 `rav --list-devices` shows what rav can see and `rav -d "<name>"` selects one.
 On Linux that list is ALSA PCMs only — a PipeWire/PulseAudio `.monitor` source

--- a/src/main.rs
+++ b/src/main.rs
@@ -173,7 +173,14 @@ async fn rav_main() -> Result<()> {
             .init();
     }
 
-    info!("🚀 RAV Audio Visualizer starting up...");
+    // With the pid, because the log is appended to and two ravs running at once
+    // interleave with nothing to tell them apart - which is not hypothetical:
+    // a stray run from hours earlier was read as the current one, and its
+    // frame counts taken for this run's.
+    info!(
+        "🚀 RAV Audio Visualizer starting up... (pid {})",
+        std::process::id()
+    );
 
     // Load configuration
     let config = Config::load(args.config.as_deref()).await?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -176,7 +176,7 @@ async fn rav_main() -> Result<()> {
     // With the pid, because the log is appended to and two ravs running at once
     // interleave with nothing to tell them apart - which is not hypothetical:
     // a stray run from hours earlier was read as the current one, and its
-    // frame counts taken for this run's.
+    // frame counts were reported as this run's.
     info!(
         "🚀 RAV Audio Visualizer starting up... (pid {})",
         std::process::id()


### PR DESCRIPTION
`rav.log` is appended to, and two ravs going at once interleave with nothing to tell them apart. `docs/troubleshooting.md` already said exactly that — without offering anything to tell them apart *with*. The startup line carries the pid now:

```
🚀 RAV Audio Visualizer starting up... (pid 41337)
```

**Not hypothetical.** A stray rav from hours earlier was still writing to this log today, and I read its `60 frames from 98 wakes` as the current run's. The measurement looked entirely reasonable and was from a different process — the trap the doc warns about, costing time again.

The doc now says to check the pid with `ps`, and why: a run you thought had finished and has not goes on filing lines under yours that look exactly like yours.