### PR TITLE
ci: prove the MSRV instead of declaring it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -176,14 +176,6 @@ jobs:
       - run: nix build .#default --print-build-logs
       - run: ./result/bin/rav --version
 
-  # Separate from the nix build because this binary is attached to the release
-  # and has to run on machines without nix: built here it links the runner's
-  # glibc, where a nix-built one resolves an interpreter under /nix/store.
-  #
-  # No `needs: [checks]`. Cheap-before-expensive is enforced inside the checks
-  # job, where the ordering is free; gating this one on it would serialise a
-  # ~90s release build behind a ~5min check suite on every green run to save
-  # runner minutes only on red ones. Release latency is worth more than that.
   msrv:
     name: MSRV
     runs-on: ubuntu-latest
@@ -210,8 +202,21 @@ jobs:
       # `check` rather than `build`: this asks whether the source compiles on
       # the oldest toolchain rav claims, and a linked binary answers nothing
       # more than that for twice the time.
-      - run: cargo check --workspace --all-features --all-targets
+      #
+      # `--locked` is what makes the answer mean anything. Without it cargo may
+      # quietly resolve older compatible versions to satisfy this toolchain and
+      # pass - proving that *some* dependency set builds on 1.88, which is not
+      # the question. The one that ships is the one in Cargo.lock.
+      - run: cargo check --locked --workspace --all-features --all-targets
 
+  # Separate from the nix build because this binary is attached to the release
+  # and has to run on machines without nix: built here it links the runner's
+  # glibc, where a nix-built one resolves an interpreter under /nix/store.
+  #
+  # No `needs: [checks]`. Cheap-before-expensive is enforced inside the checks
+  # job, where the ordering is free; gating this one on it would serialise a
+  # ~90s release build behind a ~5min check suite on every green run to save
+  # runner minutes only on red ones. Release latency is worth more than that.
   build:
     name: Build
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -184,6 +184,34 @@ jobs:
   # job, where the ordering is free; gating this one on it would serialise a
   # ~90s release build behind a ~5min check suite on every green run to save
   # runner minutes only on red ones. Release latency is worth more than that.
+  msrv:
+    name: MSRV
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+      # cpal links ALSA on Linux.
+      - name: Install ALSA headers
+        run: sudo apt-get update && sudo apt-get install -y libasound2-dev pkg-config
+      # Pinned, and the pin is the whole point: every other job here runs
+      # stable, so `rust-version` in Cargo.toml was a promise to anyone
+      # installing from crates.io that nothing checked. An API stabilised above
+      # this floor compiles everywhere rav is built and fails for the reader.
+      - uses: dtolnay/rust-toolchain@1.88
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: msrv
+      # --all-features, so the `gui` feature is covered too - winit and
+      # softbuffer declare 1.70 and 1.71, well under this, and that is a thing
+      # to keep true rather than assume.
+      #
+      # `check` rather than `build`: this asks whether the source compiles on
+      # the oldest toolchain rav claims, and a linked binary answers nothing
+      # more than that for twice the time.
+      - run: cargo check --workspace --all-features --all-targets
+
   build:
     name: Build
     runs-on: ubuntu-latest
@@ -213,16 +241,22 @@ jobs:
 
   release:
     name: Release
-    needs: [checks, package, build]
+    needs: [checks, package, build, msrv]
     # Every gate is named: a job in needs: but absent from if: is not gated.
     # !cancelled() rather than always(), so a cancelled run cannot publish.
+    #
+    # msrv is here because publishing is what makes `rust-version` a promise.
+    # A crate that says 1.88 and needs more is a compile error for a reader and
+    # nothing at all for anyone building on stable, so the one moment it must
+    # hold is the moment it goes to crates.io - where it cannot be taken back.
     if: |
       !cancelled() &&
       github.event_name == 'push' &&
       github.ref == 'refs/heads/master' &&
       needs.checks.result == 'success' &&
       needs.package.result == 'success' &&
-      needs.build.result == 'success'
+      needs.build.result == 'success' &&
+      needs.msrv.result == 'success'
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:


### PR DESCRIPTION
`rust-version = "1.88"` is a promise to anyone installing from crates.io, and **nothing checked it**. Every job here runs stable — currently 1.97 — so an API stabilised above that floor compiles in CI, compiles for every contributor, and fails for the reader.

**Not hypothetical by much.** The alignment check I added to the CoreAudio tap today uses `is_multiple_of`, stabilised in **1.87** — one version under the floor rav claims. It is fine, and nothing would have told me either way.

## What it does

A pinned `dtolnay/rust-toolchain@1.88` job running `cargo check --workspace --all-features --all-targets`.

- `--all-features`, so the `gui` feature is covered. winit and softbuffer declare 1.70 and 1.71, comfortably under — a thing to keep true rather than assume.
- `check` rather than `build`: the question is whether the source compiles on the oldest toolchain rav claims, and linking a binary answers nothing more for twice the time.

**The release waits on it**, in both `needs:` and `if:` as this workflow requires. Publishing is the moment `rust-version` becomes a promise, and crates.io is where a wrong one cannot be taken back.

## What it costs

One job per PR, in parallel with the others. That is the trade — and unlike the release-profile test pass I declined earlier today, this one guards a claim rav makes publicly to people who cannot check it themselves.