### PR TITLE
experiment: do winit and softbuffer need those Linux libraries

### DIFF
--- a/devenv.nix
+++ b/devenv.nix
@@ -38,17 +38,6 @@
     # record-demo reads the focused window and sends the tour's keys through
     # this. macOS does both through osascript, which ships with the system.
     xdotool
-
-    # winit and softbuffer, behind the `gui` feature. Off by default and still
-    # compiled here, because clippy and the tests run under --all-features -
-    # so these arrive with the feature rather than after it turns CI red.
-    # Both backends: winit carries X11 and Wayland and chooses at runtime.
-    libxkbcommon
-    wayland
-    xorg.libX11
-    xorg.libXcursor
-    xorg.libXi
-    xorg.libXrandr
   ];
 
   # Development scripts


### PR DESCRIPTION
**Not for merge.** Open to answer one question with CI rather than by assuming.

I added libxkbcommon, wayland and four xorg libraries to the dev shell when the `gui` feature landed, on the assumption winit and softbuffer need them to build on Linux. I never checked — and the README now tells people to run `cargo install rav --features gui`, so what a Linux user needs is a thing I have documented without knowing.

This removes them. `Checks` runs `devenv test` under `--all-features` on ubuntu, so it compiles winit and softbuffer without those libraries present.

- **Green** → they were never needed at build time. Remove them as noise, and the README needs no Linux caveat for `--features gui`.
- **Red** → they are needed, and the README has to say so, because right now it tells Linux users to run a command that will not work.