### PR TITLE
docs: devenv test runs more than the four commands beside it

### DIFF
--- a/docs/developing.md
+++ b/docs/developing.md
@@ -51,6 +51,19 @@ green result. 54 tests stopped running that way once.
 the same command you can run locally, which is where the
 `#[cfg(target_os = "macos")]` mistakes surface.
 
+**`devenv test` is the suite; those four commands are not.** It runs three more,
+and each exists because the four above came back green while something was
+broken:
+
+| task | what the four miss |
+|---|---|
+| `test:default` | everything else runs `--all-features`, which nobody installs. A method reached only from behind a feature is *dead code* in the default build, and this crate denies that — so the default build failed while the suite was green |
+| `test:package` | every other check builds the repository. Nothing built the **tarball**, and `assets/` was excluded from it while the binary embedded a file from there. The published crate would not have compiled |
+| `test:portable` | `rav-core` and `rav-appearance` claim to run on a microcontroller. `no_std` stops them reaching for a filesystem; it does not stop a machine assumption, which building for `wasm32` does |
+
+Adding a check means adding a task **and** naming it in `enterTest`, which lists
+them one at a time. A task that is not named there does not run.
+
 CI does **not** build the flake, so run `nix build .#default` yourself before a
 push that touches packaging. Flakes only see **git-tracked** files, so a new asset
 that has not been `git add`ed fails there and nowhere else — and `nix run


### PR DESCRIPTION
The Checks section listed four commands and called it the checks. `devenv test` runs **seven** tasks, and the three missing from that list are the ones that exist *because* the four came back green while something was broken:

| task | what the four miss |
|---|---|
| `test:default` | everything else runs `--all-features`, which nobody installs. A method reached only from behind a feature is dead code in the default build, and this crate denies that — the default build failed while the whole suite was green |
| `test:package` | every other check builds the repository. Nothing built the **tarball**, and `assets/` was excluded from it while the binary embedded a file from there. The published crate would not have compiled, after two immutable versions had already gone up |
| `test:portable` | the two portable crates claim to run on a microcontroller. `no_std` stops them reaching for a filesystem; it does not stop a machine assumption |

Each row says what the four *miss* rather than what the task does, because the reason is the part worth knowing — a reader who understands why `test:package` exists will not delete it during a cleanup.

Also documented: a task has to be named in `enterTest` to run at all. That list is one-at-a-time, so adding a task to `devenv.nix` and stopping there is its own way to add a check that checks nothing — which happened, and stayed green for an hour.