### PR TITLE
fix: rav does not abort when it cannot write its log

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -121,12 +121,26 @@ async fn rav_main() -> Result<()> {
         "info"
     };
 
-    // Always write logs to file to avoid TUI interference
+    // Always to a file, never to the terminal, which rav is about to paint on.
+    //
+    // An error rather than a panic, and it is the only startup failure that
+    // ever was one: a read-only working directory is an ordinary thing to run
+    // from - `/`, a system directory, anywhere someone landed after installing
+    // - and it deserves the same one-line report a mistyped flag gets rather
+    // than an abort and a backtrace.
     let log_file = std::fs::OpenOptions::new()
         .create(true)
         .append(true)
         .open("rav.log")
-        .expect("Failed to create log file");
+        .with_context(|| {
+            format!(
+                "Cannot write rav.log in {} - rav logs beside wherever it is started, \
+                 so run it somewhere writable",
+                std::env::current_dir()
+                    .map(|at| at.display().to_string())
+                    .unwrap_or_else(|_| "this directory".to_string()),
+            )
+        })?;
 
     // Not everything that writes to this terminal goes through `tracing`.
     // libasound reports from C straight to stderr, and merely enumerating the


### PR DESCRIPTION
Opening `rav.log` was the one `expect` left on a startup path — a read-only working directory aborted with a backtrace where every other startup failure prints one line and exits 1.

That is an ordinary place to be: `/`, a system directory, wherever somebody landed after `cargo install rav`. It was also the only way left to make rav panic on purpose — an audit of the tree found no other panicking call outside tests.

```
rav: Cannot write rav.log in /private/tmp/ro2 - rav logs beside wherever it is started, so run it somewhere writable: Permission denied (os error 13)
```

The message names the directory, because "cannot write rav.log" without one sends people to look beside the binary, and the log goes beside wherever rav was **started**.

## Verified

Run from a `chmod 555` directory: exits 1, one line on stdout, stderr empty — the same shape as a mistyped `--theme` or an unreadable skin. `devenv test` green.