### PR TITLE
fix: those Linux libraries are for running a window, not building one

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2476,16 +2476,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "socket2"
-version = "0.6.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
-dependencies = [
- "libc",
- "windows-sys 0.61.2",
-]
-
-[[package]]
 name = "softbuffer"
 version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2739,13 +2729,10 @@ version = "1.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "202caea871b69668250d242070849eb495be178ed697a3e98aebce5bc81a0bed"
 dependencies = [
- "bytes",
  "libc",
  "mio",
- "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2040,7 +2040,6 @@ dependencies = [
  "rav-core",
  "realfft",
  "resvg",
- "rustfft",
  "serde",
  "softbuffer",
  "tiny-skia 0.12.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -102,8 +102,16 @@ anyhow = "1.0"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
-# Async runtime and channels
-tokio = { version = "1.0", features = ["full"] }
+# Async runtime and channels.
+#
+# The features rav uses, rather than `full`. `full` claims rav needs all of
+# tokio - it does not touch `net`, `process` or the io helpers - and the claim
+# cost every install one crate it never ran: socket2, through the networking
+# tokio was told to bring.
+#
+# `signal` is what keeps mio, and it is the one that has to be here: Ctrl-C is
+# handled through `tokio::signal::ctrl_c`.
+tokio = { version = "1.0", default-features = false, features = ["rt-multi-thread", "macros", "time", "sync", "signal", "fs"] }
 flume = "0.11"
 
 # Utilities

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,8 +77,11 @@ crossterm = "0.28"
 # cpal is the only backend used; it selects ALSA on Linux and CoreAudio on macOS.
 cpal = "0.15"
 
-# Signal processing and FFT
-rustfft = "6.2"
+# Signal processing and FFT.
+#
+# `rustfft` is not named here. realfft is built on it and re-exports what rav
+# touches - `realfft::num_complex::Complex` - so declaring it too was a version
+# constraint kept for nothing, and one that could argue with realfft's own.
 realfft = "3.3"
 
 # Rasterising, for the surfaces that draw pixels rather than glyphs.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -134,9 +134,12 @@ winit = { version = "0.30", optional = true }
 softbuffer = { version = "0.4", optional = true }
 
 # `--all-features` is what devenv runs clippy and the tests under, so this is
-# compiled on both platforms in CI whether or not anybody turns it on. The
-# Linux system libraries it needs are in `flake.nix` and `devenv.nix` for the
-# same reason.
+# compiled on both platforms in CI whether or not anybody turns it on.
+#
+# It needs no system libraries to *build*: winit and softbuffer dlopen X11 and
+# Wayland rather than linking them, which is why `flake.nix` names none. The
+# dev shell carries them so a window opened from there has something to open
+# on, and that is the only place they belong.
 [features]
 gui = ["dep:winit", "dep:softbuffer"]
 

--- a/devenv.nix
+++ b/devenv.nix
@@ -41,12 +41,14 @@
 
     # For *running* the `gui` window here, not for building it. winit and
     # softbuffer dlopen X11 and Wayland rather than linking them, so
-    # `--all-features` compiles on a Linux box with none of these - measured, by
+    # `--all-features` compiles on a Linux box with none of these - measured by
     # taking them out and watching CI stay green.
     #
     # Which also means `cargo install rav --features gui` needs no system
-    # packages beyond what a desktop already has. A headless machine builds it
-    # and cannot open a window, and that is a property of being headless.
+    # packages beyond what a desktop already has. What it cannot do is open a
+    # window with no display server to open it on - over ssh, or in a container
+    # with no X11 or Wayland session - and that is the session missing rather
+    # than a dependency.
     #
     # Both backends, because winit carries both and chooses at runtime.
     libxkbcommon

--- a/devenv.nix
+++ b/devenv.nix
@@ -39,10 +39,16 @@
     # this. macOS does both through osascript, which ships with the system.
     xdotool
 
-    # winit and softbuffer, behind the `gui` feature. Off by default and still
-    # compiled here, because clippy and the tests run under --all-features -
-    # so these arrive with the feature rather than after it turns CI red.
-    # Both backends: winit carries X11 and Wayland and chooses at runtime.
+    # For *running* the `gui` window here, not for building it. winit and
+    # softbuffer dlopen X11 and Wayland rather than linking them, so
+    # `--all-features` compiles on a Linux box with none of these - measured, by
+    # taking them out and watching CI stay green.
+    #
+    # Which also means `cargo install rav --features gui` needs no system
+    # packages beyond what a desktop already has. A headless machine builds it
+    # and cannot open a window, and that is a property of being headless.
+    #
+    # Both backends, because winit carries both and chooses at runtime.
     libxkbcommon
     wayland
     xorg.libX11

--- a/flake.nix
+++ b/flake.nix
@@ -43,24 +43,12 @@
             inherit src;
             strictDeps = true;
             nativeBuildInputs = lib.optionals stdenv.isLinux [ pkgs.pkg-config ];
-            buildInputs = lib.optionals stdenv.isLinux ([ pkgs.alsa-lib ]
-              # The `gui` feature is off here, but `devenv test` runs clippy and
-              # the tests under --all-features, so winit and softbuffer are
-              # compiled on Linux in CI whether or not anyone turns them on.
-              # These have to arrive with the feature, not after the build that
-              # first needs them goes red.
-              #
-              # X11 and Wayland both, because winit's default features carry
-              # both backends and picks at runtime - a build with one is a
-              # binary that cannot open a window on half of Linux.
-              ++ (with pkgs; [
-              libxkbcommon
-              wayland
-              xorg.libX11
-              xorg.libXcursor
-              xorg.libXi
-              xorg.libXrandr
-            ]));
+            # No X11 or Wayland here on purpose. This builds the default feature
+            # set, so winit and softbuffer are not compiled at all - and even
+            # under `--features gui` they would not need them, because both
+            # dlopen their backends rather than linking. Measured by removing
+            # them and watching Linux CI stay green.
+            buildInputs = lib.optionals stdenv.isLinux [ pkgs.alsa-lib ];
           };
 
           # The dependencies as a store path of their own, built from a stub


### PR DESCRIPTION
The comment added with the `gui` feature said winit and softbuffer need X11 and Wayland present or `devenv test` breaks the moment the feature exists.

**It does not.** Both `dlopen` their backends rather than linking them, so `--all-features` compiles on a Linux box with none of them. Measured in #150 by removing them and watching Linux CI stay green, rather than by reasoning about it a second time.

**They come out of `flake.nix` entirely.** That build is the default feature set, so it never compiles either crate — they were `buildInputs` for code that is not in the derivation.

**They stay in the dev shell**, where the reason is real: running the window there needs libraries the store paths would otherwise not have.

## What it means for anyone installing

`cargo install rav --features gui` needs no system packages beyond what a desktop already has. That matters because the README now tells people to run it, and I had documented that command without knowing what it required — which is what prompted the experiment.

A headless machine builds it and cannot open a window. That is a property of being headless, not a missing dependency.

## Verified

`nix flake check --all-systems`, `nix build .#default` and `devenv test` all green with the inputs removed.