### PR TITLE
docs(audio): what the realtime callback promises, and why it holds

### DIFF
--- a/src/audio/tap.rs
+++ b/src/audio/tap.rs
@@ -481,12 +481,15 @@ fn aggregate_reading(
     // the audio thread can take the allocator lock, which is exactly what a
     // realtime callback must not do.
     //
-    // Twice the cap, and the factor is the whole of the guarantee. The callback
-    // drains down to `MAX_QUEUED` and *then* appends, so the high-water mark is
-    // `MAX_QUEUED` plus one buffer - and this only reallocates if a single
-    // CoreAudio buffer carried more than `MAX_QUEUED` samples, which is a full
-    // second of audio at 48kHz and not a size any device delivers. One times
-    // the cap would reallocate on the first append after a full queue.
+    // The drain counts the arriving samples before it runs, so after appending
+    // the length is *exactly* `MAX_QUEUED` for any buffer no larger than the
+    // cap - which is every buffer a device delivers. One times the cap carries
+    // that on its own.
+    //
+    // The second cap is for the case the drain cannot reach: a single buffer
+    // longer than the whole queue empties it and then becomes it, so the length
+    // is that buffer's. `MAX_QUEUED` is a second of audio at 48kHz, so this is
+    // headroom against a device nobody has, not against the ordinary path.
     let buffer: Shared = Arc::new(TapChannel {
         buffer: Mutex::new(TapBuffer {
             samples: Vec::with_capacity(MAX_QUEUED * 2),
@@ -549,14 +552,24 @@ extern "C" fn io_proc(
         return 0;
     }
     let count = buffer.data_byte_size as usize / std::mem::size_of::<f32>();
+    // Alignment is an obligation of `from_raw_parts` and CoreAudio does not
+    // promise it for `mData` - it is a `void*`, and the guarantee is nowhere in
+    // `CoreAudioTypes.h`. In practice every buffer is at least as aligned as
+    // the allocator makes it, so this never fires; checking is two instructions
+    // and the alternative is undefined behaviour on the realtime thread if it
+    // ever does. Dropping the buffer beats reading it wrongly.
+    if !(buffer.data as usize).is_multiple_of(std::mem::align_of::<f32>()) {
+        return 0;
+    }
     // SAFETY: the most dangerous line here, so the obligations are named rather
-    // than left to be re-derived. `data` is non-null, checked above.  The length
-    // comes from the buffer's own `data_byte_size` rather than from a frame or
-    // channel count, so it cannot claim more than CoreAudio wrote - deriving it
-    // any other way is how this reads off the end. The format is checked to be
-    // 32-bit float when the tap is created, so `f32` is the element type.
-    // CoreAudio owns the memory for the length of this call and the slice does
-    // not outlive it: everything below copies out of it before returning.
+    // than left to be re-derived. `data` is non-null, checked above, and
+    // aligned for `f32`, checked directly above. The length comes from the
+    // buffer's own `data_byte_size` rather than from a frame or channel count,
+    // so it cannot claim more than CoreAudio wrote - deriving it any other way
+    // is how this reads off the end. The format is checked to be 32-bit float
+    // when the tap is created, so `f32` is the element type. CoreAudio owns the
+    // memory for the length of this call and the slice does not outlive it:
+    // everything below copies out of it before returning.
     let samples = unsafe { std::slice::from_raw_parts(buffer.data as *const f32, count) };
 
     if let Ok(mut out) = shared.buffer.try_lock() {

--- a/src/audio/tap.rs
+++ b/src/audio/tap.rs
@@ -385,6 +385,18 @@ fn tap_uid(tap: AudioObjectID) -> Result<Retained<NSString>> {
     if status != 0 || value.is_null() {
         bail!("reading kAudioTapPropertyUID failed (OSStatus {status})");
     }
+    // SAFETY: `kAudioTapPropertyUID` hands back a CFString the caller owns -
+    // `AudioHardware.h` says so in as many words: "The caller is responsible
+    // for releasing the returned CFObject." So it arrives at +1, and
+    // `from_raw` is the constructor that takes ownership *without* retaining
+    // again, which is what balances it. `Retained` releases on drop.
+    //
+    // The two ways to get this wrong are a leak and a double free, and neither
+    // shows up in a test - which is why the header is quoted rather than
+    // paraphrased. `retain` here would leak; `from_raw` on a +0 object, as the
+    // Get Rule properties hand back, would over-release.
+    //
+    // Null is checked above, and `from_raw` returns `None` for it anyway.
     let uid = unsafe { Retained::from_raw(value as *mut NSString) }.context("tap UID was nil")?;
     Ok(uid)
 }
@@ -468,6 +480,13 @@ fn aggregate_reading(
     // Preallocated so the realtime callback never grows the Vec. Allocating on
     // the audio thread can take the allocator lock, which is exactly what a
     // realtime callback must not do.
+    //
+    // Twice the cap, and the factor is the whole of the guarantee. The callback
+    // drains down to `MAX_QUEUED` and *then* appends, so the high-water mark is
+    // `MAX_QUEUED` plus one buffer - and this only reallocates if a single
+    // CoreAudio buffer carried more than `MAX_QUEUED` samples, which is a full
+    // second of audio at 48kHz and not a size any device delivers. One times
+    // the cap would reallocate on the first append after a full queue.
     let buffer: Shared = Arc::new(TapChannel {
         buffer: Mutex::new(TapBuffer {
             samples: Vec::with_capacity(MAX_QUEUED * 2),
@@ -530,6 +549,14 @@ extern "C" fn io_proc(
         return 0;
     }
     let count = buffer.data_byte_size as usize / std::mem::size_of::<f32>();
+    // SAFETY: the most dangerous line here, so the obligations are named rather
+    // than left to be re-derived. `data` is non-null, checked above.  The length
+    // comes from the buffer's own `data_byte_size` rather than from a frame or
+    // channel count, so it cannot claim more than CoreAudio wrote - deriving it
+    // any other way is how this reads off the end. The format is checked to be
+    // 32-bit float when the tap is created, so `f32` is the element type.
+    // CoreAudio owns the memory for the length of this call and the slice does
+    // not outlive it: everything below copies out of it before returning.
     let samples = unsafe { std::slice::from_raw_parts(buffer.data as *const f32, count) };
 
     if let Ok(mut out) = shared.buffer.try_lock() {


### PR DESCRIPTION
Three invariants in the process tap that were true and unwritten, all on the path where being wrong is a crash or a read off the end rather than a wrong picture.

**The slice from CoreAudio's buffer** — the most dangerous line in the tree. Its length comes from the buffer's own `data_byte_size` rather than from a frame or channel count, which is the difference between reading what was written and reading past it. `f32` is guaranteed because the tap refuses a format that is not 32-bit float at creation (`tap.rs:241`). The slice does not outlive the call.

**Twice the cap, and the factor is the guarantee.** The callback drains to `MAX_QUEUED` and *then* appends, so the high-water mark is the cap plus one buffer — it only reallocates if a single CoreAudio buffer carried more than a full second of audio at 48kHz. At one times the cap it would reallocate on the first append after a full queue, on the audio thread, taking the allocator lock, which is exactly what the preallocation exists to avoid. The old comment said "preallocated so it never grows" without saying why that is true.

**The tap UID is owned by the caller**, quoted from `AudioHardware.h`: *"The caller is responsible for releasing the returned CFObject."* So it arrives at +1 and `Retained::from_raw` — which takes ownership without retaining again — is what balances it. A leak and a double free are the two ways to get that wrong, and neither shows up in a test.

## Why now

An audit of `unsafe` in production found 20 blocks and 7 SAFETY notes. Most of the undocumented ones are ordinary FFI calls whose obligation is that the handles are live, which the surrounding code establishes. These three are not ordinary, and each was verified against the SDK header or the code rather than reasoned about — a SAFETY comment asserting an invariant nobody checked is worse than none.