### PR TITLE
docs: which crate actually holds the MSRV

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,8 +11,14 @@ members = ["crates/rav-core", "crates/rav-appearance"]
 [workspace.package]
 version = "1.0.0-beta.12"
 edition = "2024"
-# The floor the dependency graph imposes, not rav's own source: instability
-# (reached through ratatui) and the darling family all declare 1.88.
+# The floor the dependency graph imposes, not rav's own source. One crate holds
+# it: `darling_core`, reached as ratatui -> instability -> darling. Nothing else
+# in the graph asks for more than 1.87, so that is the single thing to look at
+# if this ever wants lowering.
+#
+# `instability` was named here too and has since relaxed to 1.64, which is worth
+# knowing: this number moves when somebody else's manifest does, not when rav's
+# source does.
 rust-version = "1.88"
 authors = ["RAV Team <i-am-logger@users.noreply.github.com>"]
 repository = "https://github.com/i-am-logger/rav"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,9 +12,10 @@ members = ["crates/rav-core", "crates/rav-appearance"]
 version = "1.0.0-beta.12"
 edition = "2024"
 # The floor the dependency graph imposes, not rav's own source. One crate holds
-# it: `darling_core`, reached as ratatui -> instability -> darling. Nothing else
-# in the graph asks for more than 1.87, so that is the single thing to look at
-# if this ever wants lowering.
+# it: `darling_core`, reached as ratatui -> instability -> darling ->
+# darling_core. Only the first of those is a dependency rav names; the rest
+# arrive underneath it. Nothing else in the graph asks for more than 1.87, so
+# that is the single manifest to look at if this ever wants lowering.
 #
 # `instability` was named here too and has since relaxed to 1.64, which is worth
 # knowing: this number moves when somebody else's manifest does, not when rav's


### PR DESCRIPTION
`rust-version = "1.88"` carried a comment naming `instability` and the darling family as the crates declaring it. **`instability` has since relaxed to 1.64**, so exactly one crate holds the floor now:

```
darling_core v0.24.0
└── darling v0.24.0
    └── instability v0.3.13 (proc-macro)
        └── ratatui v0.28.1
            └── rav
```

Nothing else in the graph asks for more than 1.87 — checked across every locked dependency, not sampled. That turns lowering the MSRV from a survey into a question about one manifest.

The path is written down because none of those three crates is a dependency rav names; `ratatui` is, and the rest arrive underneath it.

Also now stated: **this number moves when somebody else's manifest does, not when rav's source does.** Both crates the old comment named have changed under it without rav touching a line, which is exactly how it went stale.

Checked while verifying that winit and softbuffer had not raised the floor when the window landed. They declare 1.70 and 1.71, so they had not.