### PR TITLE
feat: h draws the help panel in a window

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -831,6 +831,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
+name = "font8x8"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "875488b8711a968268c7cf5d139578713097ca4635a76044e8fe8eedf831d07e"
+
+[[package]]
 name = "foreign-types"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2031,6 +2037,7 @@ dependencies = [
  "crossterm",
  "dirs",
  "flume",
+ "font8x8",
  "libc",
  "objc2 0.6.4",
  "objc2-foundation 0.3.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -139,6 +139,7 @@ usvg = { version = "0.48", default-features = false }
 # bring a GPU abstraction to move bytes that are already where they need to be.
 winit = { version = "0.30", optional = true }
 softbuffer = { version = "0.4", optional = true }
+font8x8 = { version = "0.3.1", default-features = false, features = ["unicode"], optional = true }
 
 # `--all-features` is what devenv runs clippy and the tests under, so this is
 # compiled on both platforms in CI whether or not anybody turns it on.
@@ -149,6 +150,7 @@ softbuffer = { version = "0.4", optional = true }
 # on, and that is the only place they belong.
 [features]
 gui = ["dep:winit", "dep:softbuffer"]
+font8x8 = ["dep:font8x8"]
 
 [[bin]]
 name = "rav"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -149,8 +149,7 @@ font8x8 = { version = "0.3.1", default-features = false, features = ["unicode"],
 # dev shell carries them so a window opened from there has something to open
 # on, and that is the only place they belong.
 [features]
-gui = ["dep:winit", "dep:softbuffer"]
-font8x8 = ["dep:font8x8"]
+gui = ["dep:winit", "dep:softbuffer", "dep:font8x8"]
 
 [[bin]]
 name = "rav"

--- a/src/surface/mod.rs
+++ b/src/surface/mod.rs
@@ -22,6 +22,10 @@ pub mod frame;
 pub mod kitty;
 pub mod overlay;
 pub mod pixels;
+/// Drawing words without a terminal to draw them. Behind `gui` for now: the
+/// kitty surface writes cells and has no use for it.
+#[cfg(feature = "gui")]
+pub mod text;
 /// Behind `gui`, which is off by default - a terminal visualiser should not
 /// make everyone who installs it build a windowing stack.
 #[cfg(feature = "gui")]

--- a/src/surface/text.rs
+++ b/src/surface/text.rs
@@ -22,7 +22,13 @@ pub trait Bitmap {
     fn cell(&self) -> (u32, u32);
 
     /// Write one row per pixel of height into `into`, and say whether the
-    /// font carries that character. A character it does not carry is drawn as
+    /// font carries that character.
+    ///
+    /// **One byte a row, so eight columns.** A cell wider than that is drawn
+    /// to eight and the rest is dropped, which is stated here rather than
+    /// discovered: a 16-wide font would render as its left half with nothing
+    /// to say so. Taller is fine - that is one byte per row, however many
+    /// rows there are. A character it does not carry is drawn as
     /// nothing rather than as a substitute - a box glyph in the middle of a
     /// help panel reads as data corruption.
     ///
@@ -77,6 +83,10 @@ pub fn draw(
     colour: Colour,
 ) -> u32 {
     let (across, down) = font.cell();
+    // Eight columns is what a row byte holds - `Bitmap::rows` says so. The
+    // *advance* is still the full cell, or a wider font would overlap itself
+    // as well as losing its right-hand columns.
+    let columns = across.min(8);
     let mut paint = Paint::default();
     paint.set_color_rgba8(colour.red, colour.green, colour.blue, colour.alpha);
     paint.anti_alias = false;
@@ -97,13 +107,13 @@ pub fn draw(
                 // strokes. `bits` is 8 wide, so this is at most four rects a
                 // row instead of eight.
                 let mut col = 0u32;
-                while col < across.min(8) {
+                while col < columns {
                     if bits & leftmost.mask(col) == 0 {
                         col += 1;
                         continue;
                     }
                     let start = col;
-                    while col < across.min(8) && bits & leftmost.mask(col) != 0 {
+                    while col < columns && bits & leftmost.mask(col) != 0 {
                         col += 1;
                     }
                     if let Some(run) = Rect::from_xywh(
@@ -284,29 +294,53 @@ mod tests {
 /// panel disagrees with a terminal's about which rows fit.
 ///
 /// `screen` is in pixels; the cell comes from the font.
+pub fn help_area(
+    font: &dyn Bitmap,
+    rows: &[crate::ui::help::HelpRow<'_>],
+    title: &str,
+    (screen_across, screen_down): (u32, u32),
+) -> Option<(u32, u32, u32, u32)> {
+    let (across, down) = font.cell();
+    if across == 0 || down == 0 {
+        return None;
+    }
+    // Saturating, not truncating. `as u16` on a window wide enough to hold more
+    // than 65535 cells wraps to a small number and quietly draws a panel a few
+    // characters wide - which needs a very large screen and a very small font,
+    // and is silent when it happens.
+    let cells = |pixels: u32, cell: u32| (pixels / cell).min(u32::from(u16::MAX)) as u16;
+    let at = crate::ui::help::Help { rows, title }.panel(ratatui::layout::Rect {
+        x: 0,
+        y: 0,
+        width: cells(screen_across, across),
+        height: cells(screen_down, down),
+    });
+    if at.width == 0 || at.height == 0 {
+        return None;
+    }
+    Some((
+        u32::from(at.x) * across,
+        u32::from(at.y) * down,
+        u32::from(at.width) * across,
+        u32::from(at.height) * down,
+    ))
+}
+
+/// Draw the panel, filling `onto`.
+///
+/// `onto` is the panel and nothing else - [`help_area`] says how big to make it
+/// and where it goes. A surface the size of the window would mean clearing and
+/// scanning every pixel of it each frame the panel is open, for a panel that
+/// covers a fraction of one.
 pub fn help(
     onto: &mut Pixmap,
     font: &dyn Bitmap,
     rows: &[crate::ui::help::HelpRow<'_>],
     title: &str,
-    (screen_across, screen_down): (u32, u32),
     (ink, background): (Colour, Colour),
 ) {
     let (across, down) = font.cell();
     if across == 0 || down == 0 {
-        return;
-    }
-    let panel = crate::ui::help::Help { rows, title };
-    // The terminal's own sizing, asked in cells: how many of them fit across
-    // and down this window at the font's size.
-    let area = ratatui::layout::Rect {
-        x: 0,
-        y: 0,
-        width: (screen_across / across) as u16,
-        height: (screen_down / down) as u16,
-    };
-    let at = panel.panel(area);
-    if at.width == 0 || at.height == 0 {
         return;
     }
 
@@ -318,29 +352,22 @@ pub fn help(
         background.alpha,
     );
     paint.anti_alias = false;
-    if let Some(behind) = Rect::from_xywh(
-        (u32::from(at.x) * across) as f32,
-        (u32::from(at.y) * down) as f32,
-        (u32::from(at.width) * across) as f32,
-        (u32::from(at.height) * down) as f32,
-    ) {
+    if let Some(behind) = Rect::from_xywh(0.0, 0.0, onto.width() as f32, onto.height() as f32) {
         onto.fill_rect(behind, &paint, Transform::identity(), None);
     }
 
-    let left = u32::from(at.x) * across;
-    let top = u32::from(at.y) * down;
-    draw(onto, font, title, (left + across * 2, top + down), ink);
+    draw(onto, font, title, (across * 2, down), ink);
 
     // Two cells in from the border and one line below the title, which is what
     // the terminal panel does - the two are meant to be the same panel.
-    let key_width = panel.key_width() as u32;
+    let key_width = crate::ui::help::Help { rows, title }.key_width() as u32;
     for (line, row) in rows.iter().enumerate() {
-        let y = top + down * (line as u32 + 3);
-        if y + down > top + u32::from(at.height) * down {
+        let y = down * (line as u32 + 3);
+        if y + down > onto.height() {
             break;
         }
-        draw(onto, font, row.key, (left + across * 2, y), ink);
-        let description = left + across * (2 + key_width + 2);
+        draw(onto, font, row.key, (across * 2, y), ink);
+        let description = across * (2 + key_width + 2);
         let after = draw(onto, font, row.description, (description, y), ink);
         if let Some(value) = &row.value {
             draw(onto, font, value, (after + across, y), ink);
@@ -353,8 +380,6 @@ mod panel_tests {
     use super::*;
     use crate::ui::help::HelpRow;
 
-    /// The same two-glyph font the tests above use, declared again rather than
-    /// reached for across module walls.
     struct Probe;
     impl Bitmap for Probe {
         fn cell(&self) -> (u32, u32) {
@@ -390,10 +415,6 @@ mod panel_tests {
         }
     }
 
-    fn painted(map: &Pixmap, x: u32, y: u32) -> bool {
-        map.pixel(x, y).is_some_and(|p| p.alpha() > 0)
-    }
-
     fn rows() -> Vec<HelpRow<'static>> {
         vec![
             HelpRow {
@@ -410,53 +431,22 @@ mod panel_tests {
     }
 
     #[test]
-    fn the_panel_stays_inside_its_own_box() {
-        let mut map = Pixmap::new(240, 120).unwrap();
-        help(
-            &mut map,
-            &Probe,
-            &rows(),
-            "##",
-            (240, 120),
-            (white(), grey()),
+    fn the_panel_sits_on_whole_cells_and_inside_the_screen() {
+        let (x, y, wide, tall) = help_area(&Probe, &rows(), "##", (240, 120)).unwrap();
+        assert_eq!((x % 8, y % 4), (0, 0), "not on a cell boundary");
+        assert!(
+            x + wide <= 240 && y + tall <= 120,
+            "it hangs off the screen"
         );
-
-        // Something was drawn, and nothing outside the panel the layout chose.
-        let panel = crate::ui::help::Help {
-            rows: &rows(),
-            title: "##",
-        }
-        .panel(ratatui::layout::Rect {
-            x: 0,
-            y: 0,
-            width: 240 / 8,
-            height: 120 / 4,
-        });
-        let (x0, y0) = (u32::from(panel.x) * 8, u32::from(panel.y) * 4);
-        let (x1, y1) = (
-            x0 + u32::from(panel.width) * 8,
-            y0 + u32::from(panel.height) * 4,
-        );
-
-        assert!(painted(&map, x0, y0), "the panel background is not there");
-        if x0 > 0 {
-            assert!(!painted(&map, x0 - 1, y0), "it painted left of itself");
-        }
-        if y0 > 0 {
-            assert!(!painted(&map, x0, y0 - 1), "it painted above itself");
-        }
-        assert!(!painted(&map, x1, y0), "it painted right of itself");
-        assert!(!painted(&map, x0, y1), "it painted below itself");
+        assert!(wide > 0 && tall > 0);
     }
 
     #[test]
-    fn a_window_too_small_draws_nothing_rather_than_a_ruin() {
+    fn a_window_too_small_has_nowhere_to_put_one() {
         // Fewer pixels than one cell. The terminal panel shrinks to fit; here
         // there is nothing to shrink into, and half a border is worse than no
         // panel.
-        let mut map = Pixmap::new(4, 2).unwrap();
-        help(&mut map, &Probe, &rows(), "##", (4, 2), (white(), grey()));
-        assert!(!painted(&map, 0, 0), "it drew into a window with no room");
+        assert_eq!(help_area(&Probe, &rows(), "##", (4, 2)), None);
     }
 
     #[test]
@@ -471,16 +461,23 @@ mod panel_tests {
             }
         }
         // A zero cell would divide by zero working out how many fit.
-        let mut map = Pixmap::new(64, 64).unwrap();
-        help(
-            &mut map,
-            &Nothing,
-            &rows(),
-            "x",
-            (64, 64),
-            (white(), grey()),
-        );
-        assert!(!painted(&map, 0, 0));
+        assert_eq!(help_area(&Nothing, &rows(), "x", (64, 64)), None);
+    }
+
+    #[test]
+    fn the_panel_fills_the_surface_it_is_given() {
+        // Every pixel of it, so the composite below has a solid rectangle to
+        // put down rather than a background showing through the gaps.
+        let (_, _, wide, tall) = help_area(&Probe, &rows(), "##", (240, 120)).unwrap();
+        let mut map = Pixmap::new(wide, tall).unwrap();
+        help(&mut map, &Probe, &rows(), "##", (white(), grey()));
+
+        for (x, y) in [(0, 0), (wide - 1, 0), (0, tall - 1), (wide - 1, tall - 1)] {
+            assert!(
+                map.pixel(x, y).is_some_and(|p| p.alpha() == 0xff),
+                "corner {x},{y} is not opaque"
+            );
+        }
     }
 }
 
@@ -561,5 +558,46 @@ mod shipped_font {
         {
             assert!(Font8x8.rows(ch, &mut glyph), "no glyph for {ch:?}");
         }
+    }
+}
+
+#[cfg(test)]
+mod wide_cells {
+    use super::*;
+
+    /// Ten pixels wide, which is wider than a row byte can describe.
+    struct Wide;
+    impl Bitmap for Wide {
+        fn cell(&self) -> (u32, u32) {
+            (10, 1)
+        }
+        fn rows(&self, _: char, into: &mut [u8]) -> bool {
+            into.fill(0xff);
+            true
+        }
+    }
+
+    #[test]
+    fn a_cell_wider_than_a_row_byte_still_advances_by_the_cell() {
+        // The eight columns a byte holds are drawn and the rest are not - which
+        // is stated on `Bitmap::rows`. What must not happen is the *advance*
+        // shrinking with them, which would overlap every glyph with the last.
+        let mut map = Pixmap::new(20, 1).unwrap();
+        let white = Colour {
+            red: 0xff,
+            green: 0xff,
+            blue: 0xff,
+            alpha: 0xff,
+        };
+        let end = draw(&mut map, &Wide, "xx", (0, 0), white);
+
+        assert_eq!(
+            end, 20,
+            "the advance followed the clamp instead of the cell"
+        );
+        let lit = |x: u32| map.pixel(x, 0).is_some_and(|p| p.alpha() > 0);
+        assert!(lit(7), "the eighth column of the first glyph");
+        assert!(!lit(8), "a ninth column a row byte cannot describe");
+        assert!(lit(10), "the second glyph started a whole cell along");
     }
 }

--- a/src/surface/text.rs
+++ b/src/surface/text.rs
@@ -21,10 +21,15 @@ pub trait Bitmap {
     /// Cell size in pixels, the same for every glyph.
     fn cell(&self) -> (u32, u32);
 
-    /// One row per pixel of height. `None` for a character the font does not
-    /// carry, which is drawn as nothing rather than as a substitute - a box
-    /// glyph in the middle of a help panel reads as data corruption.
-    fn rows(&self, ch: char) -> Option<&[u8]>;
+    /// Write one row per pixel of height into `into`, and say whether the
+    /// font carries that character. A character it does not carry is drawn as
+    /// nothing rather than as a substitute - a box glyph in the middle of a
+    /// help panel reads as data corruption.
+    ///
+    /// A buffer rather than a borrow because the crates differ: `font8x8`
+    /// returns an owned `[u8; 8]` with nothing to borrow from, and a PSF-2
+    /// loader has a blob it would rather copy out of than hand out.
+    fn rows(&self, ch: char, into: &mut [u8]) -> bool;
 
     /// Which end of a row byte holds the leftmost pixel.
     ///
@@ -77,10 +82,16 @@ pub fn draw(
     paint.anti_alias = false;
 
     let leftmost = font.leftmost();
+    // On the stack, and big enough for any bitmap font worth using - 8 and 16
+    // are the usual heights. A taller one is cut to what fits rather than
+    // allocating per glyph on a path that runs every frame.
+    let mut glyph = [0u8; 32];
+    let height = (down as usize).min(glyph.len());
     let mut at = x;
     for ch in text.chars() {
-        if let Some(rows) = font.rows(ch) {
-            for (row, bits) in rows.iter().take(down as usize).enumerate() {
+        glyph[..height].fill(0);
+        if font.rows(ch, &mut glyph[..height]) {
+            for (row, bits) in glyph[..height].iter().enumerate() {
                 // A run at a time rather than a pixel at a time: a filled span
                 // is one rectangle, and a help panel is mostly horizontal
                 // strokes. `bits` is 8 wide, so this is at most four rects a
@@ -128,12 +139,15 @@ mod tests {
         fn cell(&self) -> (u32, u32) {
             (8, 4)
         }
-        fn rows(&self, ch: char) -> Option<&[u8]> {
-            match ch {
-                '#' => Some(&[0xff, 0xff, 0xff, 0xff]),
-                '|' => Some(&[0x80, 0x80, 0x80, 0x80]),
-                _ => None,
-            }
+        fn rows(&self, ch: char, into: &mut [u8]) -> bool {
+            let glyph: &[u8] = match ch {
+                '#' => &[0xff, 0xff, 0xff, 0xff],
+                '|' => &[0x80, 0x80, 0x80, 0x80],
+                _ => return false,
+            };
+            let n = into.len().min(glyph.len());
+            into[..n].copy_from_slice(&glyph[..n]);
+            true
         }
     }
 
@@ -215,8 +229,11 @@ mod tests {
             fn cell(&self) -> (u32, u32) {
                 (8, 1)
             }
-            fn rows(&self, _: char) -> Option<&[u8]> {
-                Some(&[0x01])
+            fn rows(&self, _: char, into: &mut [u8]) -> bool {
+                if let Some(first) = into.first_mut() {
+                    *first = 0x01;
+                }
+                true
             }
             fn leftmost(&self) -> Leftmost {
                 self.0
@@ -247,8 +264,9 @@ mod tests {
             fn cell(&self) -> (u32, u32) {
                 (8, 2)
             }
-            fn rows(&self, _: char) -> Option<&[u8]> {
-                Some(&[0xff, 0xff, 0xff, 0xff])
+            fn rows(&self, _: char, into: &mut [u8]) -> bool {
+                into.fill(0xff);
+                true
             }
         }
         let mut map = Pixmap::new(8, 8).unwrap();
@@ -342,12 +360,15 @@ mod panel_tests {
         fn cell(&self) -> (u32, u32) {
             (8, 4)
         }
-        fn rows(&self, ch: char) -> Option<&[u8]> {
-            match ch {
-                '#' => Some(&[0xff, 0xff, 0xff, 0xff]),
-                '|' => Some(&[0x80, 0x80, 0x80, 0x80]),
-                _ => None,
-            }
+        fn rows(&self, ch: char, into: &mut [u8]) -> bool {
+            let glyph: &[u8] = match ch {
+                '#' => &[0xff, 0xff, 0xff, 0xff],
+                '|' => &[0x80, 0x80, 0x80, 0x80],
+                _ => return false,
+            };
+            let n = into.len().min(glyph.len());
+            into[..n].copy_from_slice(&glyph[..n]);
+            true
         }
     }
 
@@ -445,8 +466,8 @@ mod panel_tests {
             fn cell(&self) -> (u32, u32) {
                 (0, 0)
             }
-            fn rows(&self, _: char) -> Option<&[u8]> {
-                None
+            fn rows(&self, _: char, _: &mut [u8]) -> bool {
+                false
             }
         }
         // A zero cell would divide by zero working out how many fit.
@@ -460,5 +481,85 @@ mod panel_tests {
             (white(), grey()),
         );
         assert!(!painted(&map, 0, 0));
+    }
+}
+
+/// The bitmap font rav ships with, behind the `font8x8` feature.
+///
+/// Public domain, `no_std`, and 8x8 - small for a fourteen-row panel but it
+/// carries no licence obligations into a project that has its own. Swapping it
+/// is one impl: nothing above this line knows which font it is drawing.
+#[cfg(feature = "gui")]
+pub struct Font8x8;
+
+#[cfg(feature = "gui")]
+impl Bitmap for Font8x8 {
+    fn cell(&self) -> (u32, u32) {
+        (8, 8)
+    }
+
+    fn rows(&self, ch: char, into: &mut [u8]) -> bool {
+        use font8x8::UnicodeFonts;
+        // BASIC covers ASCII, which is all the panel writes. The other tables
+        // are Greek, hiragana and box-drawing, and carrying them would be
+        // kilobytes of glyphs nothing asks for.
+        match font8x8::BASIC_FONTS.get(ch) {
+            Some(glyph) => {
+                let n = into.len().min(glyph.len());
+                into[..n].copy_from_slice(&glyph[..n]);
+                true
+            }
+            None => false,
+        }
+    }
+
+    /// font8x8 keeps the leftmost pixel in bit 0. Established by printing an
+    /// asymmetric glyph both ways - the crate does not say, and `A` reads
+    /// correctly whichever way it is read.
+    fn leftmost(&self) -> Leftmost {
+        Leftmost::LowBit
+    }
+}
+
+#[cfg(all(test, feature = "gui"))]
+mod shipped_font {
+    use super::*;
+
+    fn lit(map: &Pixmap, x: u32, y: u32) -> bool {
+        map.pixel(x, y).is_some_and(|p| p.alpha() > 0)
+    }
+
+    #[test]
+    fn an_l_has_its_stroke_on_the_left() {
+        // The whole point of asking the font which end its bits are at. `L` is
+        // the cheapest letter that can tell: a stem down the left and a foot
+        // along the bottom. Mirrored, the stem is on the right and every
+        // symmetric letter still looks perfect.
+        let mut map = Pixmap::new(8, 8).unwrap();
+        let white = Colour {
+            red: 0xff,
+            green: 0xff,
+            blue: 0xff,
+            alpha: 0xff,
+        };
+        draw(&mut map, &Font8x8, "L", (0, 0), white);
+
+        let left: u32 = (0..8).filter(|&y| lit(&map, 1, y)).count() as u32;
+        let right: u32 = (0..8).filter(|&y| lit(&map, 6, y)).count() as u32;
+        assert!(
+            left > right,
+            "the stem is on the right, so the font is mirrored: left {left}, right {right}"
+        );
+    }
+
+    #[test]
+    fn every_character_the_panel_writes_is_carried() {
+        // The panel's own vocabulary. A missing glyph draws a gap, which reads
+        // as a rendering fault rather than as a font that stops at ASCII.
+        let mut glyph = [0u8; 8];
+        for ch in " abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-+/:.,()".chars()
+        {
+            assert!(Font8x8.rows(ch, &mut glyph), "no glyph for {ch:?}");
+        }
     }
 }

--- a/src/surface/text.rs
+++ b/src/surface/text.rs
@@ -21,11 +21,39 @@ pub trait Bitmap {
     /// Cell size in pixels, the same for every glyph.
     fn cell(&self) -> (u32, u32);
 
-    /// One row per pixel of height, most significant bit leftmost. `None` for a
-    /// character the font does not carry, which is drawn as nothing rather than
-    /// as a substitute - a box glyph in the middle of a help panel reads as
-    /// data corruption.
+    /// One row per pixel of height. `None` for a character the font does not
+    /// carry, which is drawn as nothing rather than as a substitute - a box
+    /// glyph in the middle of a help panel reads as data corruption.
     fn rows(&self, ch: char) -> Option<&[u8]>;
+
+    /// Which end of a row byte holds the leftmost pixel.
+    ///
+    /// Fonts disagree and neither is wrong: `font8x8` puts it in bit 0.
+    /// Getting it backwards mirrors every glyph, and a symmetric one hides
+    /// that completely - `A` reads correctly either way and `L` does not,
+    /// which is why this is asked rather than assumed.
+    fn leftmost(&self) -> Leftmost {
+        Leftmost::HighBit
+    }
+}
+
+/// Where a row byte keeps its leftmost pixel.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Leftmost {
+    /// Bit 7 first, reading the byte as it is written.
+    HighBit,
+    /// Bit 0 first, which is what `font8x8` does.
+    LowBit,
+}
+
+impl Leftmost {
+    /// The mask for a column, counted from the left.
+    fn mask(self, column: u32) -> u8 {
+        match self {
+            Leftmost::HighBit => 0x80 >> column,
+            Leftmost::LowBit => 1 << column,
+        }
+    }
 }
 
 /// Draw one line of text with its top-left corner at `x`, `y`.
@@ -48,6 +76,7 @@ pub fn draw(
     paint.set_color_rgba8(colour.red, colour.green, colour.blue, colour.alpha);
     paint.anti_alias = false;
 
+    let leftmost = font.leftmost();
     let mut at = x;
     for ch in text.chars() {
         if let Some(rows) = font.rows(ch) {
@@ -58,12 +87,12 @@ pub fn draw(
                 // row instead of eight.
                 let mut col = 0u32;
                 while col < across.min(8) {
-                    if bits & (0x80 >> col) == 0 {
+                    if bits & leftmost.mask(col) == 0 {
                         col += 1;
                         continue;
                     }
                     let start = col;
-                    while col < across.min(8) && bits & (0x80 >> col) != 0 {
+                    while col < across.min(8) && bits & leftmost.mask(col) != 0 {
                         col += 1;
                     }
                     if let Some(run) = Rect::from_xywh(
@@ -174,6 +203,39 @@ mod tests {
         let mut map = Pixmap::new(64, 8).unwrap();
         let end = draw(&mut map, &Probe, "###", (0, 0), white());
         assert_eq!(end, width(&Probe, "###"));
+    }
+
+    #[test]
+    fn the_bit_order_is_asked_for_and_not_assumed() {
+        // The trap this exists for: `A` reads correctly whichever end the
+        // leftmost pixel is at, so a mirrored font ships looking fine until
+        // somebody types an `L`. One glyph, one edge lit, read both ways.
+        struct OneEdge(Leftmost);
+        impl Bitmap for OneEdge {
+            fn cell(&self) -> (u32, u32) {
+                (8, 1)
+            }
+            fn rows(&self, _: char) -> Option<&[u8]> {
+                Some(&[0x01])
+            }
+            fn leftmost(&self) -> Leftmost {
+                self.0
+            }
+        }
+
+        let mut high = Pixmap::new(8, 1).unwrap();
+        draw(&mut high, &OneEdge(Leftmost::HighBit), "x", (0, 0), white());
+        assert!(
+            lit(&high, 7, 0) && !lit(&high, 0, 0),
+            "bit 0 is the right edge"
+        );
+
+        let mut low = Pixmap::new(8, 1).unwrap();
+        draw(&mut low, &OneEdge(Leftmost::LowBit), "x", (0, 0), white());
+        assert!(
+            lit(&low, 0, 0) && !lit(&low, 7, 0),
+            "bit 0 is the left edge"
+        );
     }
 
     #[test]

--- a/src/surface/text.rs
+++ b/src/surface/text.rs
@@ -195,3 +195,208 @@ mod tests {
         assert!(!lit(&map, 0, 2), "past the declared height");
     }
 }
+
+/// Draw the help panel into a frame.
+///
+/// The layout is the terminal's - [`Help::panel`] decides where it sits and how
+/// big it is, in cells, and this multiplies by the font's cell to reach pixels.
+/// Two implementations of "how wide is the key column" would be a window whose
+/// panel disagrees with a terminal's about which rows fit.
+///
+/// `screen` is in pixels; the cell comes from the font.
+pub fn help(
+    onto: &mut Pixmap,
+    font: &dyn Bitmap,
+    rows: &[crate::ui::help::HelpRow<'_>],
+    title: &str,
+    (screen_across, screen_down): (u32, u32),
+    (ink, background): (Colour, Colour),
+) {
+    let (across, down) = font.cell();
+    if across == 0 || down == 0 {
+        return;
+    }
+    let panel = crate::ui::help::Help { rows, title };
+    // The terminal's own sizing, asked in cells: how many of them fit across
+    // and down this window at the font's size.
+    let area = ratatui::layout::Rect {
+        x: 0,
+        y: 0,
+        width: (screen_across / across) as u16,
+        height: (screen_down / down) as u16,
+    };
+    let at = panel.panel(area);
+    if at.width == 0 || at.height == 0 {
+        return;
+    }
+
+    let mut paint = Paint::default();
+    paint.set_color_rgba8(
+        background.red,
+        background.green,
+        background.blue,
+        background.alpha,
+    );
+    paint.anti_alias = false;
+    if let Some(behind) = Rect::from_xywh(
+        (u32::from(at.x) * across) as f32,
+        (u32::from(at.y) * down) as f32,
+        (u32::from(at.width) * across) as f32,
+        (u32::from(at.height) * down) as f32,
+    ) {
+        onto.fill_rect(behind, &paint, Transform::identity(), None);
+    }
+
+    let left = u32::from(at.x) * across;
+    let top = u32::from(at.y) * down;
+    draw(onto, font, title, (left + across * 2, top + down), ink);
+
+    // Two cells in from the border and one line below the title, which is what
+    // the terminal panel does - the two are meant to be the same panel.
+    let key_width = panel.key_width() as u32;
+    for (line, row) in rows.iter().enumerate() {
+        let y = top + down * (line as u32 + 3);
+        if y + down > top + u32::from(at.height) * down {
+            break;
+        }
+        draw(onto, font, row.key, (left + across * 2, y), ink);
+        let description = left + across * (2 + key_width + 2);
+        let after = draw(onto, font, row.description, (description, y), ink);
+        if let Some(value) = &row.value {
+            draw(onto, font, value, (after + across, y), ink);
+        }
+    }
+}
+
+#[cfg(test)]
+mod panel_tests {
+    use super::*;
+    use crate::ui::help::HelpRow;
+
+    /// The same two-glyph font the tests above use, declared again rather than
+    /// reached for across module walls.
+    struct Probe;
+    impl Bitmap for Probe {
+        fn cell(&self) -> (u32, u32) {
+            (8, 4)
+        }
+        fn rows(&self, ch: char) -> Option<&[u8]> {
+            match ch {
+                '#' => Some(&[0xff, 0xff, 0xff, 0xff]),
+                '|' => Some(&[0x80, 0x80, 0x80, 0x80]),
+                _ => None,
+            }
+        }
+    }
+
+    fn white() -> Colour {
+        Colour {
+            red: 0xff,
+            green: 0xff,
+            blue: 0xff,
+            alpha: 0xff,
+        }
+    }
+
+    fn grey() -> Colour {
+        Colour {
+            red: 0x20,
+            green: 0x20,
+            blue: 0x20,
+            alpha: 0xff,
+        }
+    }
+
+    fn painted(map: &Pixmap, x: u32, y: u32) -> bool {
+        map.pixel(x, y).is_some_and(|p| p.alpha() > 0)
+    }
+
+    fn rows() -> Vec<HelpRow<'static>> {
+        vec![
+            HelpRow {
+                key: "#",
+                description: "##",
+                value: Some("#".to_string()),
+            },
+            HelpRow {
+                key: "|",
+                description: "##",
+                value: None,
+            },
+        ]
+    }
+
+    #[test]
+    fn the_panel_stays_inside_its_own_box() {
+        let mut map = Pixmap::new(240, 120).unwrap();
+        help(
+            &mut map,
+            &Probe,
+            &rows(),
+            "##",
+            (240, 120),
+            (white(), grey()),
+        );
+
+        // Something was drawn, and nothing outside the panel the layout chose.
+        let panel = crate::ui::help::Help {
+            rows: &rows(),
+            title: "##",
+        }
+        .panel(ratatui::layout::Rect {
+            x: 0,
+            y: 0,
+            width: 240 / 8,
+            height: 120 / 4,
+        });
+        let (x0, y0) = (u32::from(panel.x) * 8, u32::from(panel.y) * 4);
+        let (x1, y1) = (
+            x0 + u32::from(panel.width) * 8,
+            y0 + u32::from(panel.height) * 4,
+        );
+
+        assert!(painted(&map, x0, y0), "the panel background is not there");
+        if x0 > 0 {
+            assert!(!painted(&map, x0 - 1, y0), "it painted left of itself");
+        }
+        if y0 > 0 {
+            assert!(!painted(&map, x0, y0 - 1), "it painted above itself");
+        }
+        assert!(!painted(&map, x1, y0), "it painted right of itself");
+        assert!(!painted(&map, x0, y1), "it painted below itself");
+    }
+
+    #[test]
+    fn a_window_too_small_draws_nothing_rather_than_a_ruin() {
+        // Fewer pixels than one cell. The terminal panel shrinks to fit; here
+        // there is nothing to shrink into, and half a border is worse than no
+        // panel.
+        let mut map = Pixmap::new(4, 2).unwrap();
+        help(&mut map, &Probe, &rows(), "##", (4, 2), (white(), grey()));
+        assert!(!painted(&map, 0, 0), "it drew into a window with no room");
+    }
+
+    #[test]
+    fn a_font_with_no_size_is_declined() {
+        struct Nothing;
+        impl Bitmap for Nothing {
+            fn cell(&self) -> (u32, u32) {
+                (0, 0)
+            }
+            fn rows(&self, _: char) -> Option<&[u8]> {
+                None
+            }
+        }
+        // A zero cell would divide by zero working out how many fit.
+        let mut map = Pixmap::new(64, 64).unwrap();
+        help(
+            &mut map,
+            &Nothing,
+            &rows(),
+            "x",
+            (64, 64),
+            (white(), grey()),
+        );
+        assert!(!painted(&map, 0, 0));
+    }
+}

--- a/src/surface/text.rs
+++ b/src/surface/text.rs
@@ -1,0 +1,197 @@
+//! Drawing text into a frame, for the surfaces that have no terminal to do it.
+//!
+//! A window has no ratatui and no font stack - `usvg` is built without one on
+//! purpose - so the help panel and anything else with words in it are drawn a
+//! glyph at a time out of a bitmap.
+//!
+//! The font is not here. This knows how to place glyphs and nothing about what
+//! they look like: a [`Bitmap`] is whatever supplies rows of bits, and which
+//! crate does that is a separate decision from any of the geometry below.
+
+use tiny_skia::{Paint, Pixmap, Rect, Transform};
+
+use rav_appearance::ink::Colour;
+
+/// A monospaced bitmap font: fixed cell, one bit per pixel, rows top-first.
+///
+/// Deliberately a trait over "give me the rows for this character" rather than
+/// a concrete array. Every candidate crate stores its glyphs differently - a
+/// flat table, PSF-2 blobs, per-size modules - and all of them can answer this.
+pub trait Bitmap {
+    /// Cell size in pixels, the same for every glyph.
+    fn cell(&self) -> (u32, u32);
+
+    /// One row per pixel of height, most significant bit leftmost. `None` for a
+    /// character the font does not carry, which is drawn as nothing rather than
+    /// as a substitute - a box glyph in the middle of a help panel reads as
+    /// data corruption.
+    fn rows(&self, ch: char) -> Option<&[u8]>;
+}
+
+/// Draw one line of text with its top-left corner at `x`, `y`.
+///
+/// Returns where the next character would start, so a caller can put two
+/// colours on one line without measuring anything twice.
+///
+/// Whole pixels throughout. A bitmap glyph placed on a fractional boundary is
+/// resampled into a blur, which is the one thing a bitmap font is chosen to
+/// avoid - and #63 in this repository is what rounding did the last time.
+pub fn draw(
+    onto: &mut Pixmap,
+    font: &dyn Bitmap,
+    text: &str,
+    (x, y): (u32, u32),
+    colour: Colour,
+) -> u32 {
+    let (across, down) = font.cell();
+    let mut paint = Paint::default();
+    paint.set_color_rgba8(colour.red, colour.green, colour.blue, colour.alpha);
+    paint.anti_alias = false;
+
+    let mut at = x;
+    for ch in text.chars() {
+        if let Some(rows) = font.rows(ch) {
+            for (row, bits) in rows.iter().take(down as usize).enumerate() {
+                // A run at a time rather than a pixel at a time: a filled span
+                // is one rectangle, and a help panel is mostly horizontal
+                // strokes. `bits` is 8 wide, so this is at most four rects a
+                // row instead of eight.
+                let mut col = 0u32;
+                while col < across.min(8) {
+                    if bits & (0x80 >> col) == 0 {
+                        col += 1;
+                        continue;
+                    }
+                    let start = col;
+                    while col < across.min(8) && bits & (0x80 >> col) != 0 {
+                        col += 1;
+                    }
+                    if let Some(run) = Rect::from_xywh(
+                        (at + start) as f32,
+                        (y + row as u32) as f32,
+                        (col - start) as f32,
+                        1.0,
+                    ) {
+                        onto.fill_rect(run, &paint, Transform::identity(), None);
+                    }
+                }
+            }
+        }
+        at += across;
+    }
+    at
+}
+
+/// How wide that text is, in pixels.
+pub fn width(font: &dyn Bitmap, text: &str) -> u32 {
+    font.cell().0 * text.chars().count() as u32
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A font of two glyphs, so the geometry can be checked without deciding
+    /// which real one rav ships. `#` is solid, `|` is a single left column.
+    struct Probe;
+
+    impl Bitmap for Probe {
+        fn cell(&self) -> (u32, u32) {
+            (8, 4)
+        }
+        fn rows(&self, ch: char) -> Option<&[u8]> {
+            match ch {
+                '#' => Some(&[0xff, 0xff, 0xff, 0xff]),
+                '|' => Some(&[0x80, 0x80, 0x80, 0x80]),
+                _ => None,
+            }
+        }
+    }
+
+    fn lit(map: &Pixmap, x: u32, y: u32) -> bool {
+        map.pixel(x, y).is_some_and(|p| p.alpha() > 0)
+    }
+
+    fn white() -> Colour {
+        Colour {
+            red: 0xff,
+            green: 0xff,
+            blue: 0xff,
+            alpha: 0xff,
+        }
+    }
+
+    #[test]
+    fn a_glyph_lands_in_its_own_cell_and_nowhere_else() {
+        let mut map = Pixmap::new(24, 8).unwrap();
+        draw(&mut map, &Probe, "#", (0, 0), white());
+
+        assert!(lit(&map, 0, 0) && lit(&map, 7, 3), "the cell is not filled");
+        assert!(!lit(&map, 8, 0), "it bled into the next cell across");
+        assert!(!lit(&map, 0, 4), "it bled into the row below");
+    }
+
+    #[test]
+    fn the_second_character_starts_one_cell_along() {
+        let mut map = Pixmap::new(24, 8).unwrap();
+        let end = draw(&mut map, &Probe, "||", (0, 0), white());
+
+        assert!(lit(&map, 0, 0), "the first stroke");
+        assert!(lit(&map, 8, 0), "the second, one cell along");
+        assert!(
+            !lit(&map, 1, 0),
+            "a single-column glyph filled more than one"
+        );
+        assert_eq!(end, 16, "the caller is told where to carry on");
+    }
+
+    #[test]
+    fn an_unknown_character_draws_nothing_and_still_takes_its_place() {
+        // Nothing rather than a substitute: a box glyph in the middle of a help
+        // panel reads as corruption, where a gap reads as a gap.
+        let mut map = Pixmap::new(24, 8).unwrap();
+        let end = draw(&mut map, &Probe, "?#", (0, 0), white());
+
+        assert!(!lit(&map, 0, 0), "the unknown one drew something");
+        assert!(lit(&map, 8, 0), "the known one moved out of its way");
+        assert_eq!(end, 16);
+    }
+
+    #[test]
+    fn an_offset_is_whole_pixels_and_exact() {
+        let mut map = Pixmap::new(24, 8).unwrap();
+        draw(&mut map, &Probe, "#", (3, 2), white());
+
+        assert!(lit(&map, 3, 2) && lit(&map, 10, 5), "the corners");
+        assert!(!lit(&map, 2, 2), "one column left of where it was put");
+        assert!(!lit(&map, 3, 1), "one row above");
+    }
+
+    #[test]
+    fn width_is_what_draw_uses() {
+        // The two agree, or a panel measured with one and drawn with the other
+        // is a border that does not fit its contents.
+        let mut map = Pixmap::new(64, 8).unwrap();
+        let end = draw(&mut map, &Probe, "###", (0, 0), white());
+        assert_eq!(end, width(&Probe, "###"));
+    }
+
+    #[test]
+    fn a_glyph_taller_than_the_cell_is_cut_to_it() {
+        // A font whose rows outnumber its declared height would otherwise draw
+        // over the line below, which is invisible until two lines are adjacent.
+        struct TooTall;
+        impl Bitmap for TooTall {
+            fn cell(&self) -> (u32, u32) {
+                (8, 2)
+            }
+            fn rows(&self, _: char) -> Option<&[u8]> {
+                Some(&[0xff, 0xff, 0xff, 0xff])
+            }
+        }
+        let mut map = Pixmap::new(8, 8).unwrap();
+        draw(&mut map, &TooTall, "x", (0, 0), white());
+        assert!(lit(&map, 0, 1), "inside the cell");
+        assert!(!lit(&map, 0, 2), "past the declared height");
+    }
+}

--- a/src/surface/window.rs
+++ b/src/surface/window.rs
@@ -34,6 +34,8 @@ use winit::event_loop::{ActiveEventLoop, ControlFlow, EventLoop};
 use winit::keyboard::{Key, NamedKey};
 use winit::window::{Window, WindowId};
 
+use tiny_skia::Pixmap;
+
 use crate::audio::AudioData;
 use crate::ui::App;
 
@@ -139,6 +141,13 @@ struct Showing {
     /// Kept between frames for the same reason the canvas is: a screenful of
     /// `u32` per frame is an allocation the frame budget has no room for.
     packed: Vec<u32>,
+    /// Where the help panel is drawn before it is composited over the frame.
+    ///
+    /// Its own surface because `frame_pixels` hands back bytes rather than a
+    /// `Pixmap`, and kept between frames for the reason the canvas is: this
+    /// is a screenful, and a screenful allocated per frame is the trap the
+    /// rest of this loop avoids. Rebuilt only when the window resizes.
+    overlay: Option<Pixmap>,
     /// What the title already says, so a frame that changed nothing does not
     /// ask the window server to set it again.
     titled: String,
@@ -183,18 +192,7 @@ impl ApplicationHandler for Showing {
             WindowEvent::CloseRequested => events.exit(),
             WindowEvent::KeyboardInput { event, .. } if event.state == ElementState::Pressed => {
                 if let Some(code) = pressed(&event.logical_key) {
-                    let action = crate::ui::map_key(code);
-                    self.app.apply(action);
-                    // The panel is fourteen rows of text and a window has no
-                    // font for them yet, so `h` toggles something nothing
-                    // draws. Said out loud through the same note a setting
-                    // uses, which reaches the title bar - a key that silently
-                    // does nothing is the defect this whole surface keeps
-                    // being careful about.
-                    if action == crate::ui::Action::ToggleHelp {
-                        self.app
-                            .note("help is a terminal thing for now".to_string());
-                    }
+                    self.app.apply(crate::ui::map_key(code));
                     if self.app.wants_to_quit() {
                         events.exit();
                     }
@@ -305,10 +303,12 @@ impl Showing {
     }
 
     fn draw(&mut self) -> Result<()> {
-        let (Some(window), Some(surface)) = (&self.window, &mut self.surface) else {
+        // The size and the title first, and the window borrow released before
+        // anything else: the frame and the panel below both want `&mut self`,
+        // and the surface is only needed for the blit at the end.
+        let Some(size) = self.window.as_ref().map(|w| w.inner_size()) else {
             return Ok(());
         };
-        let size = window.inner_size();
         let (Some(width), Some(height)) =
             (NonZeroU32::new(size.width), NonZeroU32::new(size.height))
         else {
@@ -326,7 +326,9 @@ impl Showing {
         // server, and this runs on every frame.
         let saying = titled(self.app.status_line().as_deref());
         if saying != self.titled {
-            window.set_title(&saying);
+            if let Some(window) = &self.window {
+                window.set_title(&saying);
+            }
             self.titled = saying;
         }
 
@@ -335,6 +337,16 @@ impl Showing {
         };
         onto_black(&pixels, &mut self.packed);
 
+        // Over the frame rather than into it: the panel is opaque and the bars
+        // behind it are not meant to show through, which is what makes it
+        // readable over a moving picture.
+        if self.app.showing_help() {
+            self.draw_help(size.width, size.height);
+        }
+
+        let Some(surface) = &mut self.surface else {
+            return Ok(());
+        };
         surface
             .resize(width, height)
             .map_err(|why| anyhow::anyhow!("the window would not take that size: {why}"))?;
@@ -357,6 +369,34 @@ impl Showing {
         }
         Ok(())
     }
+    ///
+    /// Into a `Pixmap` of its own and then composited, because `frame_pixels`
+    /// hands back bytes and the text drawing works on a surface. Only the
+    /// pixels the panel actually covered are copied, so the frame shows
+    /// everywhere it does not.
+    fn draw_help(&mut self, across: u32, down: u32) {
+        use crate::surface::text;
+
+        let fits = self
+            .overlay
+            .as_ref()
+            .is_some_and(|had| had.width() == across && had.height() == down);
+        if !fits {
+            self.overlay = Pixmap::new(across, down);
+        }
+        let Some(overlay) = &mut self.overlay else {
+            return;
+        };
+        // Transparent, so the composite below can tell what the panel covered
+        // from what it did not.
+        overlay.fill(tiny_skia::Color::TRANSPARENT);
+
+        let rows = self.app.help_rows();
+        let theme = self.app.overlay_colours();
+        text::help(overlay, &text::Font8x8, &rows, "rav", (across, down), theme);
+
+        over(&mut self.packed, overlay);
+    }
 }
 
 /// Show rav in a window until it is closed.
@@ -373,6 +413,7 @@ pub fn show(app: App, audio: Receiver<AudioData>) -> Result<()> {
         surface: None,
         packed: Vec::new(),
         titled: String::new(),
+        overlay: None,
         min_frame,
         next_frame: Instant::now(),
         drawn: 0,
@@ -386,6 +427,25 @@ pub fn show(app: App, audio: Receiver<AudioData>) -> Result<()> {
     match showing.failed {
         Some(why) => Err(why),
         None => Ok(()),
+    }
+}
+
+/// Composite an overlay over a packed frame, in place.
+///
+/// Only where the overlay has any alpha at all: everywhere else the frame
+/// shows, which is what makes this a panel over a picture rather than a new
+/// picture. Anything partly transparent is taken at full strength rather than
+/// blended - the panel is drawn opaque on purpose, and a half-transparent
+/// help row over moving bars is unreadable.
+fn over(packed: &mut [u32], overlay: &Pixmap) {
+    for (under, pixel) in packed.iter_mut().zip(overlay.pixels()) {
+        if pixel.alpha() == 0 {
+            continue;
+        }
+        let straight = pixel.demultiply();
+        *under = (u32::from(straight.red()) << 16)
+            | (u32::from(straight.green()) << 8)
+            | u32::from(straight.blue());
     }
 }
 
@@ -490,17 +550,40 @@ mod tests {
     }
 
     #[test]
-    fn h_is_a_key_that_says_why_nothing_happened() {
-        // The one key a window cannot honour yet. It is `ToggleHelp` that has
-        // to be recognised here, so this asserts through `map_key` rather than
-        // against the character - rebinding help would otherwise leave the
-        // note attached to whatever `h` became.
+    fn h_and_f1_both_reach_the_panel() {
+        // Through `map_key` rather than against the character, so rebinding
+        // help cannot leave the window opening something else.
         assert_eq!(typed("h"), Some(crate::ui::Action::ToggleHelp));
         assert_eq!(
             pressed(&Key::Named(NamedKey::F1)).map(crate::ui::map_key),
             Some(crate::ui::Action::ToggleHelp),
             "F1 is the same key and gets the same answer",
         );
+    }
+
+    #[test]
+    fn an_overlay_covers_only_where_it_painted() {
+        // The whole of what makes this a panel over a picture: a transparent
+        // pixel leaves the frame alone. Getting it backwards paints a black
+        // rectangle over the bars and looks like the window stopped drawing.
+        let mut frame = vec![0x00ff_0000u32; 4];
+        let mut overlay = Pixmap::new(2, 2).unwrap();
+        overlay.fill(tiny_skia::Color::TRANSPARENT);
+        // One opaque white pixel, top left.
+        let mut paint = tiny_skia::Paint::default();
+        paint.set_color_rgba8(0xff, 0xff, 0xff, 0xff);
+        paint.anti_alias = false;
+        overlay.fill_rect(
+            tiny_skia::Rect::from_xywh(0.0, 0.0, 1.0, 1.0).unwrap(),
+            &paint,
+            tiny_skia::Transform::identity(),
+            None,
+        );
+
+        over(&mut frame, &overlay);
+        assert_eq!(frame[0], 0x00ff_ffff, "the painted pixel did not take");
+        assert_eq!(frame[1], 0x00ff_0000, "an untouched pixel was overwritten");
+        assert_eq!(frame[3], 0x00ff_0000, "an untouched pixel was overwritten");
     }
 
     #[test]

--- a/src/surface/window.rs
+++ b/src/surface/window.rs
@@ -369,33 +369,39 @@ impl Showing {
         }
         Ok(())
     }
+    /// Draw the help panel over the packed frame.
     ///
-    /// Into a `Pixmap` of its own and then composited, because `frame_pixels`
-    /// hands back bytes and the text drawing works on a surface. Only the
-    /// pixels the panel actually covered are copied, so the frame shows
-    /// everywhere it does not.
+    /// Onto a surface of its own and then composited, because `frame_pixels`
+    /// hands back bytes and the text drawing works on a `Pixmap`.
+    ///
+    /// That surface is the size of the **panel**, not the window. A
+    /// window-sized one would mean clearing and then scanning a few million
+    /// pixels every frame the panel is open, to find the few hundred thousand
+    /// it covers.
     fn draw_help(&mut self, across: u32, down: u32) {
         use crate::surface::text;
+
+        let rows = self.app.help_rows();
+        let Some((x, y, wide, tall)) =
+            text::help_area(&text::Font8x8, &rows, "rav", (across, down))
+        else {
+            return;
+        };
 
         let fits = self
             .overlay
             .as_ref()
-            .is_some_and(|had| had.width() == across && had.height() == down);
+            .is_some_and(|had| had.width() == wide && had.height() == tall);
         if !fits {
-            self.overlay = Pixmap::new(across, down);
+            self.overlay = Pixmap::new(wide, tall);
         }
         let Some(overlay) = &mut self.overlay else {
             return;
         };
-        // Transparent, so the composite below can tell what the panel covered
-        // from what it did not.
-        overlay.fill(tiny_skia::Color::TRANSPARENT);
 
-        let rows = self.app.help_rows();
-        let theme = self.app.overlay_colours();
-        text::help(overlay, &text::Font8x8, &rows, "rav", (across, down), theme);
-
-        over(&mut self.packed, overlay);
+        let colours = self.app.overlay_colours();
+        text::help(overlay, &text::Font8x8, &rows, "rav", colours);
+        over(&mut self.packed, across, overlay, (x, y));
     }
 }
 
@@ -430,22 +436,37 @@ pub fn show(app: App, audio: Receiver<AudioData>) -> Result<()> {
     }
 }
 
-/// Composite an overlay over a packed frame, in place.
+/// Composite an overlay onto a packed frame at `(x, y)`, in place.
 ///
-/// Only where the overlay has any alpha at all: everywhere else the frame
-/// shows, which is what makes this a panel over a picture rather than a new
-/// picture. Anything partly transparent is taken at full strength rather than
-/// blended - the panel is drawn opaque on purpose, and a half-transparent
-/// help row over moving bars is unreadable.
-fn over(packed: &mut [u32], overlay: &Pixmap) {
-    for (under, pixel) in packed.iter_mut().zip(overlay.pixels()) {
-        if pixel.alpha() == 0 {
-            continue;
+/// Touches only the rows and columns the overlay occupies - it is the panel,
+/// not a screenful - and within those, only pixels it actually painted. A
+/// transparent pixel leaves the frame showing, which is what makes this a panel
+/// over a picture rather than a second picture.
+///
+/// Anything partly transparent is taken at full strength rather than blended:
+/// the panel is drawn opaque on purpose, because a half-transparent help row
+/// over moving bars is unreadable.
+fn over(packed: &mut [u32], frame_width: u32, overlay: &Pixmap, (x, y): (u32, u32)) {
+    for row in 0..overlay.height() {
+        let start = ((y + row) * frame_width + x) as usize;
+        let Some(line) = packed.get_mut(start..start + overlay.width() as usize) else {
+            // The frame changed size between being packed and being covered.
+            // The next one is drawn at the new size, so this one is skipped
+            // rather than written past its end.
+            return;
+        };
+        for (column, under) in line.iter_mut().enumerate() {
+            let Some(pixel) = overlay.pixel(column as u32, row) else {
+                continue;
+            };
+            if pixel.alpha() == 0 {
+                continue;
+            }
+            let straight = pixel.demultiply();
+            *under = (u32::from(straight.red()) << 16)
+                | (u32::from(straight.green()) << 8)
+                | u32::from(straight.blue());
         }
-        let straight = pixel.demultiply();
-        *under = (u32::from(straight.red()) << 16)
-            | (u32::from(straight.green()) << 8)
-            | u32::from(straight.blue());
     }
 }
 
@@ -566,8 +587,10 @@ mod tests {
         // The whole of what makes this a panel over a picture: a transparent
         // pixel leaves the frame alone. Getting it backwards paints a black
         // rectangle over the bars and looks like the window stopped drawing.
-        let mut frame = vec![0x00ff_0000u32; 4];
-        let mut overlay = Pixmap::new(2, 2).unwrap();
+        // A 4x2 frame with a 2x1 panel dropped at (1, 1): the offset is half
+        // of what this checks, since a panel almost never sits at the origin.
+        let mut frame = vec![0x00ff_0000u32; 8];
+        let mut overlay = Pixmap::new(2, 1).unwrap();
         overlay.fill(tiny_skia::Color::TRANSPARENT);
         // One opaque white pixel, top left.
         let mut paint = tiny_skia::Paint::default();
@@ -580,10 +603,17 @@ mod tests {
             None,
         );
 
-        over(&mut frame, &overlay);
-        assert_eq!(frame[0], 0x00ff_ffff, "the painted pixel did not take");
-        assert_eq!(frame[1], 0x00ff_0000, "an untouched pixel was overwritten");
-        assert_eq!(frame[3], 0x00ff_0000, "an untouched pixel was overwritten");
+        over(&mut frame, 4, &overlay, (1, 1));
+        assert_eq!(
+            frame[5], 0x00ff_ffff,
+            "the painted pixel did not land at the offset"
+        );
+        assert_eq!(
+            frame[6], 0x00ff_0000,
+            "a transparent pixel overwrote the frame"
+        );
+        assert_eq!(frame[0], 0x00ff_0000, "it painted outside its rectangle");
+        assert_eq!(frame[1], 0x00ff_0000, "it painted above itself");
     }
 
     #[test]

--- a/src/ui/help.rs
+++ b/src/ui/help.rs
@@ -28,7 +28,7 @@ pub struct Help<'a> {
 
 impl Help<'_> {
     /// Width of the key column, which every row is indented by.
-    fn key_width(&self) -> usize {
+    pub(crate) fn key_width(&self) -> usize {
         self.rows
             .iter()
             .map(|r| r.key.chars().count())
@@ -42,7 +42,7 @@ impl Help<'_> {
     /// because that is what layout indents by. Measuring per-row leaves any row
     /// with a short key and a long description too narrow, and its value is then
     /// dropped without a trace.
-    fn desired_width(&self) -> u16 {
+    pub(crate) fn desired_width(&self) -> u16 {
         let key = self.key_width();
         let widest = self
             .rows
@@ -57,7 +57,7 @@ impl Help<'_> {
     }
 
     /// Centre the panel, shrinking it if the terminal is too small.
-    fn panel(&self, area: Rect) -> Rect {
+    pub(crate) fn panel(&self, area: Rect) -> Rect {
         let width = self.desired_width().min(area.width);
         let height = (self.rows.len() as u16 + 4).min(area.height);
         Rect {

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -498,6 +498,38 @@ impl App {
             .or_else(|| self.active_status().map(str::to_string))
     }
 
+    /// Ink and background for an overlay, as the terminal draws one.
+    ///
+    /// The same pair the status line uses there: near-white on the theme's
+    /// darkest grid stop, so a window and a terminal show the same panel in
+    /// the same colours rather than each picking its own.
+    ///
+    /// A named colour the terminal never answered for resolves to the
+    /// theme's own fallback, which is what `Colour::from` does - a window has
+    /// no palette to ask.
+    #[cfg(feature = "gui")]
+    pub(crate) fn overlay_colours(
+        &self,
+    ) -> (rav_appearance::ink::Colour, rav_appearance::ink::Colour) {
+        use rav_appearance::ink::Colour;
+        let ink = Colour {
+            red: 222,
+            green: 222,
+            blue: 222,
+            alpha: 255,
+        };
+        (ink, self.palette.resolve(self.theme.grid[0]))
+    }
+
+    /// Whether the help panel is up.
+    ///
+    /// A surface that draws its own overlay has to ask; `App::run` reads the
+    /// field where it stands.
+    #[cfg(feature = "gui")]
+    pub(crate) fn showing_help(&self) -> bool {
+        self.show_help
+    }
+
     /// Whether a key has asked rav to stop.
     ///
     /// A surface that drives its own loop needs to ask, where `App::run`
@@ -982,7 +1014,7 @@ impl App {
 
     /// The help rows, each carrying its current value so the overlay doubles as
     /// a settings readout.
-    fn help_rows(&self) -> Vec<HelpRow<'static>> {
+    pub(crate) fn help_rows(&self) -> Vec<HelpRow<'static>> {
         let limit = match FREQUENCY_LIMITS[self.limit_index] {
             Some(hz) => format!("up to {} kHz", hz / 1000),
             None => "full range".to_string(),


### PR DESCRIPTION
The window can draw text. `h` opens the same panel a terminal shows, in the same colours, sized by the same `Help::panel` so the two cannot disagree about which rows fit.

Adds `font8x8` — public domain, `no_std`, 8x8 — behind `gui`, which stays off by default. The font sits behind a `Bitmap` trait, so swapping to an 8x16 one is a single impl.

8x8 may read small on a fourteen-row panel; that is the thing to look at when you run it.