### PR TITLE
feat: room to add a field after 1.0

### DIFF
--- a/crates/rav-core/src/capability.rs
+++ b/crates/rav-core/src/capability.rs
@@ -84,6 +84,7 @@ impl Capabilities {
 
 /// What a visualisation needs before it can say anything useful.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
 pub struct Requirements {
     pub columns: usize,
     pub rungs: usize,

--- a/crates/rav-core/src/units.rs
+++ b/crates/rav-core/src/units.rs
@@ -562,7 +562,7 @@ mod tests {
         let two_and_a_bit = Fill::new(2, Step::new(3, 8));
         assert_eq!(two_and_a_bit.whole, 2);
         assert!(two_and_a_bit.has_part());
-        assert_eq!(Fill::new(0, Step::new(0, 8)).has_part(), false);
+        assert!(!Fill::new(0, Step::new(0, 8)).has_part());
     }
 
     #[test]

--- a/crates/rav-core/src/units.rs
+++ b/crates/rav-core/src/units.rs
@@ -223,6 +223,7 @@ impl Step {
 /// A bar in a terminal is this - three whole rows lit and the fourth five
 /// eighths full - without the core ever knowing what an eighth looks like.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
 pub struct Fill {
     /// Rungs completely filled.
     pub whole: usize,

--- a/crates/rav-core/src/units.rs
+++ b/crates/rav-core/src/units.rs
@@ -232,6 +232,16 @@ pub struct Fill {
 }
 
 impl Fill {
+    /// A fill of that many whole rungs and that much of the one above.
+    ///
+    /// Here because the type is `#[non_exhaustive]`, which stops a struct
+    /// literal outside this crate - and `Fill` derives `Eq`, so a caller
+    /// comparing what it measured against what it expected needs a way to
+    /// write the expectation down.
+    pub fn new(whole: usize, part: Step) -> Self {
+        Self { whole, part }
+    }
+
     /// Whether the rung above the whole ones carries anything at all.
     pub fn has_part(self) -> bool {
         !self.part.is_first()
@@ -543,6 +553,17 @@ impl Frames {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn a_fill_can_be_written_down_as_well_as_measured() {
+        // `Fill` is `#[non_exhaustive]`, so a struct literal is gone from
+        // outside this crate - and it derives `Eq`, which is only useful to
+        // somebody who can write the value they expected.
+        let two_and_a_bit = Fill::new(2, Step::new(3, 8));
+        assert_eq!(two_and_a_bit.whole, 2);
+        assert!(two_and_a_bit.has_part());
+        assert_eq!(Fill::new(0, Step::new(0, 8)).has_part(), false);
+    }
 
     #[test]
     fn a_level_is_always_in_range() {


### PR DESCRIPTION
`Requirements` and `Fill` have public fields and nothing outside `rav-core` builds either, so `#[non_exhaustive]` costs nothing and stops a new field being a major version. `Requirements` is what a display says it can do — columns, rungs, shades, channels, history — and the LED direction is where a sixth would come from.

Not applied where it would be theatre: `Step`, `Level` and `Bounded` keep their fields private and already cannot be built from outside. Not applied to `Scene`, `BarLayout`, `Screen`, `CellSize`, `Rectangle` or `Ramp` either — rav builds those literally in 22 places, which is a real trade rather than a free win.