### PR TITLE
feat: room to add a variant after 1.0

### DIFF
--- a/crates/rav-appearance/src/scene.rs
+++ b/crates/rav-appearance/src/scene.rs
@@ -116,6 +116,7 @@ impl Band {
 /// a cell grid has no room for a bar that leans, and half a lean is worse than
 /// none.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[non_exhaustive]
 pub enum View {
     /// Straight on, which is what every surface has always drawn.
     #[default]

--- a/crates/rav-appearance/src/skin.rs
+++ b/crates/rav-appearance/src/skin.rs
@@ -40,6 +40,7 @@
 
 /// How a skin covers a partial rung.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum Shapes {
     /// One shape, clipped to the fill height.
     ///

--- a/crates/rav-core/src/capability.rs
+++ b/crates/rav-core/src/capability.rs
@@ -173,6 +173,7 @@ impl Requirements {
 
 /// Why a surface cannot show a visualisation.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum Shortfall {
     Columns { needs: usize, has: usize },
     Rungs { needs: usize, has: usize },

--- a/crates/rav-core/src/geometry.rs
+++ b/crates/rav-core/src/geometry.rs
@@ -204,6 +204,7 @@ impl BarLayout {
 /// Stacked and interleaved arrangements need nothing here: stacked is two
 /// panels, and interleaved is which column a band is given.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[non_exhaustive]
 pub enum Anchor {
     /// Grows upward from the bottom. What a spectrum analyser has always done.
     #[default]

--- a/crates/rav-core/src/units.rs
+++ b/crates/rav-core/src/units.rs
@@ -108,6 +108,7 @@ impl Level {
 /// of which is in `core`. An allocator-free target wants `libm`, or `Linear`,
 /// which needs nothing.
 #[derive(Debug, Clone, Copy, PartialEq, Default)]
+#[non_exhaustive]
 pub enum Curve {
     /// The display *is* the amplitude. rav's default and its documented choice.
     #[default]


### PR DESCRIPTION
`rav-core` and `rav-appearance` publish alongside rav, so 1.0.0 commits their APIs to semver — and nothing in either was `#[non_exhaustive]`. A sixth viewing angle, or the LED projection surface #68 still wants, would have been rav 2.0.

Five enums, and it costs nothing: rav compares and constructs them but never matches on them, so all the exhaustive matching is inside the crate that defines each one, where the attribute does not apply. Adding a variant still fails to compile in `label`, `next` and `placing_at` — checked by adding one — and no longer breaks anything downstream.

`Ink` is left alone: rav matches it in four places, so this would trade the compiler pointing at them for the ability to add a colour kind, and exact-or-named is the whole space. The public structs are a separate question — `#[non_exhaustive]` stops literal construction and rav builds `CellSize` that way.