### PR TITLE
docs: where a theme actually goes on macOS

### DIFF
--- a/docs/developing.md
+++ b/docs/developing.md
@@ -51,6 +51,19 @@ green result. 54 tests stopped running that way once.
 the same command you can run locally, which is where the
 `#[cfg(target_os = "macos")]` mistakes surface.
 
+**`devenv test` is the suite; those four commands are not.** It runs three more,
+and each exists because the four above came back green while something was
+broken:
+
+| task | what the four miss |
+|---|---|
+| `test:default` | everything else runs `--all-features`, which nobody installs. A method reached only from behind a feature is *dead code* in the default build, and this crate denies that — so the default build failed while the suite was green |
+| `test:package` | every other check builds the repository. Nothing built the **tarball**, and `assets/` was excluded from it while the binary embedded a file from there. The published crate would not have compiled |
+| `test:portable` | `rav-core` and `rav-appearance` claim to run on a microcontroller. `no_std` stops them reaching for a filesystem; it does not stop a machine assumption, which building for `wasm32` does |
+
+Adding a check means adding a task **and** naming it in `enterTest`, which lists
+them one at a time. A task that is not named there does not run.
+
 CI does **not** build the flake, so run `nix build .#default` yourself before a
 push that touches packaging. Flakes only see **git-tracked** files, so a new asset
 that has not been `git add`ed fails there and nowhere else — and `nix run

--- a/docs/developing.md
+++ b/docs/developing.md
@@ -66,8 +66,8 @@ them one at a time. A task that is not named there does not run.
 
 CI does **not** build the flake, so run `nix build .#default` yourself before a
 push that touches packaging. Flakes only see **git-tracked** files, so a new asset
-that has not been `git add`ed fails there and nowhere else — and `nix run
-github:i-am-logger/rav` is the install path in the README.
+that has not been `git add`ed fails there and nowhere else. `nix run github:i-am-logger/rav`
+is the install path in the README, so that is the one that breaks.
 
 ## Recording the demo
 

--- a/docs/themes.md
+++ b/docs/themes.md
@@ -16,8 +16,8 @@ your platform calls the config directory. That is **not** `~/.config` everywhere
 | Linux | `~/.config/rav/themes` |
 | macOS | `~/Library/Application Support/rav/themes` |
 
-A path always works and never has to be guessed at, which is what `--theme
-./sunset.toml` is for.
+Neither has to be guessed at: `--theme ./sunset.toml` takes a path and always
+works, wherever the file is.
 
 Press `t` in rav to cycle the built-ins; a theme loaded with `--theme` joins the
 rotation.

--- a/docs/themes.md
+++ b/docs/themes.md
@@ -5,8 +5,19 @@ code — so adding one means writing a file, not touching Rust.
 
 ```
 rav --theme ./sunset.toml     # a path
-rav --theme sunset            # a name, looked up in ./themes then ~/.config/rav/themes
+rav --theme sunset            # a name, looked up in ./themes then your config directory
 ```
+
+A name is looked for in `./themes` first, then under `rav/themes` in whatever
+your platform calls the config directory. That is **not** `~/.config` everywhere:
+
+| | |
+|---|---|
+| Linux | `~/.config/rav/themes` |
+| macOS | `~/Library/Application Support/rav/themes` |
+
+A path always works and never has to be guessed at, which is what `--theme
+./sunset.toml` is for.
 
 Press `t` in rav to cycle the built-ins; a theme loaded with `--theme` joins the
 rotation.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -83,6 +83,6 @@ reports rather than forecasts: **drawing on** while the pixels are going,
 
 **Pixels are the bars.** The oscilloscope is block characters on every surface,
 so `Space` takes the picture down and the panel goes back to saying *would*.
-Switching back brings it up again - and `v`, the viewing angle, reads `needs
-pixels` for as long as either of those is true, rather than moving a setting
-nothing is drawing.
+Switching back brings it up again - and `v`, the viewing angle, reads
+`needs pixels` for as long as either of those is true, rather than moving a
+setting nothing is drawing.


### PR DESCRIPTION
The lookup was documented as `~/.config/rav/themes`. `resolve` uses `dirs::config_dir()`, which on macOS is `~/Library/Application Support` — measured on this machine as `/Users/logger/Library/Application Support`.

So a reader **on the platform rav is developed on** would put a theme where rav never looks, and get `no theme 'sunset'` with the file sitting exactly where the documentation told them to put it.

| | |
|---|---|
| Linux | `~/.config/rav/themes` |
| macOS | `~/Library/Application Support/rav/themes` |

Both are named now, and the text says a path argument never has to be guessed at — `--theme ./sunset.toml` always works.

The plan flagged this exact bug during the theme/skin rename, for the file this one was renamed *from*. It was fixed there and not here.