### PR TITLE
docs: the window is in this release, not in what's next

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,9 +58,13 @@ its size in pixels. `--surface glyphs` forces the block characters. Press `h` fo
 which surface rav is on and why.
 
 `--surface window` draws the same picture in a window of rav's own, in a build
-that has one: `cargo install rav --features gui`, or `cargo run --features gui`.
-It is off by default because a terminal visualiser should not make everyone who
-installs it build a windowing stack.
+that has one. It is off by default because a terminal visualiser should not make
+everyone who installs it build a windowing stack.
+
+```
+cargo install rav --features gui && rav --surface window
+cargo run --features gui -- --surface window   # from a clone
+```
 
 Everything else is a keypress, and `h` shows the lot with their current values:
 

--- a/README.md
+++ b/README.md
@@ -57,6 +57,11 @@ everything else draws block characters, as does a terminal that will not report
 its size in pixels. `--surface glyphs` forces the block characters. Press `h` for
 which surface rav is on and why.
 
+`--surface window` draws the same picture in a window of rav's own, in a build
+that has one: `cargo install rav --features gui`, or `cargo run --features gui`.
+It is off by default because a terminal visualiser should not make everyone who
+installs it build a windowing stack.
+
 Everything else is a keypress, and `h` shows the lot with their current values:
 
 | Key | |
@@ -107,9 +112,8 @@ The ballistics, and the ramp the `rav` and `winamp` themes use, come from
 
 ## What's next
 
-A window of its own. Small displays — a strip of LEDs, or a matrix — which the
-same themes already cover, since what rav measures is kept apart from what it
-looks like.
+Small displays — a strip of LEDs, or a matrix — which the same themes already
+cover, since what rav measures is kept apart from what it looks like.
 
 ## License
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -79,6 +79,7 @@ reports rather than forecasts: **drawing on** while the pixels are going,
 | `pixels (your terminal can draw images)` | pixels are going, and nothing needs fixing. `asked for` in place of the reason means `--surface kitty` on the command line |
 | `glyphs (your terminal will not say how big it is in pixels)` | rav asked the terminal how big it is and got no answer. Deriving a cell size from the font is the rounding the pixel surface exists to remove, so rav declines to guess |
 | `glyphs (tmux or screen is in the way)` | image escapes do not pass through a multiplexer intact. An explicit `--surface kitty` is still honoured — asking always wins — but it is the terminal underneath that has to answer |
+| `glyphs (this build has no window in it)` | `--surface window` on a build without the `gui` feature. It is off by default so that installing a terminal visualiser does not build a windowing stack; `cargo install rav --features gui` turns it on |
 
 **Pixels are the bars.** The oscilloscope is block characters on every surface,
 so `Space` takes the picture down and the panel goes back to saying *would*.


### PR DESCRIPTION
**"What's next" promised a window of rav's own**, which is built and merged. A roadmap listing a shipped feature undersells the release and oversells what is coming — at the top of the first thing anyone reads, and on the crates.io front page.

Small displays stay in that section. They are genuinely next, and the reason given for them still holds: the same themes already cover them, because what rav measures is kept apart from what it looks like.

**The surfaces paragraph now says what `--surface window` needs.** It appeared in the flag comment as one of `auto, glyphs, kitty or window` with nothing about the feature, so somebody installing from crates.io and trying it got `this build has no window in it` with no idea why. Four lines, factual, and they say why it is off by default rather than apologising for it.